### PR TITLE
[WIP] Patch for media response context explosion

### DIFF
--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -6,7 +6,7 @@ import { ICompressionStrategy } from './compression/types.js';
 import { MiddleRemovalStrategy } from './compression/middle-removal.js';
 import { OldestRemovalStrategy } from './compression/oldest-removal.js';
 import { logger } from '../logger/index.js';
-import { getImageData, countMessagesTokens } from './utils.js';
+import { countMessagesTokens, sanitizeToolResultToContent } from './utils.js';
 import { DynamicContributorContext } from '../systemPrompt/types.js';
 import { PromptManager } from '../systemPrompt/manager.js';
 import { IConversationHistoryProvider } from '@core/session/history/types.js';
@@ -421,30 +421,30 @@ export class ContextManager<TMessage = unknown> {
         if (!toolCallId || !name) {
             throw ContextError.toolCallIdNameRequired();
         }
-
-        // Simplest image detection: if result has an 'image' field, treat as ImagePart
+        // Sanitize tool result to avoid adding non-text data as raw text
+        // and to convert media/data-uris/base64 to structured parts.
         let content: InternalMessage['content'];
-        if (result && typeof result === 'object' && 'image' in result) {
-            // Use shared helper to get base64/URL
-            const imagePart = result as {
-                image: string | Uint8Array | Buffer | ArrayBuffer | URL;
-                mimeType?: string;
-            };
-            content = [
-                {
-                    type: 'image',
-                    image: getImageData(imagePart),
-                    mimeType: imagePart.mimeType || 'image/jpeg',
-                },
-            ];
-        } else if (typeof result === 'string') {
-            content = result;
-        } else if (Array.isArray(result)) {
-            // Assume array of parts already
-            content = result;
-        } else {
-            // Fallback: stringify all other values
-            content = JSON.stringify(result ?? '');
+        content = sanitizeToolResultToContent(result);
+
+        // Log what we are storing (brief)
+        if (typeof content === 'string') {
+            const preview = content.slice(0, 200);
+            logger.debug(
+                `ContextManager: Storing tool result (text) for ${name} (len=${content.length}): ${preview}${
+                    content.length > 200 ? '...' : ''
+                }`
+            );
+        } else if (Array.isArray(content)) {
+            const summary = content
+                .map((p) =>
+                    p.type === 'text'
+                        ? `text(${p.text.length})`
+                        : p.type === 'image'
+                          ? `image(${p.mimeType || 'image'})`
+                          : `file(${p.mimeType || 'file'})`
+                )
+                .join(', ');
+            logger.debug(`ContextManager: Storing tool result (parts) for ${name}: [${summary}]`);
         }
 
         await this.addMessage({ role: 'tool', content, toolCallId, name });

--- a/src/core/context/utils.ts
+++ b/src/core/context/utils.ts
@@ -5,8 +5,10 @@ import { validateModelFileSupport } from '@core/llm/registry.js';
 import { LLMContext } from '@core/llm/types.js';
 import { ContextError } from './errors.js';
 
-// Approximation for message format overhead
-const DEFAULT_OVERHEAD_PER_MESSAGE = 4;
+// Tunable heuristics and shared constants
+const DEFAULT_OVERHEAD_PER_MESSAGE = 4; // Approximation for message format overhead
+const MIN_BASE64_HEURISTIC_LENGTH = 512; // Below this length, treat as regular text
+const MAX_TOOL_TEXT_CHARS = 8000; // Truncate overly long tool text
 
 /**
  * Counts the total tokens in an array of InternalMessages using a provided tokenizer.
@@ -45,8 +47,7 @@ export function countMessagesTokens(
                         } else if (part.type === 'image') {
                             // Approximate tokens for images: estimate ~1 token per 1KB or based on Base64 length
                             if (typeof part.image === 'string') {
-                                // Base64 string length -> bytes -> tokens (~4 bytes per token)
-                                const byteLength = Math.floor((part.image.length * 3) / 4);
+                                const byteLength = base64LengthToBytes(part.image.length);
                                 total += Math.ceil(byteLength / 1024);
                             } else if (
                                 part.image instanceof Uint8Array ||
@@ -62,8 +63,7 @@ export function countMessagesTokens(
                         } else if (part.type === 'file') {
                             // Approximate tokens for files: estimate ~1 token per 1KB or based on Base64 length
                             if (typeof part.data === 'string') {
-                                // Base64 string length -> bytes -> tokens (~4 bytes per token)
-                                const byteLength = Math.floor((part.data.length * 3) / 4);
+                                const byteLength = base64LengthToBytes(part.data.length);
                                 total += Math.ceil(byteLength / 1024);
                             } else if (
                                 part.data instanceof Uint8Array ||
@@ -125,7 +125,7 @@ export function getImageData(imagePart: {
     } else if (image instanceof URL) {
         return image.toString();
     }
-    console.warn('Unexpected image data type in getImageData:', typeof image);
+    logger.warn(`Unexpected image data type in getImageData: ${typeof image}`);
     return '';
 }
 
@@ -149,7 +149,7 @@ export function getFileData(filePart: {
     } else if (data instanceof URL) {
         return data.toString();
     }
-    console.warn('Unexpected file data type in getFileData:', typeof data);
+    logger.warn(`Unexpected file data type in getFileData: ${typeof data}`);
     return '';
 }
 
@@ -206,7 +206,279 @@ export function filterMessagesByLLMCapabilities(
         });
     } catch (error) {
         // If filtering fails, return original messages to avoid breaking the flow
-        console.warn('Failed to filter messages by LLM capabilities:', error);
+        logger.warn(`Failed to filter messages by LLM capabilities: ${String(error)}`);
         return messages;
     }
+}
+
+/**
+ * Detect if a string is likely a Base64 blob (not a typical sentence/text).
+ * Uses a length threshold and character set heuristic.
+ */
+export function isLikelyBase64String(
+    value: string,
+    minLength: number = MIN_BASE64_HEURISTIC_LENGTH
+): boolean {
+    if (!value || value.length < minLength) return false;
+    // Fast-path for data URIs which embed base64
+    if (value.startsWith('data:') && value.includes(';base64,')) return true;
+    // Heuristic: base64 characters only and length divisible by 4 (allow small remainder due to padding)
+    const b64Regex = /^[A-Za-z0-9+/=\r\n]+$/;
+    if (!b64Regex.test(value)) return false;
+    // Low whitespace / punctuation typical for base64
+    const nonWordRatio = (value.match(/[^A-Za-z0-9+/=]/g)?.length || 0) / value.length;
+    return nonWordRatio < 0.01;
+}
+
+/**
+ * Parse data URI and return { mediaType, base64 } or null if not a data URI.
+ */
+export function parseDataUri(value: string): { mediaType: string; base64: string } | null {
+    if (!value.startsWith('data:')) return null;
+    const commaIdx = value.indexOf(',');
+    if (commaIdx === -1) return null;
+    const meta = value.slice(5, commaIdx); // skip 'data:'
+    if (!/;base64$/i.test(meta)) return null;
+    const mediaType = meta.replace(/;base64$/i, '') || 'application/octet-stream';
+    const base64 = value.slice(commaIdx + 1);
+    return { mediaType, base64 };
+}
+
+/**
+ * Recursively sanitize objects by replacing suspiciously-large base64 strings
+ * with placeholders to avoid blowing up the context window.
+ */
+function sanitizeDeepObject(obj: unknown): unknown {
+    if (obj == null) return obj;
+    if (typeof obj === 'string') {
+        if (isLikelyBase64String(obj)) {
+            // Replace with short placeholder; do not keep raw data
+            const approxBytes = Math.floor((obj.length * 3) / 4);
+            logger.debug(
+                `sanitizeDeepObject: replaced large base64 string (~${approxBytes} bytes) with placeholder`
+            );
+            return `[binary data omitted ~${approxBytes} bytes]`;
+        }
+        return obj;
+    }
+    if (Array.isArray(obj)) return obj.map((x) => sanitizeDeepObject(x));
+    if (typeof obj === 'object') {
+        const out: Record<string, any> = {};
+        for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+            out[k] = sanitizeDeepObject(v);
+        }
+        return out;
+    }
+    return obj;
+}
+
+/**
+ * Convert an arbitrary tool result into safe InternalMessage content.
+ * - Converts data URIs and base64 blobs to media/file parts
+ * - Removes huge binary blobs inside objects
+ * - Truncates extremely long raw text
+ */
+export function sanitizeToolResultToContent(result: unknown): InternalMessage['content'] {
+    try {
+        // Case 1: string outputs
+        if (typeof result === 'string') {
+            // Data URI
+            const dataUri = parseDataUri(result);
+            if (dataUri) {
+                const mediaType = dataUri.mediaType;
+                logger.debug(
+                    `sanitizeToolResultToContent: detected data URI (${mediaType}), converting to media part`
+                );
+                if (mediaType.startsWith('image/')) {
+                    return [{ type: 'image', image: dataUri.base64, mimeType: mediaType }];
+                }
+                // Use a generic file part for non-image media types
+                return [{ type: 'file', data: dataUri.base64, mimeType: mediaType }];
+            }
+            // Raw base64-like blob
+            if (isLikelyBase64String(result)) {
+                logger.debug(
+                    'sanitizeToolResultToContent: detected base64-like string, converting to file part'
+                );
+                return [
+                    {
+                        type: 'file',
+                        data: result,
+                        mimeType: 'application/octet-stream',
+                        filename: 'tool-output.bin',
+                    },
+                ];
+            }
+            // Long text: truncate with ellipsis to keep context sane
+            if (result.length > MAX_TOOL_TEXT_CHARS) {
+                const head = result.slice(0, 4000);
+                const tail = result.slice(-1000);
+                logger.debug(
+                    `sanitizeToolResultToContent: truncating long text tool output (len=${result.length})`
+                );
+                return `${head}\n... [${result.length - 5000} chars omitted] ...\n${tail}`;
+            }
+            return result;
+        }
+
+        // Case 2: array of parts or mixed
+        if (Array.isArray(result)) {
+            // Ensure only supported part types (text|image|file) appear in the array
+            const parts: Array<InternalMessage['content'][number]> = [];
+            for (const item of result as any[]) {
+                if (item == null) continue;
+                // Strings: decide if base64/file or plain text
+                if (typeof item === 'string') {
+                    const dataUri = parseDataUri(item);
+                    if (dataUri) {
+                        const mt = dataUri.mediaType;
+                        if (mt.startsWith('image/'))
+                            parts.push({ type: 'image', image: dataUri.base64, mimeType: mt });
+                        else parts.push({ type: 'file', data: dataUri.base64, mimeType: mt });
+                        continue;
+                    }
+                    if (isLikelyBase64String(item)) {
+                        parts.push({
+                            type: 'file',
+                            data: item,
+                            mimeType: 'application/octet-stream',
+                            filename: 'tool-output.bin',
+                        });
+                        continue;
+                    }
+                    parts.push({ type: 'text', text: item });
+                    continue;
+                }
+                // Objects: try coercions, else stringify as text
+                if (typeof item === 'object') {
+                    const obj = item as Record<string, any>;
+                    // Explicitly-typed text part
+                    if (obj.type === 'text' && typeof obj.text === 'string') {
+                        parts.push({ type: 'text', text: obj.text });
+                        continue;
+                    }
+                    // Image-like
+                    if (obj.type === 'image' && obj.image !== undefined) {
+                        parts.push({
+                            type: 'image',
+                            image: getImageData({ image: obj.image }),
+                            mimeType: obj.mimeType || 'image/jpeg',
+                        });
+                        continue;
+                    }
+                    if ('image' in obj) {
+                        parts.push({
+                            type: 'image',
+                            image: getImageData({ image: obj.image }),
+                            mimeType: obj.mimeType || 'image/jpeg',
+                        });
+                        continue;
+                    }
+                    // File-like
+                    if (obj.type === 'file' && obj.data !== undefined) {
+                        parts.push({
+                            type: 'file',
+                            data: getFileData({ data: obj.data }),
+                            mimeType: obj.mimeType || 'application/octet-stream',
+                            filename: obj.filename,
+                        });
+                        continue;
+                    }
+                    if ('data' in obj && (typeof obj.mimeType === 'string' || obj.filename)) {
+                        parts.push({
+                            type: 'file',
+                            data: getFileData({ data: obj.data }),
+                            mimeType: obj.mimeType || 'application/octet-stream',
+                            filename: obj.filename,
+                        });
+                        continue;
+                    }
+                    // Unknown object -> stringify a sanitized copy as text
+                    const cleaned = sanitizeDeepObject(obj);
+                    parts.push({ type: 'text', text: JSON.stringify(cleaned) });
+                    continue;
+                }
+                // Other primitives -> coerce to text
+                parts.push({ type: 'text', text: String(item) });
+            }
+            return parts as InternalMessage['content'];
+        }
+
+        // Case 3: object — attempt to infer media, otherwise stringify safely
+        if (result && typeof result === 'object') {
+            // Common shapes: { image, mimeType? } or { data, mimeType }
+            const anyObj = result as Record<string, any>;
+            if ('image' in anyObj) {
+                return [
+                    {
+                        type: 'image',
+                        image: getImageData({ image: anyObj.image }),
+                        mimeType: anyObj.mimeType || 'image/jpeg',
+                    },
+                ];
+            }
+            if ('data' in anyObj && anyObj.mimeType) {
+                return [
+                    {
+                        type: 'file',
+                        data: getFileData({ data: anyObj.data }),
+                        mimeType: anyObj.mimeType,
+                        filename: anyObj.filename,
+                    },
+                ];
+            }
+            // Generic object: remove huge base64 fields and stringify
+            const cleaned = sanitizeDeepObject(anyObj);
+            return JSON.stringify(cleaned);
+        }
+
+        // Fallback
+        return JSON.stringify(result ?? '');
+    } catch (err) {
+        logger.warn(`sanitizeToolResultToContent failed, falling back to string: ${String(err)}`);
+        try {
+            return JSON.stringify(result ?? '');
+        } catch {
+            return String(result ?? '');
+        }
+    }
+}
+
+/**
+ * Produce a short textual summary for tool content, to be used with providers
+ * that only accept text for tool messages (e.g., OpenAI/Anthropic tool role).
+ */
+export function summarizeToolContentForText(content: InternalMessage['content']): string {
+    if (!Array.isArray(content)) return String(content || '');
+    const parts: string[] = [];
+    for (const p of content) {
+        if (p.type === 'text') {
+            parts.push(p.text);
+        } else if (p.type === 'image') {
+            // Try estimating size
+            let bytes = 0;
+            if (typeof p.image === 'string') bytes = Math.floor((p.image.length * 3) / 4);
+            else if (p.image instanceof ArrayBuffer) bytes = p.image.byteLength;
+            else if (p.image instanceof Uint8Array) bytes = p.image.length;
+            else if (p.image instanceof Buffer) bytes = p.image.length;
+            parts.push(`[image ${p.mimeType || 'image'} ~${Math.ceil(bytes / 1024)}KB]`);
+        } else if (p.type === 'file') {
+            let bytes = 0;
+            if (typeof p.data === 'string') bytes = Math.floor((p.data.length * 3) / 4);
+            else if (p.data instanceof ArrayBuffer) bytes = p.data.byteLength;
+            else if (p.data instanceof Uint8Array) bytes = p.data.length;
+            else if (p.data instanceof Buffer) bytes = p.data.length;
+            const label = p.filename ? `${p.filename}` : `${p.mimeType || 'file'}`;
+            parts.push(`[file ${label} ~${Math.ceil(bytes / 1024)}KB]`);
+        }
+    }
+    const summary = parts.join('\n');
+    // Avoid passing enormous text anyway
+    return summary.slice(0, 4000);
+}
+
+// Helper: estimate base64 byte length from string length
+function base64LengthToBytes(charLength: number): number {
+    // 4 base64 chars -> 3 bytes; ignore padding for approximation
+    return Math.floor((charLength * 3) / 4);
 }

--- a/src/core/llm/formatters/anthropic.ts
+++ b/src/core/llm/formatters/anthropic.ts
@@ -9,7 +9,13 @@ import { IMessageFormatter } from './types.js';
 import { LLMContext } from '../types.js';
 import { InternalMessage } from '@core/context/types.js';
 import { logger } from '@core/logger/index.js';
-import { getImageData, getFileData, filterMessagesByLLMCapabilities } from '@core/context/utils.js';
+import {
+    getImageData,
+    getFileData,
+    filterMessagesByLLMCapabilities,
+    summarizeToolContentForText,
+    isLikelyBase64String,
+} from '@core/context/utils.js';
 
 /**
  * Message formatter for Anthropic's Claude API.
@@ -91,13 +97,23 @@ export class AnthropicMessageFormatter implements IMessageFormatter {
                     }
 
                     // Then add the tool result as a user message
+                    let safeContent: string = '';
+                    if (Array.isArray(msg.content)) {
+                        safeContent = summarizeToolContentForText(msg.content);
+                    } else if (typeof msg.content === 'string') {
+                        safeContent = isLikelyBase64String(msg.content)
+                            ? '[binary data omitted]'
+                            : msg.content;
+                    } else {
+                        safeContent = String(msg.content || '');
+                    }
                     const toolResultMsg: MessageParam = {
                         role: 'user',
                         content: [
                             {
                                 type: 'tool_result',
                                 tool_use_id: msg.toolCallId,
-                                content: String(msg.content || ''),
+                                content: safeContent,
                             } as ToolResultBlockParam,
                         ],
                     };
@@ -108,13 +124,23 @@ export class AnthropicMessageFormatter implements IMessageFormatter {
                 } else {
                     // This shouldn't normally happen
                     logger.warn(`Tool result found without matching tool call: ${msg.toolCallId}`);
+                    let orphanSafe: string = '';
+                    if (Array.isArray(msg.content)) {
+                        orphanSafe = summarizeToolContentForText(msg.content);
+                    } else if (typeof msg.content === 'string') {
+                        orphanSafe = isLikelyBase64String(msg.content)
+                            ? '[binary data omitted]'
+                            : msg.content;
+                    } else {
+                        orphanSafe = String(msg.content || '');
+                    }
                     const orphanToolResult: MessageParam = {
                         role: 'user',
                         content: [
                             {
                                 type: 'tool_result',
                                 tool_use_id: msg.toolCallId!,
-                                content: String(msg.content || ''),
+                                content: orphanSafe,
                             } as ToolResultBlockParam,
                         ],
                     };


### PR DESCRIPTION
This patch addresses a bug where toolResponses containing media type data as base64 strings leads to exploded contexts due to addition into the context window as text parts. Currently, we implement a defensive approach and return media types for UI rendering while filtering it completely in the context.

Ideally, the media type should be parsed and filtered based on the model capabilities and added to the context with appropriate text/image/audio/file part. 

Note: Only OpenAI/Anthropic services are addressed in this since Vercel automatically re-ingests toolResponses and needs some explicit work around to prevent this. - Needs to be addressed asap or else token cost can explode very easily. 