### PR TITLE
Refactor SaikiAgent usage to be more siimlar to other libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,15 +267,21 @@ Saiki can be easily integrated into your applications as a powerful AI agent lib
 
 ```typescript
 import 'dotenv/config';
-import { loadConfigFile, createSaikiAgent } from '@truffle-ai/saiki';
+import { loadConfigFile, SaikiAgent } from '@truffle-ai/saiki';
 
 // Load your agent configuration
 const config = await loadConfigFile('./agent.yml');
-const agent = await createSaikiAgent(config);
+const agent = new SaikiAgent(config);
+
+// Start the agent (initialize async services)
+await agent.start();
 
 // Use the agent for single tasks
 const result = await agent.run("Analyze the files in this directory and create a summary");
 console.log(result);
+
+// Clean shutdown when done
+await agent.stop();
 
 // Or have conversations
 const response1 = await agent.run("What files are in the current directory?");

--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -269,9 +269,10 @@ Fired when a tool execution completes.
 ### Basic Event Listening
 
 ```typescript
-import { createSaikiAgent } from '@truffle-ai/saiki';
+import { SaikiAgent } from '@truffle-ai/saiki';
 
-const agent = await createSaikiAgent(config);
+const agent = new SaikiAgent(config);
+await agent.start();
 
 // Listen to agent-level events
 agent.agentEventBus.on('saiki:conversationReset', (data) => {
@@ -391,6 +392,10 @@ sessionBus.on('llmservice:thinking', () => {
 
 // Emit custom events
 agentBus.emit('saiki:conversationReset', { sessionId: 'test-session' });
+
+// Don't forget to clean up when done
+// agentBus.removeAllListeners();
+// sessionBus.removeAllListeners();
 ```
 
 ---

--- a/docs/api/nodejs-sdk.md
+++ b/docs/api/nodejs-sdk.md
@@ -16,7 +16,6 @@ npm install @truffle-ai/saiki
 
 ```typescript
 import {
-  createSaikiAgent,
   SaikiAgent,
   MCPManager,
   Logger,
@@ -31,7 +30,7 @@ import {
 
 ### [SaikiAgent Class](./saiki-agent)
 Complete API reference for the main `SaikiAgent` class:
-- Factory function (`createSaikiAgent`)
+- Constructor and lifecycle methods (`new SaikiAgent()`, `start()`, `stop()`)
 - Core methods (`run`, session management)
 - Configuration management
 - MCP server integration

--- a/docs/api/saiki-agent.md
+++ b/docs/api/saiki-agent.md
@@ -6,27 +6,51 @@ sidebar_position: 1
 
 Complete API reference for the main `SaikiAgent` class.
 
-## Factory Function
+## Constructor and Lifecycle
 
-### `createSaikiAgent`
+### `constructor`
 
-Creates and initializes a new Saiki agent with all required services.
+Creates a new Saiki agent instance with the provided configuration.
 
 ```typescript
-function createSaikiAgent(
-  config: AgentConfig,
-  overrides?: CLIConfigOverrides,
-  options?: InitializeServicesOptions
-): Promise<SaikiAgent>
+constructor(config: AgentConfig, overrides?: CLIConfigOverrides)
 ```
 
 | Parameter | Type | Description |
 | :--- | :--- | :--- |
 | `config` | `AgentConfig` | Agent configuration object |
 | `overrides` | `CLIConfigOverrides` | (Optional) Configuration overrides |
+
+### `start`
+
+Initializes and starts the agent with all required services.
+
+```typescript
+async start(options?: InitializeServicesOptions): Promise<void>
+```
+
+| Parameter | Type | Description |
+| :--- | :--- | :--- |
 | `options` | `InitializeServicesOptions` | (Optional) Service initialization options |
 
-**Returns:** `Promise<SaikiAgent>`
+**Example:**
+```typescript
+const agent = new SaikiAgent(config);
+await agent.start();
+```
+
+### `stop`
+
+Stops the agent and cleans up all resources.
+
+```typescript
+async stop(): Promise<void>
+```
+
+**Example:**
+```typescript
+await agent.stop();
+```
 
 ---
 
@@ -54,8 +78,13 @@ async run(
 
 **Returns:** `Promise<string | null>` - AI response or null
 
+**Example:**
 ```typescript
+const agent = new SaikiAgent(config);
+await agent.start();
 const response = await agent.run("Explain quantum computing");
+// ... use agent ...
+await agent.stop();
 ```
 
 ---

--- a/src/app/cli/commands/init.ts
+++ b/src/app/cli/commands/init.ts
@@ -264,18 +264,24 @@ export async function createSaikiExampleFile(directory: string): Promise<string>
 
     const indexTsLines = [
         "import 'dotenv/config';",
-        "import { loadConfigFile, SaikiAgent, createSaikiAgent } from '@truffle-ai/saiki';",
+        "import { loadConfigFile, SaikiAgent } from '@truffle-ai/saiki';",
         '',
         '// 1. Initialize the agent from the config file',
         '// Every agent is defined by its own config file',
         `const config = await loadConfigFile('${configPath}');`,
-        'export const agent = await createSaikiAgent(config);',
+        'const agent = new SaikiAgent(config);',
         '',
-        '// 2. Run the agent',
+        '// 2. Start the agent (initialize async services)',
+        'await agent.start();',
+        '',
+        '// 3. Run the agent',
         'const response = await agent.run("Hello saiki! What are the files in this directory");',
         'console.log("Agent response:", response);',
         '',
-        '// 3. Read Saiki documentation to understand more about using Saiki: https://github.com/truffle-ai/saiki',
+        '// 4. Clean shutdown when done',
+        'await agent.stop();',
+        '',
+        '// 5. Read Saiki documentation to understand more about using Saiki: https://github.com/truffle-ai/saiki',
     ];
     const indexTsContent = indexTsLines.join('\n');
     const outputPath = path.join(directory, 'saiki-example.ts');

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -271,7 +271,7 @@ program
 
             // TODO: process cli config overrides and create a new config here before creating the agent
             // maybe move the cli overrides into the loading of the config file?
-            agent = await createSaikiAgent(
+            agent = new SaikiAgent(
                 cfg,
                 {
                     model: opts.model,
@@ -284,6 +284,9 @@ program
                     runMode: opts.mode,
                 }
             );
+
+            // Start the agent (initialize async services)
+            await agent.start();
         } catch (err) {
             logger.error((err as Error).message);
             process.exit(1);

--- a/src/core/ai/agent/SaikiAgent.lifecycle.test.ts
+++ b/src/core/ai/agent/SaikiAgent.lifecycle.test.ts
@@ -1,0 +1,329 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SaikiAgent } from './SaikiAgent.js';
+import type { AgentConfig } from '../../config/schemas.js';
+import type { AgentServices } from '../../utils/service-initializer.js';
+
+// Mock the createAgentServices function
+vi.mock('../../utils/service-initializer.js', () => ({
+    createAgentServices: vi.fn(),
+}));
+
+import { createAgentServices } from '../../utils/service-initializer.js';
+const mockCreateAgentServices = vi.mocked(createAgentServices);
+
+describe('SaikiAgent Lifecycle Management', () => {
+    let mockConfig: AgentConfig;
+    let mockServices: AgentServices;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+
+        mockConfig = {
+            llm: {
+                provider: 'openai',
+                model: 'gpt-4o',
+                apiKey: 'test-key',
+                router: 'vercel',
+                systemPrompt: 'You are a helpful assistant',
+                maxIterations: 50,
+                maxInputTokens: 128000,
+            },
+            mcpServers: {},
+            storage: {
+                cache: { type: 'in-memory' },
+                database: { type: 'in-memory' },
+            },
+            sessions: {
+                maxSessions: 10,
+                sessionTTL: 3600,
+            },
+        };
+
+        mockServices = {
+            clientManager: {
+                disconnectAll: vi.fn().mockResolvedValue(undefined),
+                initializeFromConfig: vi.fn().mockResolvedValue(undefined),
+            } as any,
+            promptManager: {} as any,
+            agentEventBus: {} as any,
+            stateManager: {
+                getRuntimeState: vi.fn().mockReturnValue({
+                    llm: mockConfig.llm,
+                    mcpServers: {},
+                    runtime: { debugMode: false, logLevel: 'info' },
+                }),
+            } as any,
+            sessionManager: {
+                cleanup: vi.fn().mockResolvedValue(undefined),
+                init: vi.fn().mockResolvedValue(undefined),
+                createSession: vi.fn().mockResolvedValue({ id: 'test-session' }),
+            } as any,
+            storage: {} as any,
+            storageManager: {
+                disconnect: vi.fn().mockResolvedValue(undefined),
+            } as any,
+        };
+
+        mockCreateAgentServices.mockResolvedValue(mockServices);
+    });
+
+    describe('Constructor Patterns', () => {
+        test('should create agent with config (new pattern)', () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            expect(agent.getIsStarted()).toBe(false);
+            expect(agent.getIsStopped()).toBe(false);
+        });
+
+        test('should create agent with services (backward compatibility)', () => {
+            const agent = new SaikiAgent(mockServices);
+
+            expect(agent.getIsStarted()).toBe(true);
+            expect(agent.getIsStopped()).toBe(false);
+        });
+
+        test('should correctly identify AgentServices vs AgentConfig', () => {
+            // Test with services (should work)
+            expect(() => new SaikiAgent(mockServices)).not.toThrow();
+
+            // Test with config (should work)
+            expect(() => new SaikiAgent(mockConfig)).not.toThrow();
+        });
+
+        test('should validate required services when using services constructor', () => {
+            const incompleteServices = {
+                // Include the required properties for type guard but make clientManager undefined
+                clientManager: undefined,
+                promptManager: mockServices.promptManager,
+                agentEventBus: mockServices.agentEventBus,
+                stateManager: mockServices.stateManager,
+                sessionManager: mockServices.sessionManager,
+                storage: mockServices.storage,
+                storageManager: mockServices.storageManager,
+            };
+
+            expect(() => new SaikiAgent(incompleteServices)).toThrow(
+                'Required service clientManager is missing in SaikiAgent constructor'
+            );
+        });
+    });
+
+    describe('start() Method', () => {
+        test('should start successfully with valid config', async () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            await agent.start();
+
+            expect(agent.getIsStarted()).toBe(true);
+            expect(agent.getIsStopped()).toBe(false);
+            expect(mockCreateAgentServices).toHaveBeenCalledWith(mockConfig, undefined, undefined);
+        });
+
+        test('should start with overrides and options', async () => {
+            const agent = new SaikiAgent(
+                mockConfig,
+                { model: 'gpt-4' },
+                { connectionMode: 'strict' }
+            );
+
+            await agent.start();
+
+            expect(mockCreateAgentServices).toHaveBeenCalledWith(
+                mockConfig,
+                { model: 'gpt-4' },
+                { connectionMode: 'strict' }
+            );
+        });
+
+        test('should throw error when starting twice', async () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            await agent.start();
+
+            await expect(agent.start()).rejects.toThrow('Agent is already started');
+        });
+
+        test('should handle start failure gracefully', async () => {
+            const agent = new SaikiAgent(mockConfig);
+            mockCreateAgentServices.mockRejectedValue(new Error('Service initialization failed'));
+
+            await expect(agent.start()).rejects.toThrow('Service initialization failed');
+            expect(agent.getIsStarted()).toBe(false);
+        });
+
+        test('should not allow start on services-based agent', async () => {
+            const agent = new SaikiAgent(mockServices);
+
+            await expect(agent.start()).rejects.toThrow('Agent is already started');
+        });
+    });
+
+    describe('stop() Method', () => {
+        test('should stop successfully after start', async () => {
+            const agent = new SaikiAgent(mockConfig);
+            await agent.start();
+
+            await agent.stop();
+
+            expect(agent.getIsStarted()).toBe(false);
+            expect(agent.getIsStopped()).toBe(true);
+            expect(mockServices.sessionManager.cleanup).toHaveBeenCalled();
+            expect(mockServices.clientManager.disconnectAll).toHaveBeenCalled();
+            expect(mockServices.storageManager.disconnect).toHaveBeenCalled();
+        });
+
+        test('should throw error when stopping before start', async () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            await expect(agent.stop()).rejects.toThrow(
+                'Agent must be started before it can be stopped'
+            );
+        });
+
+        test('should warn when stopping twice but not throw', async () => {
+            const agent = new SaikiAgent(mockConfig);
+            await agent.start();
+            await agent.stop();
+
+            // Second stop should not throw but should warn
+            await expect(agent.stop()).resolves.toBeUndefined();
+        });
+
+        test('should handle partial cleanup failures gracefully', async () => {
+            const agent = new SaikiAgent(mockConfig);
+            await agent.start();
+
+            // Make session cleanup fail
+            mockServices.sessionManager.cleanup.mockRejectedValue(
+                new Error('Session cleanup failed')
+            );
+
+            // Should not throw, but should still mark as stopped
+            await expect(agent.stop()).resolves.toBeUndefined();
+            expect(agent.getIsStopped()).toBe(true);
+
+            // Should still try to clean other services
+            expect(mockServices.clientManager.disconnectAll).toHaveBeenCalled();
+            expect(mockServices.storageManager.disconnect).toHaveBeenCalled();
+        });
+
+        test('should stop services-based agent', async () => {
+            const agent = new SaikiAgent(mockServices);
+
+            await agent.stop();
+
+            expect(agent.getIsStopped()).toBe(true);
+        });
+    });
+
+    describe('Method Access Control', () => {
+        const testMethods = [
+            { name: 'run', args: ['test message'] },
+            { name: 'createSession', args: [] },
+            { name: 'getSession', args: ['session-id'] },
+            { name: 'listSessions', args: [] },
+            { name: 'deleteSession', args: ['session-id'] },
+            { name: 'resetConversation', args: [] },
+            { name: 'getCurrentLLMConfig', args: [] },
+            { name: 'switchLLM', args: [{ model: 'gpt-4' }] },
+            { name: 'connectMcpServer', args: ['test', { type: 'stdio', command: 'test' }] },
+            { name: 'getAllMcpTools', args: [] },
+        ];
+
+        test.each(testMethods)('$name should throw before start()', async ({ name, args }) => {
+            const agent = new SaikiAgent(mockConfig);
+
+            let thrownError: Error | undefined;
+            try {
+                const method = agent[name as keyof SaikiAgent] as Function;
+                await method.apply(agent, args);
+            } catch (error) {
+                thrownError = error as Error;
+            }
+
+            expect(thrownError).toBeDefined();
+            expect(thrownError?.message).toBe(
+                'Agent must be started before use. Call agent.start() first.'
+            );
+        });
+
+        test.each(testMethods)('$name should throw after stop()', async ({ name, args }) => {
+            const agent = new SaikiAgent(mockConfig);
+            await agent.start();
+            await agent.stop();
+
+            let thrownError: Error | undefined;
+            try {
+                const method = agent[name as keyof SaikiAgent] as Function;
+                await method.apply(agent, args);
+            } catch (error) {
+                thrownError = error as Error;
+            }
+
+            expect(thrownError).toBeDefined();
+            expect(thrownError?.message).toBe('Agent has been stopped and cannot be used');
+        });
+
+        test('getCurrentSessionId should work without start() (read-only)', () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            expect(() => agent.getCurrentSessionId()).not.toThrow();
+        });
+
+        test('getIsStarted and getIsStopped should work without start() (read-only)', () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            expect(() => agent.getIsStarted()).not.toThrow();
+            expect(() => agent.getIsStopped()).not.toThrow();
+        });
+    });
+
+    describe('Integration Tests', () => {
+        test('should handle complete lifecycle without errors', async () => {
+            const agent = new SaikiAgent(mockConfig);
+
+            // Initial state
+            expect(agent.getIsStarted()).toBe(false);
+            expect(agent.getIsStopped()).toBe(false);
+
+            // Start
+            await agent.start();
+            expect(agent.getIsStarted()).toBe(true);
+            expect(agent.getIsStopped()).toBe(false);
+
+            // Use agent (mock a successful operation)
+            expect(agent.getCurrentLLMConfig()).toBeDefined();
+
+            // Stop
+            await agent.stop();
+            expect(agent.getIsStarted()).toBe(false);
+            expect(agent.getIsStopped()).toBe(true);
+        });
+
+        test('should handle resource cleanup in correct order', async () => {
+            const agent = new SaikiAgent(mockConfig);
+            await agent.start();
+
+            const cleanupOrder: string[] = [];
+
+            mockServices.sessionManager.cleanup.mockImplementation(() => {
+                cleanupOrder.push('sessions');
+                return Promise.resolve();
+            });
+
+            mockServices.clientManager.disconnectAll.mockImplementation(() => {
+                cleanupOrder.push('clients');
+                return Promise.resolve();
+            });
+
+            mockServices.storageManager.disconnect.mockImplementation(() => {
+                cleanupOrder.push('storage');
+                return Promise.resolve();
+            });
+
+            await agent.stop();
+
+            expect(cleanupOrder).toEqual(['sessions', 'clients', 'storage']);
+        });
+    });
+});

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -31,7 +31,7 @@ import { PromptManager } from '../ai/systemPrompt/manager.js';
 import { StaticConfigManager } from '../config/static-config-manager.js';
 import { AgentStateManager } from '../config/agent-state-manager.js';
 import { SessionManager } from '../ai/session/session-manager.js';
-import { createStorageBackends, type StorageBackends } from '../storage/index.js';
+import { createStorageBackends, type StorageBackends, StorageManager } from '../storage/index.js';
 import { createAllowedToolsProvider } from '../client/tool-confirmation/allowed-tools-provider/factory.js';
 import { logger } from '../logger/index.js';
 import type { CLIConfigOverrides } from '../config/types.js';
@@ -48,6 +48,7 @@ export type AgentServices = {
     stateManager: AgentStateManager;
     sessionManager: SessionManager;
     storage: StorageBackends;
+    storageManager?: StorageManager;
 };
 
 /**
@@ -105,6 +106,7 @@ export async function createAgentServices(
         ? { manager: null, backends: overrides.storage }
         : await createStorageBackends(config.storage);
     const storage = storageResult.backends;
+    const storageManager = storageResult.manager;
 
     logger.debug('Storage backends initialized', {
         cache: config.storage.cache.type,
@@ -182,5 +184,6 @@ export async function createAgentServices(
         stateManager,
         sessionManager,
         storage,
+        storageManager,
     };
 }


### PR DESCRIPTION
This changes the preferred method of using the agents via library

old:

```
const agent = await createSaikiAgent()...
const response = await agent.run()
```

new:
```
const agent = new SaikiAgent()
await agent.start()


const response = await agent.run()

// once done:
await agent.stop()
```

updates all documentation, cli scaffolding commands, and adds new tests