### PR TITLE
Updated headless mode usage

### DIFF
--- a/docs/docs/guides/cli.md
+++ b/docs/docs/guides/cli.md
@@ -69,13 +69,17 @@ This overrides any individual `connectionMode` settings in your MCP server confi
 #### **Run a specific command with Dexto CLI:**
 
 ```bash
-dexto find all .sh files in this directory
+dexto "find all .sh files in this directory"
+# or use explicit -p flag
+dexto -p "find all .sh files in this directory"
 ```
 
 or do the same with gemini:
 
 ```bash
-dexto -m gemini-2.0-flash find all files in this directory
+dexto -m gemini-2.0-flash "find all files in this directory"
+# or with explicit -p flag
+dexto -m gemini-2.0-flash -p "find all files in this directory"
 ```
 
 Dexto CLI can accept __any__ command - if it doesn't see it as an in-built command, it will fire a single run CLI with that request

--- a/docs/how-to-dexto.md
+++ b/docs/how-to-dexto.md
@@ -140,7 +140,9 @@ The `dexto` command can run one-shot prompts or start in different modes.
 **One-shot prompt:**
 Execute a task directly from the command line.
 ```bash
-dexto "create a new file named 'test.txt' with the content 'hello world'"
+dexto "create a new file named test.txt with hello world content"
+# or use explicit -p flag
+dexto -p "create a new file named test.txt with hello world content"
 ```
 
 **Interactive CLI:**

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -55,6 +55,10 @@ program
     .description('AI-powered CLI and WebUI for interacting with MCP servers')
     .version(pkg.version, '-v, --version', 'output the current version')
     .option('-a, --agent <path>', 'Path to agent config file')
+    .option(
+        '-p, --prompt <text>',
+        'One-shot prompt text. Alternatively provide a single quoted string as positional argument.'
+    )
     .option('-s, --strict', 'Require all server connections to succeed')
     .option('--no-verbose', 'Disable verbose output')
     .option('-m, --model <model>', 'Specify the LLM model to use. ')
@@ -221,7 +225,7 @@ program
         'Dexto CLI allows you to talk to Dexto, build custom AI Agents, ' +
             'build complex AI applications like Cursor, and more.\n\n' +
             // TODO: Add `dexto tell me about your cli` starter prompt
-            'Run dexto interactive CLI with `dexto` or run a one-shot prompt with `dexto <prompt>`\n' +
+            'Run dexto interactive CLI with `dexto` or run a one-shot prompt with `dexto -p "<prompt>"` or `dexto "<prompt>"`\n' +
             'Start with a new session using `dexto --new-session [sessionId]`\n' +
             'Run dexto web UI with `dexto --mode web`\n' +
             'Run dexto as a server (REST APIs + WebSockets) with `dexto --mode server`\n' +
@@ -238,7 +242,25 @@ program
         }
 
         const opts = program.opts();
-        const headlessInput = prompt.join(' ') || undefined;
+        let headlessInput: string | undefined = undefined;
+
+        // Prefer explicit -p/--prompt for headless one-shot
+        if (opts.prompt) {
+            headlessInput = String(opts.prompt);
+        } else if (prompt.length > 0) {
+            // Enforce quoted single positional argument for headless mode
+            if (prompt.length === 1) {
+                headlessInput = prompt[0];
+            } else {
+                console.error(
+                    '❌ For headless one-shot mode, pass the prompt in double quotes as a single argument (e.g., "say hello") or use -p/--prompt.'
+                );
+                process.exit(1);
+            }
+        }
+
+        // Note: Agent selection must be passed via -a/--agent. We no longer interpret
+        // the first positional argument as an agent name to avoid ambiguity with prompts.
 
         // ——— Infer provider & API key from model ———
         if (opts.model) {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -245,8 +245,14 @@ program
         let headlessInput: string | undefined = undefined;
 
         // Prefer explicit -p/--prompt for headless one-shot
-        if (opts.prompt) {
+        if (opts.prompt !== undefined && String(opts.prompt).trim() !== '') {
             headlessInput = String(opts.prompt);
+        } else if (opts.prompt !== undefined) {
+            // Explicit empty -p "" was provided
+            console.error(
+                '❌ For headless one-shot mode, prompt cannot be empty. Provide a non-empty prompt with -p/--prompt or use positional argument.'
+            );
+            process.exit(1);
         } else if (prompt.length > 0) {
             // Enforce quoted single positional argument for headless mode
             if (prompt.length === 1) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global CLI option -p / --prompt to supply a one-shot prompt in headless mode.

* **Refactor**
  * Prompt handling reworked: -p takes precedence; otherwise exactly one quoted positional prompt is required. Multiple positional prompts now produce an error with guidance.
  * Agent selection must be specified via -a / --agent; first positional arg is no longer treated as agent name.

* **Documentation**
  * Updated help, usage examples, and guides to show -p usage and quoting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->