### PR TITLE
Fix first time setup issues inside dexto core with npm link + add --skip-interactive flag

### DIFF
--- a/src/app/cli/utils/first-time-setup.ts
+++ b/src/app/cli/utils/first-time-setup.ts
@@ -3,7 +3,12 @@ import * as path from 'path';
 import * as p from '@clack/prompts';
 import chalk from 'chalk';
 import { parseDocument } from 'yaml';
-import { getBundledConfigPath, isUsingBundledConfig, getUserConfigPath } from '@core/utils/path.js';
+import {
+    getBundledConfigPath,
+    isUsingBundledConfig,
+    getUserConfigPath,
+    isDextoSourceCode,
+} from '@core/utils/path.js';
 import { LLMProvider, getDefaultModelForProvider } from '@core/index.js';
 import pkg from '../../../../package.json' with { type: 'json' };
 import { getPrimaryApiKeyEnvVar } from '@core/utils/api-key-resolver.js';
@@ -12,10 +17,16 @@ import { applyLayeredEnvironmentLoading } from '@core/utils/env.js';
 
 /**
  * Detects if this is a first-time user scenario.
- * Simply checks if we're using the bundled config.
- * If yes, it means no user or project config exists yet.
+ * Checks if we're using the bundled config, but excludes the case
+ * where we're in the dexto source code (development environment).
  */
 export function isFirstTimeUserScenario(configPath: string): boolean {
+    // If we're in dexto source code, never trigger first-time setup
+    if (isDextoSourceCode()) {
+        return false;
+    }
+
+    // Otherwise, use the existing bundled config check
     return isUsingBundledConfig(configPath);
 }
 

--- a/src/app/cli/utils/interactive-api-key-setup.ts
+++ b/src/app/cli/utils/interactive-api-key-setup.ts
@@ -147,7 +147,7 @@ function showManualSetupInstructions(): void {
         `   # GROQ_API_KEY=your_key_here`,
         ``,
         `${chalk.bold('3. Run dexto again:')}`,
-        `   npx dexto`,
+        `   dexto | npx dexto`,
         ``,
         `${chalk.dim('💡 Tip: Start with Google Gemini for a free experience!')}`,
     ].join('\n');

--- a/src/app/cli/utils/options.test.ts
+++ b/src/app/cli/utils/options.test.ts
@@ -17,4 +17,12 @@ describe('validateCliOptions', () => {
         const opts = { agent: '', mode: 'cli', webPort: '8080' };
         expect(() => validateCliOptions(opts)).toThrow(ZodError);
     });
+
+    it('validates skipInteractive flag correctly', () => {
+        const optsWithSkipInteractive = { mode: 'cli', webPort: '8080', skipInteractive: true };
+        expect(() => validateCliOptions(optsWithSkipInteractive)).not.toThrow();
+
+        const optsWithoutSkipInteractive = { mode: 'cli', webPort: '8080' };
+        expect(() => validateCliOptions(optsWithoutSkipInteractive)).not.toThrow();
+    });
 });

--- a/src/app/cli/utils/options.ts
+++ b/src/app/cli/utils/options.ts
@@ -31,7 +31,11 @@ export function validateCliOptions(opts: any): void {
         provider: z.string().optional(),
         model: z.string().optional(),
         router: z.enum(['vercel', 'in-built']).optional(),
-        skipInteractive: z.boolean().optional().default(false),
+        skipInteractive: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe('Skip interactive prompts and fail instead'),
     });
 
     // Basic semantic validation

--- a/src/app/cli/utils/options.ts
+++ b/src/app/cli/utils/options.ts
@@ -31,6 +31,7 @@ export function validateCliOptions(opts: any): void {
         provider: z.string().optional(),
         model: z.string().optional(),
         router: z.enum(['vercel', 'in-built']).optional(),
+        skipInteractive: z.boolean().optional().default(false),
     });
 
     // Basic semantic validation
@@ -82,6 +83,7 @@ export function validateCliOptions(opts: any): void {
         provider: opts.provider,
         model: opts.model,
         router: opts.router,
+        skipInteractive: opts.skipInteractive,
     });
 }
 

--- a/src/core/utils/path.test.ts
+++ b/src/core/utils/path.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import {
     walkUpDirectories,
     isDextoProject,
+    isDextoSourceCode,
     getDextoProjectRoot,
     getDextoPath,
     resolveConfigPath,
@@ -119,6 +120,11 @@ describe('isDextoProject and getDextoProjectRoot', () => {
             const result = getDextoProjectRoot(nestedDir);
             expect(result).toBe(tempDir);
         });
+
+        it('isDextoSourceCode returns false for project with dexto dependency', () => {
+            const result = isDextoSourceCode(tempDir);
+            expect(result).toBe(false);
+        });
     });
 
     describe('with dexto as devDependency', () => {
@@ -158,6 +164,11 @@ describe('isDextoProject and getDextoProjectRoot', () => {
             const result = getDextoProjectRoot(tempDir);
             expect(result).toBe(tempDir);
         });
+
+        it('isDextoSourceCode returns true for dexto source project', () => {
+            const result = isDextoSourceCode(tempDir);
+            expect(result).toBe(true);
+        });
     });
 
     describe('non-dexto project', () => {
@@ -174,6 +185,11 @@ describe('isDextoProject and getDextoProjectRoot', () => {
 
         it('returns false for non-dexto project', () => {
             const result = isDextoProject(tempDir);
+            expect(result).toBe(false);
+        });
+
+        it('isDextoSourceCode returns false for non-dexto project', () => {
+            const result = isDextoSourceCode(tempDir);
             expect(result).toBe(false);
         });
 

--- a/src/core/utils/path.ts
+++ b/src/core/utils/path.ts
@@ -205,7 +205,6 @@ export function resolveBundledScript(scriptPath: string): string {
         const require = createRequire(import.meta.url);
         const packageJsonPath = require.resolve('dexto/package.json');
         const packageRoot = path.dirname(packageJsonPath);
-        console.log(`The resolve bundled script path is ${path.resolve(packageRoot, scriptPath)}`);
         return path.resolve(packageRoot, scriptPath);
     } catch {
         // Fallback for development

--- a/src/core/utils/path.ts
+++ b/src/core/utils/path.ts
@@ -76,6 +76,23 @@ export function isDextoProject(startPath: string = process.cwd()): boolean {
 }
 
 /**
+ * Check if we're currently in the dexto source code itself
+ * @param startPath Starting directory path
+ * @returns True if in dexto source code (package.name === 'dexto')
+ */
+export function isDextoSourceCode(startPath: string = process.cwd()): boolean {
+    const projectRoot = getDextoProjectRoot(startPath);
+    if (!projectRoot) return false;
+
+    try {
+        const pkg = JSON.parse(readFileSync(path.join(projectRoot, 'package.json'), 'utf-8'));
+        return pkg.name === 'dexto';
+    } catch {
+        return false;
+    }
+}
+
+/**
  * Get dexto project root (or null if not in project)
  * @param startPath Starting directory path
  * @returns Project root directory or null
@@ -188,6 +205,7 @@ export function resolveBundledScript(scriptPath: string): string {
         const require = createRequire(import.meta.url);
         const packageJsonPath = require.resolve('dexto/package.json');
         const packageRoot = path.dirname(packageJsonPath);
+        console.log(`The resolve bundled script path is ${path.resolve(packageRoot, scriptPath)}`);
         return path.resolve(packageRoot, scriptPath);
     } catch {
         // Fallback for development


### PR DESCRIPTION
npm link was causing first time setup to run every single time, because isBundledConfig was getting mapped to true because the chosen file (./agents/agent.yml) was symlinked to be the node modules file as well

to fix this, added a new function isDextoSource() that is specifically for developers working on dexto project

now firstTimeSetup interactive never runs if we are inside the dexto source repo, which also handles the link case properly


also added `--skip-interactive` flag to skip interactive flows (first time setup, api key setup), which is useful for scripting/docker which can't handle interactive flows properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global CLI option `--skip-interactive` to disable interactive prompts and fail immediately when required input is missing.
  * Introduced a non-interactive mode for first-time setup and configuration validation.

* **Improvements**
  * Enhanced detection of the Dexto source code environment to prevent first-time setup from running in development scenarios.
  * Updated manual setup instructions for clarity.

* **Bug Fixes**
  * Improved validation logic to handle the new `skipInteractive` flag correctly.

* **Tests**
  * Added and updated test cases to cover new behaviors, including the `skipInteractive` option and source code environment detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->