### PR TITLE
Adding support to cancel/interrupt a message

### DIFF
--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -188,12 +188,18 @@ export async function initializeApi(agent: DextoAgent, agentCardOverride?: Parti
         const sessionId =
             req.body && typeof req.body.sessionId === 'string' ? req.body.sessionId : undefined;
         const cancelled = agent.cancel(sessionId);
-        return res.status(200).json({ cancelled, sessionId: sessionId ?? 'default' });
+        if (!cancelled) {
+            logger.debug(`No in-flight run to cancel for session: ${sessionId || 'default'}`);
+        }
+        return res.status(200).json({ cancelled, sessionId: sessionId || 'default' });
     });
 
     app.post('/api/sessions/:sessionId/cancel', async (req, res) => {
         const { sessionId } = req.params;
         const cancelled = agent.cancel(sessionId);
+        if (!cancelled) {
+            logger.debug(`No in-flight run to cancel for session: ${sessionId}`);
+        }
         return res.status(200).json({ cancelled, sessionId });
     });
 

--- a/src/app/cli/cli.ts
+++ b/src/app/cli/cli.ts
@@ -209,7 +209,7 @@ export async function startAiCli(agent: DextoAgent) {
                     readline.emitKeypressEvents(process.stdin);
                     const restoreRaw = process.stdin.isTTY
                         ? (() => {
-                              const wasRaw = (process.stdin as any).isRaw === true;
+                              const wasRaw = process.stdin.isRaw === true;
                               process.stdin.setRawMode(true);
                               return () => {
                                   try {

--- a/src/app/cli/cli.ts
+++ b/src/app/cli/cli.ts
@@ -200,7 +200,7 @@ export async function startAiCli(agent: DextoAgent) {
                             cancelling = true;
                             console.log(chalk.yellow('\n(… cancelling current run)'));
                             // Handle both sync/async cancel; swallow any rejection.
-                            void Promise.resolve(agent.cancel()).catch(() => {});
+                            void agent.cancel().catch(() => {});
                         }
                     };
                     readline.emitKeypressEvents(process.stdin);
@@ -227,6 +227,7 @@ export async function startAiCli(agent: DextoAgent) {
                     }
                 } catch (error) {
                     const err = error instanceof Error ? error : new Error(String(error));
+                    // TODO: revert this when we handle partials properly
                     const aborted =
                         err.name === 'AbortError' ||
                         (err as any).aborted === true ||

--- a/src/app/webui/components/ChatApp.tsx
+++ b/src/app/webui/components/ChatApp.tsx
@@ -32,7 +32,7 @@ import SettingsModal from './SettingsModal';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from './ui/tooltip';
 
 export default function ChatApp() {
-  const { messages, sendMessage, currentSessionId, switchSession, isWelcomeState, returnToWelcome, websocket, activeError, clearError } = useChatContext();
+  const { messages, sendMessage, currentSessionId, switchSession, isWelcomeState, returnToWelcome, websocket, activeError, clearError, processing, cancel } = useChatContext();
 
   const [isModalOpen, setModalOpen] = useState(false);
   const [isServerRegistryOpen, setServerRegistryOpen] = useState(false);
@@ -413,7 +413,7 @@ export default function ChatApp() {
         e.preventDefault();
         setShowShortcuts(true);
       }
-      // Escape to close panels
+      // Escape to close panels or cancel run
       if (e.key === 'Escape') {
         if (isServersPanelOpen) setServersPanelOpen(false);
         else if (isSessionsPanelOpen) setSessionsPanelOpen(false);
@@ -422,6 +422,7 @@ export default function ChatApp() {
         else if (showShortcuts) setShowShortcuts(false);
         else if (isDeleteDialogOpen) setDeleteDialogOpen(false);
         else if (errorMessage) setErrorMessage(null);
+        else if (processing) cancel(currentSessionId || undefined);
       }
     };
 

--- a/src/app/webui/components/InputArea.tsx
+++ b/src/app/webui/components/InputArea.tsx
@@ -55,7 +55,7 @@ export default function InputArea({ onSend, isSending, variant = 'chat' }: Input
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   
   // Get current session context to ensure model switch applies to the correct session
-  const { currentSessionId, isStreaming, setStreaming } = useChatContext();
+  const { currentSessionId, isStreaming, setStreaming, cancel, processing } = useChatContext();
   
   // LLM selector state
   const [currentModel, setCurrentModel] = useState<ModelOption | null>(null);
@@ -581,13 +581,18 @@ export default function InputArea({ onSend, isSending, variant = 'chat' }: Input
                     onModelChange={handleModelSwitch}
                   />
 
+                  {/* Stop/Cancel button shown when a run is in progress */}
                   <Button
-                    type="submit"
-                    disabled={!text.trim() && !imageData && !fileData || isSending}
+                    type={processing ? 'button' : 'submit'}
+                    onClick={processing ? () => cancel(currentSessionId || undefined) : undefined}
+                    disabled={processing ? false : ((!text.trim() && !imageData && !fileData) || isSending)}
                     className="h-10 w-10 p-0 rounded-full shadow-sm hover:shadow-md transition-shadow"
-                    aria-label="Send message"
+                    aria-label={processing ? 'Stop' : 'Send message'}
+                    title={processing ? 'Stop' : 'Send'}
                   >
-                    {isSending ? (
+                    {processing ? (
+                      <StopCircle className="h-4 w-4" />
+                    ) : isSending ? (
                       <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
                       <SendHorizontal className="h-4 w-4" />

--- a/src/app/webui/components/hooks/ChatContext.tsx
+++ b/src/app/webui/components/hooks/ChatContext.tsx
@@ -20,6 +20,8 @@ interface ChatContextType {
   isStreaming: boolean;
   setStreaming: (streaming: boolean) => void;
   websocket: WebSocket | null;
+  processing: boolean;
+  cancel: (sessionId?: string) => void;
   // Error state
   activeError: ErrorMessage | null;
   clearError: () => void;
@@ -46,7 +48,7 @@ export function ChatProvider({ children }: { children: ReactNode }) {
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
   const [isWelcomeState, setIsWelcomeState] = useState(true);
   const [isStreaming, setIsStreaming] = useState(true); // Default to streaming enabled
-  const { messages, sendMessage: originalSendMessage, status, reset: originalReset, setMessages, websocket, activeError, clearError } = useChat(wsUrl);
+  const { messages, sendMessage: originalSendMessage, status, reset: originalReset, setMessages, websocket, activeError, clearError, processing, cancel } = useChat(wsUrl);
 
   // Auto-create session on first message with random UUID
   const createAutoSession = useCallback(async (): Promise<string> => {
@@ -288,6 +290,8 @@ export function ChatProvider({ children }: { children: ReactNode }) {
       isStreaming,
       setStreaming: setIsStreaming,
       websocket,
+      processing,
+      cancel,
       // Error state
       activeError,
       clearError

--- a/src/app/webui/components/hooks/useChat.ts
+++ b/src/app/webui/components/hooks/useChat.ts
@@ -136,8 +136,10 @@ export function useChat(wsUrl: string) {
     // Track the last user message id to anchor errors inline in the UI
     const lastUserMessageIdRef = useRef<string | null>(null);
     const [status, setStatus] = useState<'connecting' | 'open' | 'closed'>('connecting');
+    const [processing, setProcessing] = useState<boolean>(false);
     // Separate error state - not part of message flow
     const [activeError, setActiveError] = useState<ErrorMessage | null>(null);
+    const suppressNextErrorRef = useRef<boolean>(false);
 
     useEffect(() => {
         const ws = new globalThis.WebSocket(wsUrl);
@@ -171,6 +173,7 @@ export function useChat(wsUrl: string) {
             const payload = msg.data || {};
             switch (msg.event) {
                 case 'thinking':
+                    setProcessing(true);
                     setMessages((ms) => [
                         ...ms,
                         {
@@ -250,6 +253,7 @@ export function useChat(wsUrl: string) {
                     break;
                 }
                 case 'response': {
+                    setProcessing(false);
                     const text = typeof payload.text === 'string' ? payload.text : '';
                     const reasoning =
                         typeof payload.reasoning === 'string' ? payload.reasoning : undefined;
@@ -326,6 +330,7 @@ export function useChat(wsUrl: string) {
                     break;
                 }
                 case 'conversationReset':
+                    setProcessing(false);
                     setMessages([]);
                     lastUserMessageIdRef.current = null;
                     break;
@@ -430,21 +435,31 @@ export function useChat(wsUrl: string) {
                     break;
                 }
                 case 'error': {
+                    setProcessing(false);
                     // TODO: Replace untyped WebSocket payloads with a shared, typed schema
                     // Define a union for { event: 'error'; data: DextoValidationError | DextoRuntimeError } and
                     // use proper type guards instead of manual payload inspection here.
 
-                    // Keep the hierarchical top-level message, don't override with detailed issue message
-                    let errorMessage = toError(payload).message;
-
-                    // Clean up thinking messages and any incomplete assistant messages
+                    // Clean up thinking messages first
                     setMessages((ms) =>
                         ms.filter(
                             (m) => !(m.role === 'system' && m.content === 'Dexto is thinking...')
                         )
                     );
 
-                    // Set error as separate state, not as a message
+                    // If we recently triggered cancel locally, suppress the next provider error
+                    if (suppressNextErrorRef.current) {
+                        suppressNextErrorRef.current = false;
+                        break;
+                    }
+
+                    // If this is a user-initiated cancel, do not surface an error UI.
+                    if (payload?.context === 'user_cancelled') {
+                        break;
+                    }
+
+                    // Otherwise, set an error banner (separate from messages)
+                    const errorMessage = toError(payload).message;
                     setActiveError({
                         id: generateUniqueId(),
                         message: errorMessage,
@@ -486,6 +501,7 @@ export function useChat(wsUrl: string) {
                     stream,
                 };
                 wsRef.current.send(JSON.stringify(message));
+                setProcessing(true);
 
                 // Add user message to local state immediately
                 const userId = generateUniqueId();
@@ -531,6 +547,24 @@ export function useChat(wsUrl: string) {
         setMessages([]);
         setActiveError(null); // Clear errors on reset
         lastUserMessageIdRef.current = null;
+        setProcessing(false);
+    }, []);
+
+    const cancel = useCallback((sessionId?: string) => {
+        if (wsRef.current?.readyState === globalThis.WebSocket.OPEN) {
+            wsRef.current.send(JSON.stringify({ type: 'cancel', sessionId }));
+        } else {
+            // Fallback to REST if needed
+            fetch('/api/cancel', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ sessionId }),
+            }).catch(() => void 0);
+        }
+        // Optimistically clear processing state; server will also send events
+        setProcessing(false);
+        // Ensure any ensuing provider stream error from abort does not surface as banner
+        suppressNextErrorRef.current = true;
     }, []);
 
     const clearError = useCallback(() => {
@@ -544,6 +578,8 @@ export function useChat(wsUrl: string) {
         reset,
         setMessages,
         websocket: wsRef.current,
+        processing,
+        cancel,
         // Error state
         activeError,
         clearError,

--- a/src/app/webui/components/hooks/useChat.ts
+++ b/src/app/webui/components/hooks/useChat.ts
@@ -553,13 +553,6 @@ export function useChat(wsUrl: string) {
     const cancel = useCallback((sessionId?: string) => {
         if (wsRef.current?.readyState === globalThis.WebSocket.OPEN) {
             wsRef.current.send(JSON.stringify({ type: 'cancel', sessionId }));
-        } else {
-            // Fallback to REST if needed
-            fetch('/api/cancel', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ sessionId }),
-            }).catch(() => void 0);
         }
         // Optimistically clear processing state; server will also send events
         setProcessing(false);

--- a/src/core/agent/DextoAgent.ts
+++ b/src/core/agent/DextoAgent.ts
@@ -384,17 +384,15 @@ export class DextoAgent {
      * @param sessionId Optional session id; defaults to current default session
      * @returns true if a run was in progress and was signaled to abort; false otherwise
      */
-    public cancel(sessionId?: string): boolean {
+    public async cancel(sessionId?: string): Promise<boolean> {
         this.ensureStarted();
         const targetSessionId = sessionId || this.currentDefaultSessionId;
         // Try to use in-memory default session if applicable
         if (!sessionId && this.defaultSession && this.defaultSession.id === targetSessionId) {
             return this.defaultSession.cancel();
         }
-        // If specific session is requested, attempt to fetch from sessionManager cache
-        const existing = this.sessionManager.peekSession?.(targetSessionId) as
-            | ChatSession
-            | undefined;
+        // If specific session is requested, attempt to fetch from sessionManager cache (memory only)
+        const existing = await this.sessionManager.getSession(targetSessionId, false);
         if (existing) {
             return existing.cancel();
         }

--- a/src/core/agent/DextoAgent.ts
+++ b/src/core/agent/DextoAgent.ts
@@ -378,6 +378,30 @@ export class DextoAgent {
         }
     }
 
+    /**
+     * Cancels the currently running turn for a session (or the default session).
+     * Safe to call even if no run is in progress.
+     * @param sessionId Optional session id; defaults to current default session
+     * @returns true if a run was in progress and was signaled to abort; false otherwise
+     */
+    public cancel(sessionId?: string): boolean {
+        this.ensureStarted();
+        const targetSessionId = sessionId || this.currentDefaultSessionId;
+        // Try to use in-memory default session if applicable
+        if (!sessionId && this.defaultSession && this.defaultSession.id === targetSessionId) {
+            return this.defaultSession.cancel();
+        }
+        // If specific session is requested, attempt to fetch from sessionManager cache
+        const existing = this.sessionManager.peekSession?.(targetSessionId) as
+            | ChatSession
+            | undefined;
+        if (existing) {
+            return existing.cancel();
+        }
+        // If not found, nothing to cancel
+        return false;
+    }
+
     // ============= SESSION MANAGEMENT =============
 
     /**

--- a/src/core/llm/services/anthropic.ts
+++ b/src/core/llm/services/anthropic.ts
@@ -63,10 +63,10 @@ export class AnthropicService implements ILLMService {
 
     async completeTask(
         textInput: string,
+        options: { signal?: AbortSignal },
         imageData?: ImageData,
         fileData?: FileData,
-        stream?: boolean,
-        options?: { signal?: AbortSignal }
+        stream?: boolean
     ): Promise<string> {
         // Add user message with optional image and file data
         await this.contextManager.addUserMessage(textInput, imageData, fileData);

--- a/src/core/llm/services/anthropic.ts
+++ b/src/core/llm/services/anthropic.ts
@@ -369,14 +369,19 @@ export class AnthropicService implements ILLMService {
         message: Anthropic.Messages.Message;
         usage?: Anthropic.Messages.Usage;
     }> {
-        const response = await this.anthropic.messages.create({
-            model: this.config.model,
-            messages: formattedMessages,
-            ...(formattedSystemPrompt && { system: formattedSystemPrompt }),
-            tools: formattedTools,
-            max_tokens: this.config.maxOutputTokens ?? 4096,
-            ...(this.config.temperature !== undefined && { temperature: this.config.temperature }),
-        });
+        const response = await this.anthropic.messages.create(
+            {
+                model: this.config.model,
+                messages: formattedMessages,
+                ...(formattedSystemPrompt && { system: formattedSystemPrompt }),
+                tools: formattedTools,
+                max_tokens: this.config.maxOutputTokens ?? 4096,
+                ...(this.config.temperature !== undefined && {
+                    temperature: this.config.temperature,
+                }),
+            },
+            signal ? { signal } : undefined
+        );
 
         return { message: response, usage: response.usage };
     }
@@ -390,15 +395,20 @@ export class AnthropicService implements ILLMService {
         message: Anthropic.Messages.Message;
         usage?: Anthropic.Messages.Usage;
     }> {
-        const stream = await this.anthropic.messages.create({
-            model: this.config.model,
-            messages: formattedMessages,
-            ...(formattedSystemPrompt && { system: formattedSystemPrompt }),
-            tools: formattedTools,
-            max_tokens: this.config.maxOutputTokens ?? 4096,
-            ...(this.config.temperature !== undefined && { temperature: this.config.temperature }),
-            stream: true,
-        });
+        const stream = await this.anthropic.messages.create(
+            {
+                model: this.config.model,
+                messages: formattedMessages,
+                ...(formattedSystemPrompt && { system: formattedSystemPrompt }),
+                tools: formattedTools,
+                max_tokens: this.config.maxOutputTokens ?? 4096,
+                ...(this.config.temperature !== undefined && {
+                    temperature: this.config.temperature,
+                }),
+                stream: true,
+            },
+            signal ? { signal } : undefined
+        );
 
         // Collect streaming response
         let content: Anthropic.Messages.ContentBlock[] = [];

--- a/src/core/llm/services/openai.ts
+++ b/src/core/llm/services/openai.ts
@@ -65,10 +65,10 @@ export class OpenAIService implements ILLMService {
 
     async completeTask(
         textInput: string,
+        options: { signal?: AbortSignal },
         imageData?: ImageData,
         fileData?: FileData,
-        stream?: boolean,
-        options?: { signal?: AbortSignal }
+        stream?: boolean
     ): Promise<string> {
         // Add user message with optional image and file data
         await this.contextManager.addUserMessage(textInput, imageData, fileData);

--- a/src/core/llm/services/openai.ts
+++ b/src/core/llm/services/openai.ts
@@ -67,7 +67,8 @@ export class OpenAIService implements ILLMService {
         textInput: string,
         imageData?: ImageData,
         fileData?: FileData,
-        stream?: boolean
+        stream?: boolean,
+        options?: { signal?: AbortSignal }
     ): Promise<string> {
         // Add user message with optional image and file data
         await this.contextManager.addUserMessage(textInput, imageData, fileData);
@@ -91,12 +92,18 @@ export class OpenAIService implements ILLMService {
 
         try {
             while (iterationCount < this.config.maxIterations) {
+                if (options?.signal?.aborted) {
+                    throw Object.assign(new Error('Aborted'), {
+                        name: 'AbortError',
+                        aborted: true,
+                    });
+                }
                 iterationCount++;
 
                 // Get response with appropriate method
                 const { message, usage } = stream
-                    ? await this.getAIStreamingResponseWithRetries(formattedTools)
-                    : await this.getAIResponseWithRetries(formattedTools);
+                    ? await this.getAIStreamingResponseWithRetries(formattedTools, options?.signal)
+                    : await this.getAIResponseWithRetries(formattedTools, options?.signal);
 
                 // Track token usage
                 if (usage) {
@@ -154,6 +161,12 @@ export class OpenAIService implements ILLMService {
 
                 // Handle tool calls (using robust non-streaming approach)
                 for (const toolCall of message.tool_calls) {
+                    if (options?.signal?.aborted) {
+                        throw Object.assign(new Error('Aborted'), {
+                            name: 'AbortError',
+                            aborted: true,
+                        });
+                    }
                     logger.debug(`Tool call initiated: ${JSON.stringify(toolCall, null, 2)}`);
                     const toolName = toolCall.function.name;
                     let args: Record<string, any> = {};
@@ -254,6 +267,12 @@ export class OpenAIService implements ILLMService {
             });
             return finalResponse;
         } catch (error) {
+            if (
+                error instanceof Error &&
+                (error.name === 'AbortError' || (error as any).aborted === true)
+            ) {
+                throw error;
+            }
             // Handle API errors
             const errorMessage = error instanceof Error ? error.message : String(error);
             logger.error(`Error in ${context}: ${errorMessage}`, { error });
@@ -316,7 +335,8 @@ export class OpenAIService implements ILLMService {
 
     // Helper methods
     private async getAIResponseWithRetries(
-        tools: OpenAI.Chat.Completions.ChatCompletionTool[]
+        tools: OpenAI.Chat.Completions.ChatCompletionTool[],
+        signal?: AbortSignal
     ): Promise<{
         message: OpenAI.Chat.Completions.ChatCompletionMessage;
         usage?: OpenAI.Completions.CompletionUsage;
@@ -347,12 +367,15 @@ export class OpenAIService implements ILLMService {
                 logger.debug(`Estimated tokens being sent to OpenAI: ${tokensUsed}`);
 
                 // Call OpenAI API
-                const response = await this.openai.chat.completions.create({
-                    model: this.config.model,
-                    messages: formattedMessages,
-                    tools: attempts === 1 ? tools : [], // Only offer tools on first attempt
-                    tool_choice: attempts === 1 ? 'auto' : 'none', // Disable tool choice on retry
-                });
+                const response = await this.openai.chat.completions.create(
+                    {
+                        model: this.config.model,
+                        messages: formattedMessages,
+                        tools: attempts === 1 ? tools : [], // Only offer tools on first attempt
+                        tool_choice: attempts === 1 ? 'auto' : 'none', // Disable tool choice on retry
+                    },
+                    signal ? { signal } : undefined
+                );
 
                 logger.silly(
                     'OPENAI CHAT COMPLETION RESPONSE: ',
@@ -370,6 +393,12 @@ export class OpenAIService implements ILLMService {
 
                 return { message, ...(usage && { usage }) };
             } catch (error) {
+                if (
+                    error instanceof Error &&
+                    (error.name === 'AbortError' || (error as any).aborted === true)
+                ) {
+                    throw error;
+                }
                 const apiError = error as APIError;
                 logger.error(
                     `Error in OpenAI API call (Attempt ${attempts}/${MAX_ATTEMPTS}): ${apiError.message || JSON.stringify(apiError, null, 2)}`,
@@ -397,7 +426,8 @@ export class OpenAIService implements ILLMService {
     }
 
     private async getAIStreamingResponseWithRetries(
-        tools: OpenAI.Chat.Completions.ChatCompletionTool[]
+        tools: OpenAI.Chat.Completions.ChatCompletionTool[],
+        signal?: AbortSignal
     ): Promise<{
         message: OpenAI.Chat.Completions.ChatCompletionMessage;
         usage?: OpenAI.Completions.CompletionUsage;
@@ -425,16 +455,19 @@ export class OpenAIService implements ILLMService {
                 logger.debug(`Estimated tokens being sent to OpenAI streaming: ${tokensUsed}`);
 
                 // Create streaming chat completion
-                const stream = await this.openai.chat.completions.create({
-                    model: this.config.model,
-                    messages: formattedMessages,
-                    tools: attempts === 1 ? tools : [], // Only offer tools on first attempt
-                    tool_choice: attempts === 1 ? 'auto' : 'none', // Disable tool choice on retry
-                    stream: true,
-                    stream_options: {
-                        include_usage: true,
+                const stream = await this.openai.chat.completions.create(
+                    {
+                        model: this.config.model,
+                        messages: formattedMessages,
+                        tools: attempts === 1 ? tools : [], // Only offer tools on first attempt
+                        tool_choice: attempts === 1 ? 'auto' : 'none', // Disable tool choice on retry
+                        stream: true,
+                        stream_options: {
+                            include_usage: true,
+                        },
                     },
-                });
+                    signal ? { signal } : undefined
+                );
 
                 // Collect the streaming response
                 let content = '';
@@ -442,6 +475,12 @@ export class OpenAIService implements ILLMService {
                 let usage: OpenAI.Completions.CompletionUsage | undefined;
 
                 for await (const chunk of stream) {
+                    if (signal?.aborted) {
+                        throw Object.assign(new Error('Aborted'), {
+                            name: 'AbortError',
+                            aborted: true,
+                        });
+                    }
                     const delta = chunk.choices[0]?.delta;
 
                     if (delta?.content) {

--- a/src/core/llm/services/types.ts
+++ b/src/core/llm/services/types.ts
@@ -22,7 +22,8 @@ export interface ILLMService {
         textInput: string,
         imageData?: ImageData,
         fileData?: FileData,
-        stream?: boolean
+        stream?: boolean,
+        options?: { signal?: AbortSignal }
     ): Promise<string>;
 
     // Get all available tools

--- a/src/core/llm/services/types.ts
+++ b/src/core/llm/services/types.ts
@@ -14,16 +14,18 @@ export interface ILLMService {
      * Handles potential tool calls and conversation management internally.
      *
      * @param textInput The primary text input from the user.
+     * @param options Options object with signal for cancellation. Always passed from chat session.
      * @param imageData Optional image data associated with the user input.
      * @param fileData Optional file data associated with the user input.
+     * @param stream Optional flag to enable streaming response.
      * @returns A promise that resolves with the final text response from the AI.
      */
     completeTask(
         textInput: string,
+        options: { signal?: AbortSignal },
         imageData?: ImageData,
         fileData?: FileData,
-        stream?: boolean,
-        options?: { signal?: AbortSignal }
+        stream?: boolean
     ): Promise<string>;
 
     // Get all available tools

--- a/src/core/llm/services/vercel.ts
+++ b/src/core/llm/services/vercel.ts
@@ -476,7 +476,7 @@ export class VercelLLMService implements ILLMService {
                         recoverable: true,
                     });
                 } else {
-                    logger.error(`Error in streamText: ${JSON.stringify(error, null, 2)}`);
+                    logger.error(`Error in streamText: ${err?.stack ?? err}`);
                     this.sessionEventBus.emit('llmservice:error', {
                         error: err,
                         context: 'streamText',

--- a/src/core/session/chat-session.test.ts
+++ b/src/core/session/chat-session.test.ts
@@ -378,7 +378,8 @@ describe('ChatSession', () => {
                 userMessage,
                 undefined,
                 undefined,
-                undefined
+                undefined,
+                expect.objectContaining({ signal: expect.any(AbortSignal) })
             );
         });
 

--- a/src/core/session/chat-session.test.ts
+++ b/src/core/session/chat-session.test.ts
@@ -376,10 +376,10 @@ describe('ChatSession', () => {
             expect(response).toBe(expectedResponse);
             expect(mockLLMService.completeTask).toHaveBeenCalledWith(
                 userMessage,
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
                 undefined,
                 undefined,
-                undefined,
-                expect.objectContaining({ signal: expect.any(AbortSignal) })
+                undefined
             );
         });
 

--- a/src/core/session/chat-session.ts
+++ b/src/core/session/chat-session.ts
@@ -444,10 +444,16 @@ export class ChatSession {
      * Returns true if a run was in progress and was signaled to abort.
      */
     public cancel(): boolean {
-        if (this.currentRunController && !this.currentRunController.signal.aborted) {
-            this.currentRunController.abort();
-            return true;
+        const controller = this.currentRunController;
+        if (!controller || controller.signal.aborted) {
+            return false;
         }
-        return false;
+        try {
+            controller.abort();
+            return true;
+        } catch {
+            // Already aborted or abort failed
+            return false;
+        }
     }
 }

--- a/src/core/session/session-manager.ts
+++ b/src/core/session/session-manager.ts
@@ -294,6 +294,14 @@ export class SessionManager {
     }
 
     /**
+     * Returns an in-memory session without loading from storage.
+     * Useful for fast checks (e.g., cancellation) when we do not want to create or restore a session.
+     */
+    public peekSession(sessionId: string): ChatSession | undefined {
+        return this.sessions.get(sessionId);
+    }
+
+    /**
      * Ends a session by removing it from memory without deleting conversation history.
      * Used for cleanup, agent shutdown, and session expiry.
      *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel in-progress AI runs:
    - Web UI: Stop button and Esc-to-cancel while a run is processing; UI exposes live "processing" state and cancel action.
    - CLI: Press Esc to cancel without exiting.
    - API: POST cancel endpoint and WebSocket cancel messages to stop current or session-specific runs.
    - Agent/session-level cancel APIs.

* **Improvements**
  * End-to-end cancellation via AbortSignal propagated to LLM providers (streaming & non‑streaming).
  * Suppresses noisy error banners for user-initiated cancels.
  * Optional session get without restoring from storage to avoid I/O.

* **Tests**
  * Updated tests to expect AbortSignal passed to LLM calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->