### PR TITLE
Feat: PromptsManager for loading and reusing prompts

### DIFF
--- a/agents/default-agent.yml
+++ b/agents/default-agent.yml
@@ -68,14 +68,6 @@ storage:
 
 # Starter prompts - predefined prompts that appear as clickable buttons in the WebUI
 starterPrompts:
-  - id: welcome
-    title: "Welcome to Dexto! 🚀"
-    description: "Get started with a friendly introduction and overview of capabilities"
-    prompt: "Hi! I'm new to Dexto. Can you show me your capabilities and help me understand how to work with you effectively?"
-    category: general
-    icon: "🚀"
-    priority: 10
-  
   - id: quick-start
     title: "Quick Start Guide 📚"
     description: "Learn the basics and see what you can do"
@@ -92,14 +84,6 @@ starterPrompts:
     icon: "💻"
     priority: 8
   
-  - id: web-development
-    title: "Web Development 🌐"
-    description: "Build websites, APIs, and web applications"
-    prompt: "I want to work on web development. Can you help me create a website, API, or web application? I'd like to see what's possible and get started on a project."
-    category: coding
-    icon: "🌐"
-    priority: 7
-  
   - id: data-analysis
     title: "Data Analysis 📊"
     description: "Process data, create visualizations, and perform analysis"
@@ -115,6 +99,22 @@ starterPrompts:
     category: tools
     icon: "⚡"
     priority: 5
+
+  - id: snake-game
+    title: "Create Snake Game 🐍"
+    description: "Build a fun interactive game with HTML, CSS, and JavaScript"
+    prompt: "Create a snake game in a new directory with HTML, CSS, and JavaScript, then open it in the browser for me to play."
+    category: coding
+    icon: "🐍"
+    priority: 4
+
+  - id: connect-tools
+    title: "Connect New Tools 🔧"
+    description: "Browse and add MCP servers to extend capabilities"
+    prompt: "I want to connect new tools to expand my capabilities. Can you help me understand what MCP servers are available and how to add them?"
+    category: tools
+    icon: "🔧"
+    priority: 3
 
 ## To use Google Gemini, replace the LLM section with Google Gemini configuration below
 ## Similar for anthropic/groq/etc.

--- a/agents/default-agent.yml
+++ b/agents/default-agent.yml
@@ -66,6 +66,56 @@ storage:
     type: sqlite
     # path: ./data/dexto.db
 
+# Starter prompts - predefined prompts that appear as clickable buttons in the WebUI
+starterPrompts:
+  - id: welcome
+    title: "Welcome to Dexto! 🚀"
+    description: "Get started with a friendly introduction and overview of capabilities"
+    prompt: "Hi! I'm new to Dexto. Can you show me your capabilities and help me understand how to work with you effectively?"
+    category: general
+    icon: "🚀"
+    priority: 10
+  
+  - id: quick-start
+    title: "Quick Start Guide 📚"
+    description: "Learn the basics and see what you can do"
+    prompt: "I'd like to get started quickly. Can you show me a few examples of what you can do and help me understand how to work with you?"
+    category: learning
+    icon: "📚"
+    priority: 9
+  
+  - id: coding-help
+    title: "Coding Assistant 💻"
+    description: "Get help with programming, debugging, and code review"
+    prompt: "I need help with coding. Can you assist me with writing, debugging, or reviewing code? I'm working on a project and could use some guidance."
+    category: coding
+    icon: "💻"
+    priority: 8
+  
+  - id: web-development
+    title: "Web Development 🌐"
+    description: "Build websites, APIs, and web applications"
+    prompt: "I want to work on web development. Can you help me create a website, API, or web application? I'd like to see what's possible and get started on a project."
+    category: coding
+    icon: "🌐"
+    priority: 7
+  
+  - id: data-analysis
+    title: "Data Analysis 📊"
+    description: "Process data, create visualizations, and perform analysis"
+    prompt: "I have some data I'd like to analyze. Can you help me process it, create visualizations, or perform statistical analysis? I'm looking to gain insights from my data."
+    category: analysis
+    icon: "📊"
+    priority: 6
+  
+  - id: tool-demo
+    title: "Tool Demonstration ⚡"
+    description: "See the tools in action with practical examples"
+    prompt: "I'd like to see your tools in action. Can you pick one of your most interesting tools and demonstrate it with a practical example? Show me what it can do and how it works."
+    category: tools
+    icon: "⚡"
+    priority: 5
+
 ## To use Google Gemini, replace the LLM section with Google Gemini configuration below
 ## Similar for anthropic/groq/etc.
 # llm:

--- a/docs/api-sidebars.ts
+++ b/docs/api-sidebars.ts
@@ -29,7 +29,14 @@ const sidebars: SidebarsConfig = {
                 description:
                     'Complete technical API reference for the Dexto SDK for TypeScript/JavaScript.',
             },
-            items: ['dexto-agent', 'mcp-manager', 'events', 'types'],
+            items: [
+                'dexto-agent',
+                'mcp-manager',
+                'prompts-manager',
+                'webui-slash-commands',
+                'events',
+                'types',
+            ],
         },
     ],
 };

--- a/docs/api/prompts-manager.md
+++ b/docs/api/prompts-manager.md
@@ -1,0 +1,212 @@
+# PromptsManager
+
+The PromptsManager is a unified interface for managing prompts from multiple sources, implementing the Model Context Protocol (MCP) specification for prompt discovery and retrieval.
+
+## Overview
+
+The PromptsManager aggregates prompts from MCP servers and internal markdown files, providing a standardized interface that follows the MCP specification. It acts as the single point of contact for all prompt operations in the Dexto system.
+
+## Architecture
+
+```
+Application → PromptsManager → [MCPPromptProvider, InternalPromptProvider]
+```
+
+### Components
+
+- **PromptsManager**: Main orchestrator that aggregates prompts from all sources
+- **MCPPromptProvider**: Bridges to MCP servers, exposing their prompts
+- **InternalPromptProvider**: Reads markdown files from a configured directory
+
+## MCP Compliance
+
+The PromptsManager implements the MCP specification (2025-06-18) for prompts:
+
+### Prompt Structure
+
+```typescript
+interface PromptDefinition {
+    name: string;
+    title?: string | undefined;
+    description?: string | undefined;
+    arguments?: PromptArgument[] | undefined;
+}
+
+interface PromptArgument {
+    name: string;
+    description?: string;
+    required: boolean;
+}
+```
+
+### Content Types
+
+Supports all MCP content types:
+- **Text**: Plain text messages
+- **Image**: Base64-encoded images with MIME types
+- **Audio**: Base64-encoded audio with MIME types
+- **Resource**: Embedded server-side resources
+
+### Pagination Support
+
+```typescript
+interface PromptListResult {
+    prompts: PromptInfo[];
+    nextCursor?: string | undefined;
+}
+```
+
+## API Reference
+
+### Core Methods
+
+#### `initialize()`
+Initialize the PromptsManager and build the initial prompt cache.
+
+#### `list()`
+Get all available prompts as a `PromptSet` (indexed by name).
+
+#### `listPrompts(cursor?: string)`
+Get all available prompts with pagination support (MCP-compliant).
+
+#### `getPrompt(name: string, args?: Record<string, unknown>)`
+Retrieve a specific prompt by name with optional arguments.
+
+#### `has(name: string)` / `hasPrompt(name: string)`
+Check if a prompt exists.
+
+#### `getPromptDefinition(name: string)`
+Get prompt metadata without executing the prompt.
+
+#### `getPromptsBySource(source: 'mcp' | 'internal')`
+Filter prompts by their source.
+
+#### `searchPrompts(query: string)`
+Search prompts by name, title, or description.
+
+#### `refresh()`
+Refresh the prompt cache from all sources.
+
+### Provider Access
+
+#### `getMCPProvider()`
+Get direct access to the MCP prompt provider.
+
+#### `getInternalProvider()`
+Get direct access to the internal prompt provider.
+
+## Usage Examples
+
+### Basic Prompt Discovery
+
+```typescript
+const promptsManager = new PromptsManager(mcpManager, './prompts');
+await promptsManager.initialize();
+
+// List all prompts
+const allPrompts = await promptsManager.list();
+console.log('Available prompts:', Object.keys(allPrompts));
+
+// Get a specific prompt
+const prompt = await promptsManager.getPrompt('code-review', {
+    language: 'typescript',
+    file: 'src/index.ts'
+});
+```
+
+### MCP-Compliant Operations
+
+```typescript
+// List prompts with pagination support
+const result = await promptsManager.listPrompts();
+console.log(`Found ${result.prompts.length} prompts`);
+
+// Get prompt definition
+const definition = await promptsManager.getPromptDefinition('code-review');
+if (definition?.arguments) {
+    console.log('Required arguments:', 
+        definition.arguments.filter(arg => arg.required).map(arg => arg.name)
+    );
+}
+```
+
+### Source-Specific Operations
+
+```typescript
+// Get only MCP prompts
+const mcpPrompts = await promptsManager.getPromptsBySource('mcp');
+
+// Get only internal prompts
+const internalPrompts = await promptsManager.getPromptsBySource('internal');
+
+// Search across all prompts
+const searchResults = await promptsManager.searchPrompts('review');
+```
+
+## Prompt Sources
+
+### MCP Prompts
+
+Prompts from connected MCP servers that support the prompts capability. These prompts follow the full MCP specification and can include:
+
+- Structured arguments with validation
+- Multiple content types (text, image, audio, resources)
+- Server-side prompt templates
+
+### Internal Prompts
+
+Prompts defined in markdown files within a configured directory. These are converted to MCP-compliant format and support:
+
+- Natural language context via `_context` argument
+- Key-value argument parsing
+- Markdown content processing
+
+## Error Handling
+
+The PromptsManager provides comprehensive error handling:
+
+- **Prompt not found**: Clear error messages when prompts don't exist
+- **Argument validation**: Validates required arguments and warns about unknown ones
+- **Source routing**: Properly routes requests to appropriate providers
+- **Cache management**: Handles cache invalidation and refresh operations
+
+## Performance Features
+
+- **Caching**: Maintains prompt metadata cache for fast access
+- **Lazy loading**: Prompts are loaded on-demand from providers
+- **Cache invalidation**: Automatic cache refresh when needed
+- **Provider isolation**: Each provider manages its own caching strategy
+
+## Configuration
+
+```typescript
+const promptsManager = new PromptsManager(
+    mcpManager,           // MCP manager instance
+    './prompts'           // Directory for internal markdown prompts
+);
+```
+
+## MCP Integration
+
+The PromptsManager seamlessly integrates with the MCP ecosystem:
+
+1. **Discovery**: Automatically discovers prompts from connected MCP servers
+2. **Compatibility**: Ensures internal prompts follow MCP standards
+3. **Unified Interface**: Single API for both MCP and internal prompts
+4. **Future-Ready**: Prepared for MCP protocol updates and new features
+
+## Best Practices
+
+1. **Initialize early**: Call `initialize()` during system startup
+2. **Handle errors**: Always wrap prompt operations in try-catch blocks
+3. **Use pagination**: For large prompt collections, use `listPrompts()` with cursors
+4. **Validate arguments**: Check prompt definitions before execution
+5. **Refresh when needed**: Call `refresh()` when prompt sources change
+
+## Future Enhancements
+
+- **Real-time updates**: Support for `listChanged` notifications
+- **Advanced pagination**: Full cursor-based pagination implementation
+- **Prompt versioning**: Support for prompt versioning and updates
+- **Content validation**: Enhanced content type validation and conversion
+- **Performance optimization**: Advanced caching strategies and lazy loading

--- a/docs/api/webui-slash-commands.md
+++ b/docs/api/webui-slash-commands.md
@@ -1,0 +1,156 @@
+# WebUI Slash Commands
+
+The Dexto WebUI now supports slash commands for accessing prompts, providing an intuitive way to discover and use available prompts directly in the chat interface.
+
+## Overview
+
+Slash commands allow users to quickly access prompts by typing `/` in the input area, which triggers an autocomplete interface showing all available prompts with their descriptions and arguments.
+
+## Features
+
+### **Automatic Prompt Discovery**
+- **Type `/`** to trigger the prompt autocomplete
+- **Real-time search** through available prompts
+- **Source identification** (MCP vs Internal prompts)
+- **Argument display** showing required and optional parameters
+
+### **User Experience**
+- **Keyboard navigation** with arrow keys
+- **Tab completion** for quick prompt insertion
+- **Visual feedback** with source badges and descriptions
+- **Responsive design** that works on all screen sizes
+
+## How It Works
+
+### 1. **Trigger Slash Commands**
+```
+Type "/" in the input area
+```
+
+### 2. **Browse Available Prompts**
+The autocomplete shows:
+- **Prompt name** (e.g., `/code-review`)
+- **Title** (if available)
+- **Description** (what the prompt does)
+- **Source badge** (MCP or Internal)
+- **Arguments** (required parameters marked with *)
+
+### 3. **Select and Use**
+- **Arrow keys** to navigate
+- **Enter** to select
+- **Escape** to close
+- **Click** to select directly
+
+### 4. **Automatic Insertion**
+Selected prompts are automatically inserted into the input area, ready for use.
+
+## API Endpoints
+
+The slash command functionality is powered by these API endpoints:
+
+### `GET /api/prompts`
+Lists all available prompts with metadata.
+
+**Response:**
+```json
+{
+  "prompts": [
+    {
+      "name": "code-review",
+      "title": "Code Review Assistant",
+      "description": "Helps review code for best practices and potential issues",
+      "source": "internal",
+      "arguments": [
+        {
+          "name": "language",
+          "description": "Programming language",
+          "required": true
+        }
+      ]
+    }
+  ],
+  "total": 1
+}
+```
+
+### `GET /api/prompts/:name`
+Gets a specific prompt definition.
+
+### `POST /api/prompts/:name/execute`
+Executes a prompt with arguments and sends the result to the AI agent.
+
+## Technical Implementation
+
+### **Frontend Components**
+- **`SlashCommandAutocomplete`**: Main autocomplete component
+- **`InputArea`**: Enhanced with slash command detection
+- **Real-time filtering** and keyboard navigation
+
+### **Backend Integration**
+- **Direct agent access** through the API server
+- **Prompt execution** via the PromptsManager
+- **Error handling** and validation
+
+### **State Management**
+- **Slash command visibility** based on input content
+- **Selected prompt tracking** for argument handling
+- **Search query filtering** for prompt discovery
+
+## Usage Examples
+
+### **Basic Prompt Usage**
+```
+1. Type "/" in the input
+2. See available prompts
+3. Select "code-review"
+4. Add arguments: "language: python"
+5. Send the message
+```
+
+### **Prompt with Arguments**
+```
+1. Type "/" to see prompts
+2. Select "email-generator"
+3. Add arguments: "tone: professional, topic: meeting request"
+4. Send to generate the email
+```
+
+## Benefits
+
+### **For Users**
+- **Faster access** to common prompts
+- **Better discovery** of available functionality
+- **Consistent interface** across all prompt types
+- **Reduced typing** with autocomplete
+
+### **For Developers**
+- **Unified prompt system** (MCP + Internal)
+- **Extensible architecture** for new prompt types
+- **Real-time prompt discovery** without page refresh
+- **Standardized API** for prompt management
+
+## Future Enhancements
+
+### **Planned Features**
+- **Argument validation** with real-time feedback
+- **Prompt templates** for common use cases
+- **Favorites system** for frequently used prompts
+- **Custom prompt creation** through the UI
+
+### **Integration Opportunities**
+- **Tool execution** through slash commands
+- **Session management** commands
+- **Configuration shortcuts** for common settings
+- **Help system** integration
+
+## Troubleshooting
+
+### **Common Issues**
+- **Prompts not showing**: Check if the agent has access to prompt sources
+- **Autocomplete not working**: Ensure JavaScript is enabled
+- **API errors**: Check the browser console for error details
+
+### **Debug Information**
+- **Browser console** shows API request/response details
+- **Network tab** displays prompt fetching operations
+- **Error messages** provide specific failure reasons

--- a/prompts/code-review.md
+++ b/prompts/code-review.md
@@ -1,0 +1,97 @@
+---
+description: "Review code for bugs, improvements, and best practices with actionable feedback"
+---
+
+# Code Review Assistant
+
+I'm here to help you review code for bugs, improvements, and best practices. I'll analyze your code and provide actionable feedback with specific suggestions for improvement.
+
+## How I Work
+
+When you share code with me, I'll:
+
+1. **Analyze the code structure** and identify potential issues
+2. **Check for common bugs** and edge cases
+3. **Suggest performance improvements** and optimizations
+4. **Review code style** and adherence to best practices
+5. **Provide specific, actionable feedback** with examples
+6. **Consider the context** and purpose of your code
+
+## Natural Language Examples
+
+```bash
+# Use natural language - I'll understand what you want!
+/code-review function calculateTotal(items) { return items.reduce((sum, item) => sum + item.price, 0); }
+/code-review this React component for accessibility issues
+/code-review my Python function for error handling
+/code-review this SQL query for performance
+/code-review my API endpoint for security vulnerabilities
+```
+
+## What I'll Review
+
+I analyze code for:
+
+- **Bugs & Logic Errors**: Incorrect calculations, edge cases, null handling
+- **Performance Issues**: Inefficient algorithms, memory leaks, unnecessary operations
+- **Security Vulnerabilities**: SQL injection, XSS, input validation
+- **Code Quality**: Readability, maintainability, naming conventions
+- **Best Practices**: Design patterns, error handling, testing considerations
+- **Accessibility**: For web applications and user interfaces
+
+## Code Review Process
+
+1. **Initial Scan**: Quick overview of structure and purpose
+2. **Detailed Analysis**: Line-by-line review for specific issues
+3. **Pattern Recognition**: Identify common anti-patterns and improvements
+4. **Alternative Solutions**: Suggest better approaches when applicable
+5. **Prioritization**: Rank issues by severity and impact
+
+## Response Format
+
+I'll structure my review as:
+
+1. **Summary** - High-level assessment and key findings
+2. **Critical Issues** - Bugs, security problems, major performance issues
+3. **Improvements** - Code quality, readability, and maintainability
+4. **Suggestions** - Alternative approaches and best practices
+5. **Questions** - Clarifications needed to provide better feedback
+6. **Overall Rating** - Code quality score with justification
+
+## Tips for Better Reviews
+
+- **Provide context**: What is this code supposed to do?
+- **Include requirements**: Any specific constraints or performance needs?
+- **Mention the language/framework**: So I can give language-specific advice
+- **Share related code**: Dependencies, interfaces, or surrounding context
+- **Ask specific questions**: "Focus on security" or "Check for memory leaks"
+
+## Language-Specific Expertise
+
+I can review code in:
+- **JavaScript/TypeScript**: Frontend, Node.js, React, Vue, Angular
+- **Python**: Web apps, data science, automation, APIs
+- **Java/C#**: Enterprise applications, Android, .NET
+- **Go/Rust**: Systems programming, performance-critical code
+- **SQL**: Database queries, performance, security
+- **HTML/CSS**: Accessibility, responsive design, best practices
+
+## Security Focus Areas
+
+When reviewing for security, I check:
+- **Input Validation**: Sanitization, type checking, bounds checking
+- **Authentication**: Session management, password handling
+- **Authorization**: Access control, permission checks
+- **Data Protection**: Encryption, secure storage, transmission
+- **Common Vulnerabilities**: OWASP Top 10, injection attacks
+
+## Performance Focus Areas
+
+When reviewing for performance, I examine:
+- **Algorithm Complexity**: Time and space complexity analysis
+- **Resource Usage**: Memory allocation, CPU utilization
+- **I/O Operations**: Database queries, file operations, network calls
+- **Caching**: Opportunities for memoization and result caching
+- **Optimization**: Unnecessary operations, redundant calculations
+
+Now, share your code and I'll provide a comprehensive review! You can paste it directly or describe what you'd like me to focus on.

--- a/prompts/debug.md
+++ b/prompts/debug.md
@@ -1,0 +1,100 @@
+---
+description: "Debug code issues with systematic problem-solving and troubleshooting steps"
+---
+
+# Debug Assistant
+
+I'm here to help you debug code issues systematically. I'll analyze problems, identify root causes, and guide you through the debugging process step by step.
+
+## How I Work
+
+When you share a bug or issue with me, I'll:
+
+1. **Understand the problem** - What's happening vs. what should happen
+2. **Analyze the symptoms** - Error messages, unexpected behavior, performance issues
+3. **Investigate potential causes** - Logic errors, data issues, environment problems
+4. **Suggest debugging strategies** - Logging, testing, isolation techniques
+5. **Provide step-by-step solutions** - Specific fixes and verification steps
+6. **Help prevent future issues** - Best practices and defensive programming
+
+## Natural Language Examples
+
+```bash
+# Use natural language - I'll understand what you want!
+/debug my function returns undefined when it should return a number
+/debug this React component won't render
+/debug my API endpoint gives 500 errors
+/debug why my loop runs forever
+/debug my database query is slow
+```
+
+## Common Debugging Scenarios
+
+I can help with:
+
+- **Runtime Errors**: Crashes, exceptions, error messages
+- **Logic Bugs**: Incorrect calculations, wrong outputs, unexpected behavior
+- **Performance Issues**: Slow execution, memory leaks, infinite loops
+- **Data Problems**: Incorrect values, null/undefined errors, type mismatches
+- **Environment Issues**: Configuration problems, dependency conflicts
+- **Race Conditions**: Timing issues, async problems, concurrency bugs
+
+## Debugging Process
+
+1. **Problem Description**: Clearly state what's wrong
+2. **Expected vs. Actual**: What should happen vs. what does happen
+3. **Environment Context**: Language, framework, platform, dependencies
+4. **Reproduction Steps**: How to trigger the issue consistently
+5. **Error Analysis**: Parse error messages and stack traces
+6. **Root Cause Investigation**: Identify the underlying problem
+7. **Solution Implementation**: Apply the fix and verify it works
+8. **Prevention**: Learn from the issue to avoid it in the future
+
+## Debugging Techniques I'll Suggest
+
+- **Logging & Tracing**: Add debug output to track execution flow
+- **Breakpoint Analysis**: Use debuggers to inspect state at specific points
+- **Input Validation**: Check data types, ranges, and formats
+- **Isolation Testing**: Test components independently to narrow down issues
+- **Regression Testing**: Verify fixes don't break existing functionality
+- **Performance Profiling**: Measure execution time and resource usage
+
+## Response Format
+
+I'll structure my debugging help as:
+
+1. **Problem Summary** - Clear understanding of the issue
+2. **Root Cause Analysis** - What's causing the problem
+3. **Debugging Steps** - Specific actions to take
+4. **Solution** - How to fix the issue
+5. **Verification** - How to confirm the fix works
+6. **Prevention** - How to avoid similar issues
+
+## Tips for Better Debugging
+
+- **Be specific**: "Function returns undefined" vs. "Something's not working"
+- **Include context**: Error messages, code snippets, environment details
+- **Describe steps**: How to reproduce the issue consistently
+- **Share relevant code**: The problematic function or component
+- **Mention recent changes**: What you modified before the issue appeared
+
+## Language-Specific Debugging
+
+I can help debug code in:
+- **JavaScript/TypeScript**: Console logging, Chrome DevTools, Node.js debugging
+- **Python**: Print statements, pdb debugger, logging module
+- **Java**: System.out.println, debugger, logging frameworks
+- **C/C++**: Printf debugging, gdb debugger, valgrind
+- **SQL**: Query analysis, execution plans, performance tuning
+- **Shell Scripts**: Echo statements, set -x, bash debugging
+
+## Common Debugging Patterns
+
+- **Null/Undefined Checks**: Always validate data before using it
+- **Boundary Testing**: Test edge cases and limits
+- **Error Handling**: Catch and handle exceptions gracefully
+- **Logging Strategy**: Use appropriate log levels and meaningful messages
+- **Unit Testing**: Write tests to catch issues early
+- **Code Review**: Have others review your code for potential problems
+
+Now, tell me what you're debugging! Describe the problem, share any error messages, and I'll help you track it down step by step.

--- a/prompts/explain.md
+++ b/prompts/explain.md
@@ -1,0 +1,67 @@
+---
+description: "Explain complex concepts in simple terms with examples and analogies"
+---
+
+# Concept Explainer
+
+I'm here to explain complex concepts in simple, engaging terms. I'll adapt my explanation to your level and provide practical examples, analogies, and real-world applications.
+
+## How I Work
+
+When you ask me to explain something, I'll:
+
+1. **Start with a clear, simple definition** that captures the essence
+2. **Break it down into key components** or characteristics
+3. **Provide relatable examples** and analogies
+4. **Show practical applications** and use cases
+5. **Connect it to related concepts** you might already know
+6. **Adapt the complexity** based on your level and context
+
+## Natural Language Examples
+
+```bash
+# Use natural language - I'll understand what you want!
+/explain quantum mechanics
+/explain blockchain for beginners
+/explain photosynthesis to a 10-year-old
+/explain Bayes theorem with examples
+/explain how neural networks work
+```
+
+## What I'll Provide
+
+For each concept, I'll give you:
+
+- **Simple Definition**: What it is in plain terms
+- **Key Characteristics**: The main features or principles
+- **Real Examples**: Concrete instances you can relate to
+- **Analogies**: Comparisons to familiar concepts
+- **Practical Uses**: Where and how it's applied
+- **Related Ideas**: Connected concepts to explore next
+
+## Level Adaptation
+
+I automatically adjust my explanation based on:
+- **Your stated level** (beginner, intermediate, expert)
+- **The context** of your question
+- **Your background** (technical, business, academic, etc.)
+- **The complexity** of the concept itself
+
+## Tips for Better Explanations
+
+- **Be specific**: "Explain machine learning" vs "Explain how Netflix recommends movies"
+- **Mention your level**: "Explain as if I'm a high school student"
+- **Ask for examples**: "Give me real-world examples of this"
+- **Request analogies**: "Use an analogy to explain this"
+
+## Response Format
+
+I'll structure my explanation as:
+1. **Simple Definition** - One sentence that captures the essence
+2. **Key Points** - 3-5 main characteristics or principles
+3. **Examples & Analogies** - Real-world instances and comparisons
+4. **How It Works** - Step-by-step breakdown (when applicable)
+5. **Why It Matters** - Practical importance and applications
+6. **Related Concepts** - What to explore next
+
+Now, what would you like me to explain? Just tell me the concept and I'll adapt my explanation to your needs!

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -1174,7 +1174,6 @@ export async function initializeApi(agent: DextoAgent, agentCardOverride?: Parti
                 source: prompt.source,
                 arguments: prompt.arguments || [],
                 // Add starter prompt metadata
-                starterPrompt: prompt.metadata?.starterPrompt || false,
                 category: prompt.metadata?.category || 'general',
                 icon: prompt.metadata?.icon,
                 priority: prompt.metadata?.priority || 0,

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -1162,6 +1162,100 @@ export async function initializeApi(agent: DextoAgent, agentCardOverride?: Parti
             return next(error);
         }
     });
+
+    // Prompt management endpoints
+    app.get('/api/prompts', async (req, res, next) => {
+        try {
+            const prompts = await agent.promptsManager.list();
+            const promptList = Object.values(prompts).map((prompt) => ({
+                name: prompt.name,
+                title: prompt.title,
+                description: prompt.description,
+                source: prompt.source,
+                arguments: prompt.arguments || [],
+            }));
+
+            res.json({
+                prompts: promptList,
+                total: promptList.length,
+            });
+        } catch (error) {
+            console.error('Error listing prompts:', error);
+            res.status(500).json({
+                error: 'Failed to list prompts',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            });
+        }
+    });
+
+    app.get('/api/prompts/:name', async (req, res, next) => {
+        try {
+            const { name } = req.params;
+            const promptDefinition = await agent.promptsManager.getPromptDefinition(name);
+            if (!promptDefinition) {
+                return res.status(404).json({ error: 'Prompt not found' });
+            }
+
+            return res.json(promptDefinition);
+        } catch (error) {
+            console.error('Error getting prompt:', error);
+            return res.status(500).json({
+                error: 'Failed to get prompt',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            });
+        }
+    });
+
+    app.post('/api/prompts/:name/execute', express.json(), async (req, res, next) => {
+        try {
+            const { name } = req.params;
+            const { arguments: args = {} } = req.body;
+
+            const promptResult = await agent.promptsManager.getPrompt(name, args);
+
+            // Extract the prompt text and send it to the agent
+            let promptText = '';
+            if (promptResult.messages && promptResult.messages.length > 0) {
+                for (const message of promptResult.messages) {
+                    if (typeof message.content === 'string') {
+                        promptText += message.content + '\n';
+                    } else if (
+                        message.content &&
+                        typeof message.content === 'object' &&
+                        'text' in message.content
+                    ) {
+                        promptText += message.content.text + '\n';
+                    } else if (Array.isArray(message.content)) {
+                        for (const content of message.content) {
+                            if (content.type === 'text') {
+                                promptText += content.text + '\n';
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (!promptText.trim()) {
+                return res.status(400).json({ error: 'Prompt returned no content' });
+            }
+
+            // Send the populated prompt text to the AI agent for processing
+            const response = await agent.run(promptText.trim());
+
+            return res.json({
+                success: true,
+                promptText: promptText.trim(),
+                response,
+            });
+        } catch (error) {
+            console.error('Error executing prompt:', error);
+            return res.status(500).json({
+                error: 'Failed to execute prompt',
+                details: error instanceof Error ? error.message : 'Unknown error',
+            });
+        }
+    });
+
     // Centralized error handling (must be registered after routes)
     app.use(errorHandler);
 

--- a/src/app/api/server.ts
+++ b/src/app/api/server.ts
@@ -1173,6 +1173,13 @@ export async function initializeApi(agent: DextoAgent, agentCardOverride?: Parti
                 description: prompt.description,
                 source: prompt.source,
                 arguments: prompt.arguments || [],
+                // Add starter prompt metadata
+                starterPrompt: prompt.metadata?.starterPrompt || false,
+                category: prompt.metadata?.category || 'general',
+                icon: prompt.metadata?.icon,
+                priority: prompt.metadata?.priority || 0,
+                // Include the actual prompt text for starter prompts
+                promptText: prompt.metadata?.prompt || null,
             }));
 
             res.json({

--- a/src/app/cli/commands/interactive-commands/general-commands.ts
+++ b/src/app/cli/commands/interactive-commands/general-commands.ts
@@ -26,12 +26,22 @@ export function createHelpCommand(getAllCommands: () => CommandDefinition[]): Co
         usage: '/help [command]',
         category: 'General',
         aliases: ['h', '?'],
-        handler: async (args: string[], _agent: DextoAgent) => {
+        handler: async (args: string[], agent: DextoAgent) => {
             const allCommands = getAllCommands();
 
+            // Get dynamic prompt commands
+            let dynamicPromptCommands: CommandDefinition[] = [];
+            try {
+                const { getDynamicPromptCommands } = await import('./prompt-commands.js');
+                dynamicPromptCommands = await getDynamicPromptCommands(agent);
+            } catch (error) {
+                // Ignore errors when getting dynamic commands
+            }
+
             if (args.length === 0) {
-                // Show all commands using the original displayAllCommands function
-                displayAllCommands(allCommands);
+                // Show all commands including dynamic prompt commands
+                const allCommandsWithPrompts = [...allCommands, ...dynamicPromptCommands];
+                displayAllCommands(allCommandsWithPrompts);
                 return true;
             }
 

--- a/src/app/cli/commands/interactive-commands/prompt-commands.ts
+++ b/src/app/cli/commands/interactive-commands/prompt-commands.ts
@@ -6,12 +6,16 @@
  *
  * Available Prompt Commands:
  * - /prompt - Display the current system prompt
+ * - /prompts - List all available prompts (MCP + internal)
+ * - /use <prompt-name> [args] - Use a specific prompt with optional arguments
+ * - /<prompt-name> [args] - Direct prompt execution (auto-generated for each prompt)
  */
 
 import chalk from 'chalk';
 import { logger } from '@core/index.js';
 import type { DextoAgent } from '@core/index.js';
 import type { CommandDefinition } from './command-parser.js';
+import type { PromptInfo } from '@core/prompts/types.js';
 
 /**
  * Prompt management commands
@@ -39,4 +43,281 @@ export const promptCommands: CommandDefinition[] = [
             return true;
         },
     },
+    {
+        name: 'prompts',
+        description: 'List all available prompts (MCP + internal)',
+        usage: '/prompts',
+        category: 'Prompt Management',
+        handler: async (args: string[], agent: DextoAgent): Promise<boolean> => {
+            try {
+                const prompts = await agent.promptsManager.list();
+                const promptNames = Object.keys(prompts);
+
+                if (promptNames.length === 0) {
+                    console.log(chalk.yellow('\n⚠️  No prompts available'));
+                    return true;
+                }
+
+                console.log(chalk.bold.green('\n📝 Available Prompts:\n'));
+
+                // Group by source
+                const mcpPrompts: string[] = [];
+                const internalPrompts: string[] = [];
+
+                for (const [name, info] of Object.entries(prompts)) {
+                    if (info.source === 'mcp') {
+                        mcpPrompts.push(name);
+                    } else if (info.source === 'internal') {
+                        internalPrompts.push(name);
+                    }
+                }
+
+                if (mcpPrompts.length > 0) {
+                    console.log(chalk.cyan('🔗 MCP Prompts:'));
+                    mcpPrompts.forEach((name) => {
+                        const info = prompts[name];
+                        if (info) {
+                            const desc = info.description ? ` - ${info.description}` : '';
+                            console.log(`  ${chalk.blue(name)}${chalk.dim(desc)}`);
+                        }
+                    });
+                    console.log();
+                }
+
+                if (internalPrompts.length > 0) {
+                    console.log(chalk.cyan('📁 Internal Prompts:'));
+                    internalPrompts.forEach((name) => {
+                        const info = prompts[name];
+                        if (info) {
+                            const desc = info.description ? ` - ${info.description}` : '';
+                            console.log(`  ${chalk.blue(name)}${chalk.dim(desc)}`);
+                        }
+                    });
+                    console.log();
+                }
+
+                console.log(chalk.dim(`Total: ${promptNames.length} prompts`));
+                console.log(
+                    chalk.dim(
+                        'Use /<prompt-name> <context> to execute with natural language context'
+                    )
+                );
+                console.log(
+                    chalk.dim(
+                        'Examples: /explain quantum mechanics, /code-review my function, /debug this error'
+                    )
+                );
+                console.log(
+                    chalk.dim(
+                        'The LLM will intelligently understand your request and execute the prompt'
+                    )
+                );
+            } catch (error) {
+                logger.error(
+                    `Failed to list prompts: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+            return true;
+        },
+    },
+    {
+        name: 'use',
+        description: 'Use a specific prompt with optional arguments',
+        usage: '/use <prompt-name> [args]',
+        category: 'Prompt Management',
+        handler: async (args: string[], agent: DextoAgent): Promise<boolean> => {
+            try {
+                if (args.length === 0) {
+                    console.log(chalk.red('❌ Please specify a prompt name'));
+                    console.log(chalk.dim('Usage: /use <prompt-name> [args]'));
+                    console.log(
+                        chalk.dim(
+                            'Example: /use code-review language=javascript code="console.log(\'hello\')"'
+                        )
+                    );
+                    return true;
+                }
+
+                const promptName = args[0];
+                const promptArgs = args.slice(1);
+
+                // Check if prompt exists
+                if (!promptName || !(await agent.promptsManager.has(promptName))) {
+                    console.log(chalk.red(`❌ Prompt '${promptName}' not found`));
+                    console.log(chalk.dim('Use /prompts to see available prompts'));
+                    return true;
+                }
+
+                // Parse arguments into key-value pairs
+                const parsedArgs: Record<string, string> = {};
+                for (const arg of promptArgs) {
+                    const [key, ...valueParts] = arg.split('=');
+                    if (key && valueParts.length > 0) {
+                        parsedArgs[key] = valueParts.join('=');
+                    }
+                }
+
+                console.log(chalk.cyan(`🤖 Using prompt: ${promptName}`));
+                if (Object.keys(parsedArgs).length > 0) {
+                    console.log(chalk.dim(`Arguments: ${JSON.stringify(parsedArgs)}`));
+                }
+
+                // Get the prompt
+                const result = await agent.promptsManager.getPrompt(promptName!, parsedArgs);
+
+                // Extract the prompt text and send it to the agent
+                let promptText = '';
+                if (result.messages && result.messages.length > 0) {
+                    for (const message of result.messages) {
+                        if (typeof message.content === 'string') {
+                            promptText += message.content + '\n';
+                        } else if (
+                            message.content &&
+                            typeof message.content === 'object' &&
+                            'text' in message.content
+                        ) {
+                            promptText += message.content.text + '\n';
+                        } else if (Array.isArray(message.content)) {
+                            for (const content of message.content) {
+                                if (content.type === 'text') {
+                                    promptText += content.text + '\n';
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (promptText.trim()) {
+                    // Send the populated prompt text to the AI agent for processing
+                    await agent.run(promptText.trim());
+                } else {
+                    console.log(chalk.yellow(`⚠️  Prompt '${promptName}' returned no content`));
+                }
+
+                return true;
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                logger.error(`Failed to use prompt: ${errorMessage}`);
+
+                if (errorMessage.includes('not found')) {
+                    console.log(
+                        chalk.red(
+                            `❌ Prompt not found. Try running /prompts to see available prompts.`
+                        )
+                    );
+                } else {
+                    console.log(chalk.red(`❌ Error: ${errorMessage}`));
+                }
+                return true;
+            }
+        },
+    },
 ];
+
+/**
+ * Create a dynamic command definition from a prompt
+ */
+function createPromptCommand(promptInfo: PromptInfo): CommandDefinition {
+    return {
+        name: promptInfo.name,
+        description: promptInfo.description || `Execute ${promptInfo.name} prompt`,
+        usage: `/${promptInfo.name} [context]`,
+        category: 'Dynamic Prompts',
+        handler: async (args: string[], agent: DextoAgent): Promise<boolean> => {
+            try {
+                // Parse arguments intelligently
+                const parsedArgs: Record<string, string> = {};
+
+                // First, try to parse key=value format
+                for (const arg of args) {
+                    const [key, ...valueParts] = arg.split('=');
+                    if (key && valueParts.length > 0) {
+                        parsedArgs[key] = valueParts.join('=');
+                    }
+                }
+
+                // If no key=value args, treat all args as context for the LLM to extrapolate
+                if (Object.keys(parsedArgs).length === 0 && args.length > 0) {
+                    // For prompts like "explain", "code-review", etc., treat args as natural language context
+                    const contextString = args.join(' ');
+                    parsedArgs['_context'] = contextString;
+                    console.log(chalk.cyan(`🤖 Executing prompt: ${promptInfo.name}`));
+                    console.log(
+                        chalk.dim(
+                            `Context: ${contextString} (LLM will extrapolate template variables)`
+                        )
+                    );
+                } else if (Object.keys(parsedArgs).length > 0) {
+                    console.log(chalk.cyan(`🤖 Executing prompt: ${promptInfo.name}`));
+                    console.log(chalk.dim(`Explicit arguments: ${JSON.stringify(parsedArgs)}`));
+                } else {
+                    console.log(chalk.cyan(`🤖 Executing prompt: ${promptInfo.name}`));
+                    console.log(
+                        chalk.dim('No arguments provided - LLM will extrapolate from context')
+                    );
+                }
+
+                // Get the prompt
+                const result = await agent.promptsManager.getPrompt(promptInfo.name, parsedArgs);
+
+                // Extract the prompt text and send it to the agent
+                let promptText = '';
+                if (result.messages && result.messages.length > 0) {
+                    for (const message of result.messages) {
+                        if (typeof message.content === 'string') {
+                            promptText += message.content + '\n';
+                        } else if (
+                            message.content &&
+                            typeof message.content === 'object' &&
+                            'text' in message.content
+                        ) {
+                            promptText += message.content.text + '\n';
+                        } else if (Array.isArray(message.content)) {
+                            for (const content of message.content) {
+                                if (content.type === 'text') {
+                                    promptText += content.text + '\n';
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (promptText.trim()) {
+                    // Send the populated prompt text to the AI agent for processing
+                    await agent.run(promptText.trim());
+                } else {
+                    console.log(
+                        chalk.yellow(`⚠️  Prompt '${promptInfo.name}' returned no content`)
+                    );
+                }
+
+                return true;
+            } catch (error) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                logger.error(
+                    `Failed to execute prompt command '${promptInfo.name}': ${errorMessage}`
+                );
+
+                console.log(
+                    chalk.red(`❌ Error executing prompt '${promptInfo.name}': ${errorMessage}`)
+                );
+                return true;
+            }
+        },
+    };
+}
+
+/**
+ * Get all dynamic prompt commands based on available prompts
+ */
+export async function getDynamicPromptCommands(agent: DextoAgent): Promise<CommandDefinition[]> {
+    try {
+        const prompts = await agent.promptsManager.list();
+        return Object.values(prompts).map(createPromptCommand);
+    } catch (error) {
+        logger.error(
+            `Failed to get dynamic prompt commands: ${error instanceof Error ? error.message : String(error)}`
+        );
+        return [];
+    }
+}

--- a/src/app/cli/commands/interactive-commands/prompt-commands.ts
+++ b/src/app/cli/commands/interactive-commands/prompt-commands.ts
@@ -77,47 +77,45 @@ export const promptCommands: CommandDefinition[] = [
                     mcpPrompts.forEach((name) => {
                         const info = prompts[name];
                         if (info) {
+                            const title = info.title ? ` (${info.title})` : '';
                             const desc = info.description ? ` - ${info.description}` : '';
-                            console.log(`  ${chalk.blue(name)}${chalk.dim(desc)}`);
+                            const args =
+                                info.arguments && info.arguments.length > 0
+                                    ? ` [args: ${info.arguments.map((a) => `${a.name}${a.required ? '*' : ''}`).join(', ')}]`
+                                    : '';
+                            console.log(
+                                `  ${chalk.blue(name)}${chalk.yellow(title)}${chalk.dim(desc)}${chalk.gray(args)}`
+                            );
                         }
                     });
                     console.log();
                 }
 
                 if (internalPrompts.length > 0) {
-                    console.log(chalk.cyan('📁 Internal Prompts:'));
+                    console.log(chalk.magenta('📁 Internal Prompts:'));
                     internalPrompts.forEach((name) => {
                         const info = prompts[name];
                         if (info) {
+                            const title = info.title ? ` (${info.title})` : '';
                             const desc = info.description ? ` - ${info.description}` : '';
-                            console.log(`  ${chalk.blue(name)}${chalk.dim(desc)}`);
+                            console.log(
+                                `  ${chalk.blue(name)}${chalk.yellow(title)}${chalk.dim(desc)}`
+                            );
                         }
                     });
                     console.log();
                 }
 
                 console.log(chalk.dim(`Total: ${promptNames.length} prompts`));
-                console.log(
-                    chalk.dim(
-                        'Use /<prompt-name> <context> to execute with natural language context'
-                    )
-                );
-                console.log(
-                    chalk.dim(
-                        'Examples: /explain quantum mechanics, /code-review my function, /debug this error'
-                    )
-                );
-                console.log(
-                    chalk.dim(
-                        'The LLM will intelligently understand your request and execute the prompt'
-                    )
-                );
+                return true;
             } catch (error) {
-                logger.error(
-                    `Failed to list prompts: ${error instanceof Error ? error.message : String(error)}`
+                console.error(
+                    chalk.red(
+                        `Error listing prompts: ${error instanceof Error ? error.message : String(error)}`
+                    )
                 );
+                return false;
             }
-            return true;
         },
     },
     {
@@ -142,7 +140,7 @@ export const promptCommands: CommandDefinition[] = [
                 const promptArgs = args.slice(1);
 
                 // Check if prompt exists
-                if (!promptName || !(await agent.promptsManager.has(promptName))) {
+                if (!promptName || !(await agent.promptsManager.hasPrompt(promptName))) {
                     console.log(chalk.red(`❌ Prompt '${promptName}' not found`));
                     console.log(chalk.dim('Use /prompts to see available prompts'));
                     return true;

--- a/src/app/webui/components/ChatApp.tsx
+++ b/src/app/webui/components/ChatApp.tsx
@@ -201,7 +201,7 @@ export default function ChatApp() {
           const data = await response.json();
           // Filter for starter prompts
           const starterPrompts = data.prompts.filter((p: any) => 
-            p.starterPrompt
+            p.source === 'starter'
           );
           setStarterPrompts(starterPrompts);
         }
@@ -374,49 +374,39 @@ export default function ChatApp() {
     }
   }, [handleSessionChange]);
 
-  const quickActions = [
-    {
-      title: "Help me get started",
-      description: "Show me what you can do",
-      action: () => handleSend("I'm new to Dexto. Can you show me your capabilities and help me understand how to work with you effectively?"),
-      icon: "🚀"
-    },
-    {
-      title: "Create Snake Game",
-      description: "Build a game and open it",
-      action: () => handleSend("Create a snake game in a new directory with HTML, CSS, and JavaScript, then open it in the browser for me to play."),
-      icon: "🐍"
-    },
-    {
-      title: "Connect new tools",
-      description: "Browse and add MCP servers",
-      action: () => setServersPanelOpen(true),
-      icon: "🔧"
-    },
-    {
-      title: "Demonstrate tools",
-      description: "Show me your capabilities",
-      action: () => handleSend("Pick one of your most interesting tools and demonstrate it with a practical example. Show me what it can do."),
-      icon: "⚡"
-    }
-  ];
-
   // Generate dynamic quick actions from starter prompts
   const dynamicQuickActions = React.useMemo(() => {
-    const actions = [...quickActions]; // Start with default actions
+    const actions: Array<{
+      title: string;
+      description: string;
+      action: () => void;
+      icon: string;
+    }> = [];
     
     // Add starter prompts from configuration
     starterPrompts.forEach((prompt) => {
-      actions.push({
-        title: prompt.title || prompt.name,
-        description: prompt.description || 'Starter prompt',
-        action: () => handleSend(prompt.promptText || prompt.name),
-        icon: prompt.icon || "💬"
-      });
+      // Handle special cases for UI actions
+      if (prompt.name === 'starter:connect-tools') {
+        // This starter prompt should open the servers panel instead of sending a message
+        actions.push({
+          title: prompt.title || prompt.name,
+          description: prompt.description || 'Starter prompt',
+          action: () => setServersPanelOpen(true),
+          icon: prompt.icon || "🔧"
+        });
+      } else {
+        // Regular starter prompts send their prompt text
+        actions.push({
+          title: prompt.title || prompt.name,
+          description: prompt.description || 'Starter prompt',
+          action: () => handleSend(prompt.promptText || prompt.name),
+          icon: prompt.icon || "💬"
+        });
+      }
     });
     
     return actions;
-  }, [starterPrompts, quickActions]);
+  }, [starterPrompts, handleSend, setServersPanelOpen]);
 
   // Keyboard shortcuts
   useEffect(() => {

--- a/src/app/webui/components/InputArea.tsx
+++ b/src/app/webui/components/InputArea.tsx
@@ -199,7 +199,7 @@ export default function InputArea({ onSend, isSending, variant = 'chat' }: Input
     // For starter prompts, insert the actual prompt text
     // For other prompts, insert the slash command
     let promptText: string;
-    if (prompt.starterPrompt && prompt.promptText) {
+    if (prompt.source === 'starter' && prompt.promptText) {
       promptText = prompt.promptText;
     } else {
       promptText = `/${prompt.name}`;

--- a/src/app/webui/components/InputArea.tsx
+++ b/src/app/webui/components/InputArea.tsx
@@ -196,8 +196,15 @@ export default function InputArea({ onSend, isSending, variant = 'chat' }: Input
       arguments: prompt.arguments || []
     });
     
-    // Insert the prompt command into the input
-    const promptText = `/${prompt.name}`;
+    // For starter prompts, insert the actual prompt text
+    // For other prompts, insert the slash command
+    let promptText: string;
+    if (prompt.starterPrompt && prompt.promptText) {
+      promptText = prompt.promptText;
+    } else {
+      promptText = `/${prompt.name}`;
+    }
+    
     setText(promptText);
     setShowSlashCommands(false);
     

--- a/src/app/webui/components/SlashCommandAutocomplete.tsx
+++ b/src/app/webui/components/SlashCommandAutocomplete.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { Sparkles, Zap } from 'lucide-react';
+import { Badge } from './ui/badge';
+
+interface PromptArgument {
+  name: string;
+  description?: string;
+  required: boolean;
+}
+
+interface Prompt {
+  name: string;
+  title?: string;
+  description?: string;
+  source: 'mcp' | 'internal';
+  arguments: PromptArgument[];
+}
+
+interface SlashCommandAutocompleteProps {
+  isVisible: boolean;
+  searchQuery: string;
+  onSelectPrompt: (prompt: Prompt) => void;
+  onClose: () => void;
+}
+
+export default function SlashCommandAutocomplete({ 
+  isVisible, 
+  searchQuery,
+  onSelectPrompt, 
+  onClose 
+}: SlashCommandAutocompleteProps) {
+  const [prompts, setPrompts] = useState<Prompt[]>([]);
+  const [filteredPrompts, setFilteredPrompts] = useState<Prompt[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Fetch available prompts
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const fetchPrompts = async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch('/api/prompts');
+        if (response.ok) {
+          const data = await response.json();
+          setPrompts(data.prompts || []);
+          setFilteredPrompts(data.prompts || []);
+        }
+      } catch (error) {
+        console.error('Failed to fetch prompts:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchPrompts();
+  }, [isVisible]);
+
+  // Filter prompts based on search query from parent input
+  useEffect(() => {
+    if (!searchQuery.trim() || searchQuery === '/') {
+      setFilteredPrompts(prompts);
+      setSelectedIndex(0);
+      return;
+    }
+
+    // Remove the leading "/" for filtering
+    const query = searchQuery.startsWith('/') ? searchQuery.slice(1) : searchQuery;
+    
+    const filtered = prompts.filter(prompt => 
+      prompt.name.toLowerCase().includes(query.toLowerCase()) ||
+      (prompt.description && prompt.description.toLowerCase().includes(query.toLowerCase())) ||
+      (prompt.title && prompt.title.toLowerCase().includes(query.toLowerCase()))
+    );
+    
+    setFilteredPrompts(filtered);
+    setSelectedIndex(0);
+  }, [searchQuery, prompts]);
+
+  // Handle keyboard navigation
+  useEffect(() => {
+    if (!isVisible) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex(prev => 
+            prev < filteredPrompts.length - 1 ? prev + 1 : 0
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex(prev => 
+            prev > 0 ? prev - 1 : filteredPrompts.length - 1
+          );
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (filteredPrompts[selectedIndex]) {
+            onSelectPrompt(filteredPrompts[selectedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+        case 'Tab':
+          e.preventDefault();
+          if (filteredPrompts[selectedIndex]) {
+            onSelectPrompt(filteredPrompts[selectedIndex]);
+          }
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isVisible, filteredPrompts, selectedIndex, onSelectPrompt, onClose]);
+
+  // Close on click outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    if (isVisible) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [isVisible, onClose]);
+
+  if (!isVisible || filteredPrompts.length === 0) return null;
+
+  console.log('🔍 Rendering SlashCommandAutocomplete:', { 
+    isVisible, 
+    searchQuery,
+    promptsCount: prompts.length, 
+    filteredCount: filteredPrompts.length 
+  });
+
+  return (
+    <div 
+      ref={containerRef}
+      className="absolute left-0 right-0 mb-2 bg-background border border-border rounded-lg shadow-lg max-h-96 overflow-hidden z-[9999]"
+      style={{ 
+        position: 'absolute',
+        bottom: 'calc(100% + 84px)', // Position well above input to prevent overlap
+        left: 0,
+        right: 0,
+        borderRadius: '8px',
+        maxHeight: '320px',
+        overflow: 'hidden',
+        zIndex: 9999,
+        minWidth: '400px',
+        // Custom dark styling
+        background: 'linear-gradient(135deg, hsl(var(--background)) 0%, hsl(var(--muted)) 100%)',
+        border: '1px solid hsl(var(--border) / 0.3)',
+        backdropFilter: 'blur(8px)',
+        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4), 0 4px 16px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.05)'
+      }}
+    >
+      {/* Header - Compact with prompt count */}
+      <div className="px-3 py-2 border-b border-border bg-muted/50">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <span>Available Prompts</span>
+          <Badge variant="secondary" className="ml-auto text-xs px-2 py-0.5">
+            {filteredPrompts.length}
+          </Badge>
+        </div>
+      </div>
+
+      {/* Prompts List */}
+      <div className="max-h-48 overflow-y-auto">
+        {isLoading ? (
+          <div className="p-3 text-center text-xs text-muted-foreground">
+            Loading prompts...
+          </div>
+        ) : (
+          filteredPrompts.map((prompt, index) => (
+            <div
+              key={prompt.name}
+              className={`px-3 py-2 cursor-pointer hover:bg-muted/30 transition-colors ${
+                index === selectedIndex ? 'bg-muted/40' : ''
+              }`}
+              onClick={() => onSelectPrompt(prompt)}
+            >
+              <div className="flex items-start gap-2">
+                <div className="flex-shrink-0 mt-0.5">
+                  {prompt.source === 'mcp' ? (
+                    <Zap className="h-3 w-3 text-blue-400" />
+                  ) : (
+                    <Sparkles className="h-3 w-3 text-purple-400" />
+                  )}
+                </div>
+                
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="font-medium text-xs text-foreground">
+                      /{prompt.name}
+                    </span>
+                    {prompt.source === 'mcp' && (
+                      <Badge variant="outline" className="text-xs px-1.5 py-0.5 h-4">
+                        MCP
+                      </Badge>
+                    )}
+                    {prompt.source === 'internal' && (
+                      <Badge variant="outline" className="text-xs px-1.5 py-0.5 h-4">
+                        Internal
+                      </Badge>
+                    )}
+                  </div>
+                  
+                  {/* Show title if available */}
+                  {prompt.title && (
+                    <div className="text-xs font-medium text-foreground/90 mb-0.5">
+                      {prompt.title}
+                    </div>
+                  )}
+                  
+                  {/* Show description if available and different from title */}
+                  {prompt.description && prompt.description !== prompt.title && (
+                    <div className="text-xs text-muted-foreground mb-1.5 line-clamp-2">
+                      {prompt.description}
+                    </div>
+                  )}
+                  
+                  {prompt.arguments && prompt.arguments.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {prompt.arguments.map((arg) => (
+                        <Badge 
+                          key={arg.name} 
+                          variant="secondary" 
+                          className="text-xs px-1.5 py-0.5 h-4 bg-muted/60 text-muted-foreground"
+                        >
+                          {arg.name}{arg.required ? '*' : ''}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Footer - Compact with navigation hints */}
+      <div className="px-2 py-1.5 border-t border-border bg-muted/20 text-xs text-muted-foreground text-center">
+        <span>↑↓ Navigate • Tab/Enter Select • Esc Close</span>
+      </div>
+    </div>
+  );
+}

--- a/src/core/agent/DextoAgent.lifecycle.test.ts
+++ b/src/core/agent/DextoAgent.lifecycle.test.ts
@@ -54,6 +54,7 @@ describe('DextoAgent Lifecycle Management', () => {
             } as any,
             toolManager: {} as any,
             promptManager: {} as any,
+            promptsManager: {} as any,
             agentEventBus: {} as any,
             stateManager: {
                 getRuntimeConfig: vi.fn().mockReturnValue({

--- a/src/core/agent/DextoAgent.lifecycle.test.ts
+++ b/src/core/agent/DextoAgent.lifecycle.test.ts
@@ -53,7 +53,7 @@ describe('DextoAgent Lifecycle Management', () => {
                 initializeFromConfig: vi.fn().mockResolvedValue(undefined),
             } as any,
             toolManager: {} as any,
-            promptManager: {} as any,
+            systemPromptManager: {} as any,
             promptsManager: {} as any,
             agentEventBus: {} as any,
             stateManager: {

--- a/src/core/agent/DextoAgent.ts
+++ b/src/core/agent/DextoAgent.ts
@@ -1,7 +1,7 @@
 // src/agent/DextoAgent.ts
 import { MCPManager } from '../mcp/manager.js';
 import { ToolManager } from '../tools/tool-manager.js';
-import { PromptManager } from '../systemPrompt/manager.js';
+import { SystemPromptManager } from '../systemPrompt/manager.js';
 import { PromptsManager } from '../prompts/index.js';
 import { AgentStateManager } from './state-manager.js';
 import { SessionManager, ChatSession, SessionError } from '../session/index.js';
@@ -39,7 +39,7 @@ import { safeStringify } from '@core/utils/safe-stringify.js';
 const requiredServices: (keyof AgentServices)[] = [
     'mcpManager',
     'toolManager',
-    'promptManager',
+    'systemPromptManager',
     'promptsManager',
     'agentEventBus',
     'stateManager',
@@ -104,7 +104,7 @@ export class DextoAgent {
      * But the main recommended entry points/functions would still be the wrapper methods we define below
      */
     public readonly mcpManager!: MCPManager;
-    public readonly promptManager!: PromptManager;
+    public readonly systemPromptManager!: SystemPromptManager;
     public readonly promptsManager!: PromptsManager;
     public readonly agentEventBus!: AgentEventBus;
     public readonly stateManager!: AgentStateManager;
@@ -170,7 +170,7 @@ export class DextoAgent {
             Object.assign(this, {
                 mcpManager: services.mcpManager,
                 toolManager: services.toolManager,
-                promptManager: services.promptManager,
+                systemPromptManager: services.systemPromptManager,
                 promptsManager: services.promptsManager,
                 agentEventBus: services.agentEventBus,
                 stateManager: services.stateManager,
@@ -988,7 +988,7 @@ export class DextoAgent {
         const context = {
             mcpManager: this.mcpManager,
         };
-        return await this.promptManager.build(context);
+        return await this.systemPromptManager.build(context);
     }
 
     // ============= CONFIGURATION ACCESS =============

--- a/src/core/agent/DextoAgent.ts
+++ b/src/core/agent/DextoAgent.ts
@@ -2,6 +2,7 @@
 import { MCPManager } from '../mcp/manager.js';
 import { ToolManager } from '../tools/tool-manager.js';
 import { PromptManager } from '../systemPrompt/manager.js';
+import { PromptsManager } from '../prompts/index.js';
 import { AgentStateManager } from './state-manager.js';
 import { SessionManager, ChatSession, SessionError } from '../session/index.js';
 import type { SessionMetadata } from '../session/index.js';
@@ -39,6 +40,7 @@ const requiredServices: (keyof AgentServices)[] = [
     'mcpManager',
     'toolManager',
     'promptManager',
+    'promptsManager',
     'agentEventBus',
     'stateManager',
     'sessionManager',
@@ -103,6 +105,7 @@ export class DextoAgent {
      */
     public readonly mcpManager!: MCPManager;
     public readonly promptManager!: PromptManager;
+    public readonly promptsManager!: PromptsManager;
     public readonly agentEventBus!: AgentEventBus;
     public readonly stateManager!: AgentStateManager;
     public readonly sessionManager!: SessionManager;
@@ -168,6 +171,7 @@ export class DextoAgent {
                 mcpManager: services.mcpManager,
                 toolManager: services.toolManager,
                 promptManager: services.promptManager,
+                promptsManager: services.promptsManager,
                 agentEventBus: services.agentEventBus,
                 stateManager: services.stateManager,
                 sessionManager: services.sessionManager,

--- a/src/core/agent/schemas.ts
+++ b/src/core/agent/schemas.ts
@@ -109,6 +109,35 @@ export const AgentConfigSchema = z
         toolConfirmation: ToolConfirmationConfigSchema.default({}).describe(
             'Tool confirmation and approval configuration'
         ),
+
+        // Agent-specific starter prompts configuration
+        starterPrompts: z
+            .array(
+                z
+                    .object({
+                        id: z.string().describe('Unique identifier for the starter prompt'),
+                        title: z.string().describe('Display title for the starter prompt button'),
+                        description: z.string().describe('Description shown on hover or in the UI'),
+                        prompt: z
+                            .string()
+                            .describe('The actual prompt text that gets sent to the agent'),
+                        category: z
+                            .enum(['general', 'coding', 'analysis', 'tools', 'learning'])
+                            .default('general')
+                            .describe('Category for organizing starter prompts'),
+                        icon: z
+                            .string()
+                            .optional()
+                            .describe('Emoji or icon to display with the prompt'),
+                        priority: z
+                            .number()
+                            .default(0)
+                            .describe('Priority for ordering (higher numbers appear first)'),
+                    })
+                    .strict()
+            )
+            .default([])
+            .describe('Starter prompts that appear as clickable buttons in the WebUI'),
     })
     .strict()
     .describe('Main configuration for an agent, including its LLM and server connections')

--- a/src/core/context/manager.ts
+++ b/src/core/context/manager.ts
@@ -8,7 +8,7 @@ import { OldestRemovalStrategy } from './compression/oldest-removal.js';
 import { logger } from '../logger/index.js';
 import { countMessagesTokens, sanitizeToolResultToContent } from './utils.js';
 import { DynamicContributorContext } from '../systemPrompt/types.js';
-import { PromptManager } from '../systemPrompt/manager.js';
+import { SystemPromptManager } from '../systemPrompt/manager.js';
 import { IConversationHistoryProvider } from '@core/session/history/types.js';
 import { ContextError } from './errors.js';
 import { ValidatedLLMConfig } from '../llm/schemas.js';
@@ -43,9 +43,9 @@ export class ContextManager<TMessage = unknown> {
     private llmConfig: ValidatedLLMConfig;
 
     /**
-     * PromptManager used to generate/manage the system prompt
+     * SystemPromptManager used to generate/manage the system prompt
      */
-    private promptManager: PromptManager;
+    private systemPromptManager: SystemPromptManager;
 
     /**
      * Formatter used to convert internal messages to LLM-specific format
@@ -88,7 +88,7 @@ export class ContextManager<TMessage = unknown> {
      * Creates a new ContextManager instance
      * @param llmConfig The validated LLM configuration.
      * @param formatter Formatter implementation for the target LLM provider
-     * @param promptManager PromptManager instance for the conversation
+     * @param systemPromptManager SystemPromptManager instance for the conversation
      * @param maxInputTokens Maximum token limit for the conversation history. Triggers compression if exceeded and a tokenizer is provided.
      * @param tokenizer Tokenizer implementation used for counting tokens and enabling compression.
      * @param historyProvider Session-scoped ConversationHistoryProvider instance for managing conversation history
@@ -98,7 +98,7 @@ export class ContextManager<TMessage = unknown> {
     constructor(
         llmConfig: ValidatedLLMConfig,
         formatter: IMessageFormatter,
-        promptManager: PromptManager,
+        systemPromptManager: SystemPromptManager,
         maxInputTokens: number,
         tokenizer: ITokenizer,
         historyProvider: IConversationHistoryProvider,
@@ -110,7 +110,7 @@ export class ContextManager<TMessage = unknown> {
     ) {
         this.llmConfig = llmConfig;
         this.formatter = formatter;
-        this.promptManager = promptManager;
+        this.systemPromptManager = systemPromptManager;
         this.maxInputTokens = maxInputTokens;
         this.tokenizer = tokenizer;
         this.historyProvider = historyProvider;
@@ -240,10 +240,10 @@ export class ContextManager<TMessage = unknown> {
     }
 
     /**
-     * Assembles and returns the current system prompt by invoking the PromptManager.
+     * Assembles and returns the current system prompt by invoking the SystemPromptManager.
      */
     async getSystemPrompt(context: DynamicContributorContext): Promise<string> {
-        const prompt = await this.promptManager.build(context);
+        const prompt = await this.systemPromptManager.build(context);
         logger.debug(`[SystemPrompt] Built system prompt:\n${prompt}`);
         return prompt;
     }

--- a/src/core/llm/services/anthropic.ts
+++ b/src/core/llm/services/anthropic.ts
@@ -9,7 +9,7 @@ import { getMaxInputTokensForModel, getEffectiveMaxInputTokens } from '../regist
 import { ImageData, FileData } from '../../context/types.js';
 import type { SessionEventBus } from '../../events/index.js';
 import type { IConversationHistoryProvider } from '../../session/history/types.js';
-import type { PromptManager } from '../../systemPrompt/manager.js';
+import type { SystemPromptManager } from '../../systemPrompt/manager.js';
 import { AnthropicMessageFormatter } from '../formatters/anthropic.js';
 import { createTokenizer } from '../tokenizer/factory.js';
 import type { ValidatedLLMConfig } from '../schemas.js';
@@ -29,7 +29,7 @@ export class AnthropicService implements ILLMService {
     constructor(
         toolManager: ToolManager,
         anthropic: Anthropic,
-        promptManager: PromptManager,
+        systemPromptManager: SystemPromptManager,
         historyProvider: IConversationHistoryProvider,
         sessionEventBus: SessionEventBus,
         config: ValidatedLLMConfig,
@@ -49,7 +49,7 @@ export class AnthropicService implements ILLMService {
         this.contextManager = new ContextManager<MessageParam>(
             config,
             formatter,
-            promptManager,
+            systemPromptManager,
             maxInputTokens,
             tokenizer,
             historyProvider,

--- a/src/core/llm/services/factory.ts
+++ b/src/core/llm/services/factory.ts
@@ -17,13 +17,13 @@ import { createCohere } from '@ai-sdk/cohere';
 import OpenAI from 'openai';
 import Anthropic from '@anthropic-ai/sdk';
 import type { IConversationHistoryProvider } from '../../session/history/types.js';
-import type { PromptManager } from '../../systemPrompt/manager.js';
+import type { SystemPromptManager } from '../../systemPrompt/manager.js';
 
 /**
  * Create an instance of one of our in-built LLM services
  * @param config LLM configuration from the config file
  * @param toolManager Unified tool manager instance
- * @param promptManager Prompt manager for system prompts
+ * @param systemPromptManager Prompt manager for system prompts
  * @param historyProvider History provider for conversation persistence
  * @param sessionEventBus Session-level event bus for emitting LLM events
  * @param sessionId Session ID
@@ -32,7 +32,7 @@ import type { PromptManager } from '../../systemPrompt/manager.js';
 function _createInBuiltLLMService(
     config: ValidatedLLMConfig,
     toolManager: ToolManager,
-    promptManager: PromptManager,
+    systemPromptManager: SystemPromptManager,
     historyProvider: IConversationHistoryProvider,
     sessionEventBus: SessionEventBus,
     sessionId: string
@@ -46,7 +46,7 @@ function _createInBuiltLLMService(
             return new OpenAIService(
                 toolManager,
                 openai,
-                promptManager,
+                systemPromptManager,
                 historyProvider,
                 sessionEventBus,
                 config,
@@ -60,7 +60,7 @@ function _createInBuiltLLMService(
             return new OpenAIService(
                 toolManager,
                 openai,
-                promptManager,
+                systemPromptManager,
                 historyProvider,
                 sessionEventBus,
                 config,
@@ -72,7 +72,7 @@ function _createInBuiltLLMService(
             return new AnthropicService(
                 toolManager,
                 anthropic,
-                promptManager,
+                systemPromptManager,
                 historyProvider,
                 sessionEventBus,
                 config,
@@ -138,7 +138,7 @@ function getOpenAICompatibleBaseURL(llmConfig: ValidatedLLMConfig): string {
 function _createVercelLLMService(
     config: ValidatedLLMConfig,
     toolManager: ToolManager,
-    promptManager: PromptManager,
+    systemPromptManager: SystemPromptManager,
     historyProvider: IConversationHistoryProvider,
     sessionEventBus: SessionEventBus,
     sessionId: string
@@ -148,7 +148,7 @@ function _createVercelLLMService(
     return new VercelLLMService(
         toolManager,
         model,
-        promptManager,
+        systemPromptManager,
         historyProvider,
         sessionEventBus,
         config,
@@ -163,7 +163,7 @@ export function createLLMService(
     config: ValidatedLLMConfig,
     router: LLMRouter,
     toolManager: ToolManager,
-    promptManager: PromptManager,
+    systemPromptManager: SystemPromptManager,
     historyProvider: IConversationHistoryProvider,
     sessionEventBus: SessionEventBus,
     sessionId: string
@@ -172,7 +172,7 @@ export function createLLMService(
         return _createVercelLLMService(
             config,
             toolManager,
-            promptManager,
+            systemPromptManager,
             historyProvider,
             sessionEventBus,
             sessionId
@@ -181,7 +181,7 @@ export function createLLMService(
         return _createInBuiltLLMService(
             config,
             toolManager,
-            promptManager,
+            systemPromptManager,
             historyProvider,
             sessionEventBus,
             sessionId

--- a/src/core/llm/services/openai.ts
+++ b/src/core/llm/services/openai.ts
@@ -11,7 +11,7 @@ import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
 import { LLMErrorCode } from '../error-codes.js';
 import type { SessionEventBus } from '../../events/index.js';
 import type { IConversationHistoryProvider } from '../../session/history/types.js';
-import type { PromptManager } from '../../systemPrompt/manager.js';
+import type { SystemPromptManager } from '../../systemPrompt/manager.js';
 import { OpenAIMessageFormatter } from '../formatters/openai.js';
 import { createTokenizer } from '../tokenizer/factory.js';
 import type { ValidatedLLMConfig } from '../schemas.js';
@@ -31,7 +31,7 @@ export class OpenAIService implements ILLMService {
     constructor(
         toolManager: ToolManager,
         openai: OpenAI,
-        promptManager: PromptManager,
+        systemPromptManager: SystemPromptManager,
         historyProvider: IConversationHistoryProvider,
         sessionEventBus: SessionEventBus,
         config: ValidatedLLMConfig,
@@ -51,7 +51,7 @@ export class OpenAIService implements ILLMService {
         this.contextManager = new ContextManager<ChatCompletionMessageParam>(
             config,
             formatter,
-            promptManager,
+            systemPromptManager,
             maxInputTokens,
             tokenizer,
             historyProvider,

--- a/src/core/llm/services/vercel.ts
+++ b/src/core/llm/services/vercel.ts
@@ -22,7 +22,7 @@ import type { SessionEventBus } from '../../events/index.js';
 import { toError } from '../../utils/error-conversion.js';
 import { ToolErrorCode } from '../../tools/error-codes.js';
 import type { IConversationHistoryProvider } from '../../session/history/types.js';
-import type { PromptManager } from '../../systemPrompt/manager.js';
+import type { SystemPromptManager } from '../../systemPrompt/manager.js';
 import { VercelMessageFormatter } from '../formatters/vercel.js';
 import { createTokenizer } from '../tokenizer/factory.js';
 import type { ValidatedLLMConfig } from '../schemas.js';
@@ -52,7 +52,7 @@ export class VercelLLMService implements ILLMService {
     constructor(
         toolManager: ToolManager,
         model: LanguageModel,
-        promptManager: PromptManager,
+        systemPromptManager: SystemPromptManager,
         historyProvider: IConversationHistoryProvider,
         sessionEventBus: SessionEventBus,
         config: ValidatedLLMConfig,
@@ -72,7 +72,7 @@ export class VercelLLMService implements ILLMService {
         this.contextManager = new ContextManager<ModelMessage>(
             config,
             formatter,
-            promptManager,
+            systemPromptManager,
             maxInputTokens,
             tokenizer,
             historyProvider,

--- a/src/core/prompts/index.ts
+++ b/src/core/prompts/index.ts
@@ -1,4 +1,5 @@
 export { PromptsManager } from './prompts-manager.js';
 export { MCPPromptProvider } from './providers/mcp-prompt-provider.js';
 export { InternalPromptProvider } from './providers/internal-prompt-provider.js';
+export { StarterPromptProvider } from './providers/starter-prompt-provider.js';
 export type { PromptInfo, PromptSet, PromptProvider } from './types.js';

--- a/src/core/prompts/index.ts
+++ b/src/core/prompts/index.ts
@@ -1,0 +1,4 @@
+export { PromptsManager } from './prompts-manager.js';
+export { MCPPromptProvider } from './providers/mcp-prompt-provider.js';
+export { InternalPromptProvider } from './providers/internal-prompt-provider.js';
+export type { PromptInfo, PromptSet, PromptProvider } from './types.js';

--- a/src/core/prompts/prompts-manager.ts
+++ b/src/core/prompts/prompts-manager.ts
@@ -1,0 +1,176 @@
+import type { MCPManager } from '../mcp/manager.js';
+import type { PromptSet } from './types.js';
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import { MCPPromptProvider } from './providers/mcp-prompt-provider.js';
+import { InternalPromptProvider } from './providers/internal-prompt-provider.js';
+import { logger } from '../logger/index.js';
+
+/**
+ * Unified Prompts Manager - Single interface for all prompt operations
+ *
+ * This class acts as the single point of contact for managing prompts from multiple sources.
+ * It aggregates prompts from MCP servers and internal markdown files, providing a unified interface
+ * for prompt discovery, metadata access, and prompt execution.
+ *
+ * Responsibilities:
+ * - Aggregate prompts from MCP servers and internal markdown files
+ * - Provide unified prompt interface for discovery and access
+ * - Cache prompt metadata for performance
+ * - Handle cross-source prompt conflicts with source prefixing
+ * - Support filtering and querying of prompts
+ *
+ * Architecture:
+ * Application → PromptsManager → [MCPPromptProvider, InternalPromptProvider]
+ */
+export class PromptsManager {
+    private mcpManager: MCPManager;
+    private mcpPromptProvider: MCPPromptProvider;
+    private internalPromptProvider: InternalPromptProvider;
+
+    // Prompt caching for performance
+    private promptsCache: PromptSet = {};
+    private cacheValid: boolean = false;
+
+    constructor(mcpManager: MCPManager, promptsDir?: string) {
+        this.mcpManager = mcpManager;
+
+        // Initialize MCP prompt provider
+        this.mcpPromptProvider = new MCPPromptProvider(mcpManager);
+
+        // Initialize internal prompt provider
+        this.internalPromptProvider = new InternalPromptProvider(promptsDir);
+
+        logger.debug('PromptsManager initialized');
+    }
+
+    /**
+     * Initialize the PromptsManager and its components
+     */
+    async initialize(): Promise<void> {
+        // Initial cache build
+        await this.buildPromptsCache();
+        logger.debug('PromptsManager initialization complete');
+    }
+
+    /**
+     * Invalidate the prompts cache
+     */
+    private invalidateCache(): void {
+        this.cacheValid = false;
+        this.promptsCache = {};
+        this.mcpPromptProvider.invalidateCache();
+        this.internalPromptProvider.invalidateCache();
+        logger.debug('PromptsManager cache invalidated');
+    }
+
+    /**
+     * Build the unified prompts cache from all providers
+     */
+    private async buildPromptsCache(): Promise<void> {
+        const allPrompts: PromptSet = {};
+
+        // Get MCP prompts
+        try {
+            const mcpPrompts = await this.mcpPromptProvider.listPrompts();
+            mcpPrompts.forEach((prompt) => {
+                allPrompts[prompt.name] = prompt;
+            });
+            logger.debug(`📝 Cached ${mcpPrompts.length} MCP prompts`);
+        } catch (error) {
+            logger.error(
+                `Failed to get MCP prompts: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        // Get internal prompts
+        try {
+            const internalPrompts = await this.internalPromptProvider.listPrompts();
+            internalPrompts.forEach((prompt) => {
+                allPrompts[prompt.name] = prompt;
+            });
+            logger.debug(`📝 Cached ${internalPrompts.length} internal prompts`);
+        } catch (error) {
+            logger.error(
+                `Failed to get internal prompts: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        this.promptsCache = allPrompts;
+        this.cacheValid = true;
+
+        const totalPrompts = Object.keys(allPrompts).length;
+        logger.debug(`📋 Prompt discovery: ${totalPrompts} total prompts`);
+
+        if (totalPrompts > 0) {
+            const sampleNames = Object.keys(allPrompts).slice(0, 5);
+            logger.debug(
+                `Sample prompts: ${sampleNames.join(', ')}${totalPrompts > 5 ? '...' : ''}`
+            );
+        }
+    }
+
+    /**
+     * List all available prompts with their info
+     */
+    async list(): Promise<PromptSet> {
+        if (!this.cacheValid) {
+            await this.buildPromptsCache();
+        }
+        return this.promptsCache;
+    }
+
+    /**
+     * Check if a prompt exists
+     */
+    async has(name: string): Promise<boolean> {
+        const prompts = await this.list();
+        return name in prompts;
+    }
+
+    /**
+     * Get a specific prompt by name
+     */
+    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+        const prompts = await this.list();
+        const metadata = prompts[name];
+        if (!metadata) {
+            throw new Error(`Prompt not found: ${name}`);
+        }
+
+        logger.debug(`📝 Getting prompt: ${name}`);
+
+        // Route to appropriate provider based on source
+        if (metadata.source === 'mcp') {
+            return await this.mcpPromptProvider.getPrompt(name, args);
+        }
+
+        if (metadata.source === 'internal') {
+            return await this.internalPromptProvider.getPrompt(name, args);
+        }
+
+        throw new Error(`No provider found for prompt: ${name}`);
+    }
+
+    /**
+     * Refresh all prompt caches
+     */
+    async refresh(): Promise<void> {
+        this.invalidateCache();
+        await this.buildPromptsCache();
+        logger.info('PromptsManager refreshed');
+    }
+
+    /**
+     * Get MCP prompt provider for direct access
+     */
+    getMcpPromptProvider(): MCPPromptProvider {
+        return this.mcpPromptProvider;
+    }
+
+    /**
+     * Get internal prompt provider for direct access
+     */
+    getInternalPromptProvider(): InternalPromptProvider {
+        return this.internalPromptProvider;
+    }
+}

--- a/src/core/prompts/providers/internal-prompt-provider.ts
+++ b/src/core/prompts/providers/internal-prompt-provider.ts
@@ -87,7 +87,7 @@ export class InternalPromptProvider implements PromptProvider {
                                         const descMatch = line.match(
                                             /description:\s*["']?([^"']+)["']?/
                                         );
-                                        if (descMatch) {
+                                        if (descMatch && descMatch[1]) {
                                             description = descMatch[1];
                                         }
                                     }

--- a/src/core/prompts/providers/internal-prompt-provider.ts
+++ b/src/core/prompts/providers/internal-prompt-provider.ts
@@ -1,4 +1,4 @@
-import type { PromptProvider, PromptInfo } from '../types.js';
+import type { PromptProvider, PromptInfo, PromptDefinition, PromptListResult } from '../types.js';
 import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
 import { logger } from '../../logger/index.js';
 import { readFile, readdir } from 'fs/promises';
@@ -9,6 +9,7 @@ import { join, extname } from 'path';
  *
  * This provider reads markdown files from a configured directory and makes them available
  * as prompts. The filename (without extension) becomes the prompt identifier.
+ * It implements the MCP specification for prompt discovery and retrieval.
  */
 export class InternalPromptProvider implements PromptProvider {
     private promptsDir: string;
@@ -57,16 +58,54 @@ export class InternalPromptProvider implements PromptProvider {
                         // Read the markdown content
                         const content = await readFile(filePath, 'utf-8');
 
-                        // Extract description from first line or use filename
+                        // Extract description from frontmatter and first line
                         const lines = content.trim().split('\n');
-                        const firstLine = lines[0]?.trim();
-                        const description =
-                            firstLine && firstLine.startsWith('#')
-                                ? firstLine.replace(/^#+\s*/, '')
-                                : `Internal prompt: ${promptName}`;
+                        let description = `Internal prompt: ${promptName}`;
+                        let title = promptName;
+
+                        // Check for frontmatter
+                        if (lines[0]?.trim() === '---') {
+                            let inFrontmatter = false;
+                            let frontmatterEnd = 0;
+
+                            for (let i = 0; i < lines.length; i++) {
+                                if (lines[i]?.trim() === '---') {
+                                    if (!inFrontmatter) {
+                                        inFrontmatter = true;
+                                    } else {
+                                        frontmatterEnd = i;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if (frontmatterEnd > 0) {
+                                // Parse frontmatter
+                                const frontmatterLines = lines.slice(1, frontmatterEnd);
+                                for (const line of frontmatterLines) {
+                                    if (line.includes('description:')) {
+                                        const descMatch = line.match(
+                                            /description:\s*["']?([^"']+)["']?/
+                                        );
+                                        if (descMatch) {
+                                            description = descMatch[1];
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Extract title from first heading after frontmatter
+                        for (const line of lines) {
+                            if (line.trim().startsWith('#')) {
+                                title = line.trim().replace(/^#+\s*/, '');
+                                break;
+                            }
+                        }
 
                         const promptInfo: PromptInfo = {
                             name: promptName,
+                            title,
                             description,
                             source: 'internal',
                             metadata: {
@@ -104,69 +143,102 @@ export class InternalPromptProvider implements PromptProvider {
     }
 
     /**
-     * List all available internal prompts
+     * Get a prompt by name
      */
-    async listPrompts(): Promise<PromptInfo[]> {
-        if (!this.cacheValid) {
-            await this.buildPromptsCache();
+    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+        try {
+            if (!this.cacheValid) {
+                await this.buildPromptsCache();
+            }
+
+            const promptInfo = this.promptsCache.find((p) => p.name === name);
+            if (!promptInfo || !promptInfo.metadata?.content) {
+                throw new Error(`Internal prompt not found: ${name}`);
+            }
+
+            logger.debug(`📝 Reading internal prompt: ${name}`);
+
+            // Get the content and apply any arguments
+            let content = promptInfo.metadata.content as string;
+
+            // If args are provided, add context for the LLM to understand
+            if (args && typeof args === 'object') {
+                // Handle special _context argument for natural language input
+                if (args._context) {
+                    const contextString = String(args._context);
+                    // Add context at the beginning so the LLM knows what to work with
+                    content = `Context: ${contextString}\n\n${content}`;
+                } else if (Object.keys(args).length > 0) {
+                    // Handle explicit key=value arguments by adding them as context
+                    const argContext = Object.entries(args)
+                        .map(([key, value]) => `${key}: ${value}`)
+                        .join(', ');
+                    content = `Arguments: ${argContext}\n\n${content}`;
+                }
+            }
+
+            // Return the prompt content
+            return {
+                description: promptInfo.description,
+                messages: [
+                    {
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: content.trim(),
+                        },
+                    },
+                ],
+            };
+        } catch (error) {
+            logger.debug(
+                `Failed to get prompt '${name}': ${error instanceof Error ? error.message : String(error)}`
+            );
+            throw error; // Re-throw as GetPromptResult doesn't allow null
         }
-        return this.promptsCache;
     }
 
     /**
-     * Get a specific internal prompt by name
+     * List all available internal prompts
      */
-    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+    async listPrompts(_cursor?: string): Promise<PromptListResult> {
         if (!this.cacheValid) {
             await this.buildPromptsCache();
         }
-
-        const promptInfo = this.promptsCache.find((p) => p.name === name);
-        if (!promptInfo || !promptInfo.metadata?.content) {
-            throw new Error(`Internal prompt not found: ${name}`);
-        }
-
-        logger.debug(`📝 Reading internal prompt: ${name}`);
-
-        // Get the content and apply any arguments
-        let content = promptInfo.metadata.content as string;
-
-        // If args are provided, add context for the LLM to understand
-        if (args && typeof args === 'object') {
-            // Handle special _context argument for natural language input
-            if (args._context) {
-                const contextString = String(args._context);
-                // Add context at the beginning so the LLM knows what to work with
-                content = `Context: ${contextString}\n\n${content}`;
-            } else if (Object.keys(args).length > 0) {
-                // Handle explicit key=value arguments by adding them as context
-                const argContext = Object.entries(args)
-                    .map(([key, value]) => `${key}: ${value}`)
-                    .join(', ');
-                content = `Arguments: ${argContext}\n\n${content}`;
-            }
-        }
-
-        // Return the prompt content
         return {
-            description: promptInfo.description,
-            messages: [
-                {
-                    role: 'user',
-                    content: {
-                        type: 'text',
-                        text: content.trim(),
-                    },
-                },
-            ],
+            prompts: this.promptsCache,
         };
     }
 
     /**
-     * Check if an internal prompt exists
+     * Check if a prompt exists
      */
     async hasPrompt(name: string): Promise<boolean> {
         const prompts = await this.listPrompts();
-        return prompts.some((prompt) => prompt.name === name);
+        return prompts.prompts.some((prompt: PromptInfo) => prompt.name === name);
+    }
+
+    /**
+     * Get prompt definition (metadata only)
+     */
+    async getPromptDefinition(name: string): Promise<PromptDefinition | null> {
+        try {
+            const promptInfo = this.promptsCache.find((p) => p.name === name);
+            if (!promptInfo) {
+                return null;
+            }
+
+            return {
+                name: promptInfo.name,
+                ...(promptInfo.title && { title: promptInfo.title }),
+                ...(promptInfo.description && { description: promptInfo.description }),
+                ...(promptInfo.arguments && { arguments: promptInfo.arguments }),
+            };
+        } catch (error) {
+            logger.debug(
+                `Failed to get prompt definition for '${name}': ${error instanceof Error ? error.message : String(error)}`
+            );
+            return null;
+        }
     }
 }

--- a/src/core/prompts/providers/internal-prompt-provider.ts
+++ b/src/core/prompts/providers/internal-prompt-provider.ts
@@ -1,0 +1,172 @@
+import type { PromptProvider, PromptInfo } from '../types.js';
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../logger/index.js';
+import { readFile, readdir } from 'fs/promises';
+import { join, extname } from 'path';
+
+/**
+ * Internal Prompt Provider - Provides prompts from markdown files in a prompts directory
+ *
+ * This provider reads markdown files from a configured directory and makes them available
+ * as prompts. The filename (without extension) becomes the prompt identifier.
+ */
+export class InternalPromptProvider implements PromptProvider {
+    private promptsDir: string;
+    private promptsCache: PromptInfo[] = [];
+    private cacheValid: boolean = false;
+
+    constructor(promptsDir: string = 'prompts') {
+        this.promptsDir = promptsDir;
+    }
+
+    /**
+     * Get the source identifier for this provider
+     */
+    getSource(): string {
+        return 'internal';
+    }
+
+    /**
+     * Invalidate the prompts cache
+     */
+    invalidateCache(): void {
+        this.cacheValid = false;
+        this.promptsCache = [];
+        logger.debug('InternalPromptProvider cache invalidated');
+    }
+
+    /**
+     * Build the prompts cache from markdown files
+     */
+    private async buildPromptsCache(): Promise<void> {
+        const allPrompts: PromptInfo[] = [];
+
+        try {
+            // Check if prompts directory exists
+            try {
+                const files = await readdir(this.promptsDir);
+
+                // Filter for markdown files
+                const markdownFiles = files.filter((file) => extname(file).toLowerCase() === '.md');
+
+                for (const file of markdownFiles) {
+                    try {
+                        const promptName = file.replace(/\.md$/, '');
+                        const filePath = join(this.promptsDir, file);
+
+                        // Read the markdown content
+                        const content = await readFile(filePath, 'utf-8');
+
+                        // Extract description from first line or use filename
+                        const lines = content.trim().split('\n');
+                        const firstLine = lines[0]?.trim();
+                        const description =
+                            firstLine && firstLine.startsWith('#')
+                                ? firstLine.replace(/^#+\s*/, '')
+                                : `Internal prompt: ${promptName}`;
+
+                        const promptInfo: PromptInfo = {
+                            name: promptName,
+                            description,
+                            source: 'internal',
+                            metadata: {
+                                originalName: promptName,
+                                filePath,
+                                content,
+                            },
+                        };
+
+                        allPrompts.push(promptInfo);
+                    } catch (error) {
+                        logger.warn(
+                            `Failed to process prompt file '${file}': ${error instanceof Error ? error.message : String(error)}`
+                        );
+                    }
+                }
+
+                logger.debug(
+                    `📝 Cached ${allPrompts.length} internal prompts from ${this.promptsDir}`
+                );
+            } catch (error) {
+                // Directory doesn't exist or can't be read
+                logger.debug(
+                    `Prompts directory '${this.promptsDir}' not found or not accessible: ${error instanceof Error ? error.message : String(error)}`
+                );
+            }
+        } catch (error) {
+            logger.error(
+                `Failed to build internal prompts cache: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        this.promptsCache = allPrompts;
+        this.cacheValid = true;
+    }
+
+    /**
+     * List all available internal prompts
+     */
+    async listPrompts(): Promise<PromptInfo[]> {
+        if (!this.cacheValid) {
+            await this.buildPromptsCache();
+        }
+        return this.promptsCache;
+    }
+
+    /**
+     * Get a specific internal prompt by name
+     */
+    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+        if (!this.cacheValid) {
+            await this.buildPromptsCache();
+        }
+
+        const promptInfo = this.promptsCache.find((p) => p.name === name);
+        if (!promptInfo || !promptInfo.metadata?.content) {
+            throw new Error(`Internal prompt not found: ${name}`);
+        }
+
+        logger.debug(`📝 Reading internal prompt: ${name}`);
+
+        // Get the content and apply any arguments
+        let content = promptInfo.metadata.content as string;
+
+        // If args are provided, add context for the LLM to understand
+        if (args && typeof args === 'object') {
+            // Handle special _context argument for natural language input
+            if (args._context) {
+                const contextString = String(args._context);
+                // Add context at the beginning so the LLM knows what to work with
+                content = `Context: ${contextString}\n\n${content}`;
+            } else if (Object.keys(args).length > 0) {
+                // Handle explicit key=value arguments by adding them as context
+                const argContext = Object.entries(args)
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join(', ');
+                content = `Arguments: ${argContext}\n\n${content}`;
+            }
+        }
+
+        // Return the prompt content
+        return {
+            description: promptInfo.description,
+            messages: [
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: content.trim(),
+                    },
+                },
+            ],
+        };
+    }
+
+    /**
+     * Check if an internal prompt exists
+     */
+    async hasPrompt(name: string): Promise<boolean> {
+        const prompts = await this.listPrompts();
+        return prompts.some((prompt) => prompt.name === name);
+    }
+}

--- a/src/core/prompts/providers/mcp-prompt-provider.ts
+++ b/src/core/prompts/providers/mcp-prompt-provider.ts
@@ -1,0 +1,117 @@
+import type { MCPManager } from '../../mcp/manager.js';
+import type { PromptProvider, PromptInfo } from '../types.js';
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '../../logger/index.js';
+
+/**
+ * MCP Prompt Provider - Provides prompts from connected MCP servers
+ *
+ * This provider acts as a bridge between the PromptsManager and MCPManager,
+ * exposing prompts from all connected MCP servers through a unified interface.
+ */
+export class MCPPromptProvider implements PromptProvider {
+    private mcpManager: MCPManager;
+
+    // Prompt caching for performance
+    private promptsCache: PromptInfo[] = [];
+    private cacheValid: boolean = false;
+
+    constructor(mcpManager: MCPManager) {
+        this.mcpManager = mcpManager;
+    }
+
+    /**
+     * Get the source identifier for this provider
+     */
+    getSource(): string {
+        return 'mcp';
+    }
+
+    /**
+     * Invalidate the prompts cache
+     */
+    invalidateCache(): void {
+        this.cacheValid = false;
+        this.promptsCache = [];
+        logger.debug('MCPPromptProvider cache invalidated');
+    }
+
+    /**
+     * Build the prompts cache from MCP servers
+     */
+    private async buildPromptsCache(): Promise<void> {
+        const allPrompts: PromptInfo[] = [];
+
+        try {
+            // Get all available prompt names
+            const promptNames = await this.mcpManager.listAllPrompts();
+
+            for (const promptName of promptNames) {
+                try {
+                    // Get the prompt definition to extract metadata
+                    const promptDef = await this.mcpManager.getPrompt(promptName);
+
+                    const promptInfo: PromptInfo = {
+                        name: promptName,
+                        description: promptDef.description || `MCP prompt: ${promptName}`,
+                        source: 'mcp',
+                        metadata: {
+                            originalName: promptName,
+                            description: promptDef.description,
+                        },
+                    };
+
+                    allPrompts.push(promptInfo);
+                } catch (error) {
+                    logger.debug(
+                        `Failed to get prompt definition for '${promptName}': ${error instanceof Error ? error.message : String(error)}`
+                    );
+                    // Still add the prompt with minimal info
+                    allPrompts.push({
+                        name: promptName,
+                        description: `MCP prompt: ${promptName}`,
+                        source: 'mcp',
+                        metadata: {
+                            originalName: promptName,
+                        },
+                    });
+                }
+            }
+
+            logger.debug(`📝 Cached ${allPrompts.length} MCP prompts`);
+        } catch (error) {
+            logger.error(
+                `Failed to get MCP prompts: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+
+        this.promptsCache = allPrompts;
+        this.cacheValid = true;
+    }
+
+    /**
+     * List all available prompts from MCP servers
+     */
+    async listPrompts(): Promise<PromptInfo[]> {
+        if (!this.cacheValid) {
+            await this.buildPromptsCache();
+        }
+        return this.promptsCache;
+    }
+
+    /**
+     * Get a specific prompt by name
+     */
+    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+        logger.debug(`📝 Reading MCP prompt: ${name}`);
+        return await this.mcpManager.getPrompt(name, args);
+    }
+
+    /**
+     * Check if a prompt exists
+     */
+    async hasPrompt(name: string): Promise<boolean> {
+        const prompts = await this.listPrompts();
+        return prompts.some((prompt) => prompt.name === name);
+    }
+}

--- a/src/core/prompts/providers/starter-prompt-provider.ts
+++ b/src/core/prompts/providers/starter-prompt-provider.ts
@@ -1,0 +1,167 @@
+import type { PromptProvider, PromptInfo, PromptDefinition, PromptListResult } from '../types.js';
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+import type { AgentConfig } from '../../agent/schemas.js';
+import { logger } from '../../logger/index.js';
+
+/**
+ * Starter Prompt Provider - Provides prompts from agent configuration starter prompts
+ *
+ * This provider exposes starter prompts defined in the agent configuration as regular prompts.
+ * Starter prompts are intended for quick access to common user workflows and are typically
+ * displayed prominently in the UI.
+ */
+export class StarterPromptProvider implements PromptProvider {
+    private starterPrompts: any[] = [];
+    private promptsCache: PromptInfo[] = [];
+    private cacheValid: boolean = false;
+
+    constructor(agentConfig?: AgentConfig) {
+        this.starterPrompts = agentConfig?.starterPrompts || [];
+        this.buildPromptsCache();
+    }
+
+    /**
+     * Get the source identifier for this provider
+     */
+    getSource(): string {
+        return 'starter';
+    }
+
+    /**
+     * Invalidate the prompts cache
+     */
+    invalidateCache(): void {
+        this.cacheValid = false;
+        this.promptsCache = [];
+        logger.debug('StarterPromptProvider cache invalidated');
+    }
+
+    /**
+     * Update starter prompts configuration
+     */
+    updateConfig(agentConfig?: AgentConfig): void {
+        this.starterPrompts = agentConfig?.starterPrompts || [];
+        this.invalidateCache();
+        this.buildPromptsCache();
+    }
+
+    /**
+     * Build the prompts cache from starter prompts configuration
+     */
+    private buildPromptsCache(): void {
+        const allPrompts: PromptInfo[] = [];
+
+        this.starterPrompts.forEach((starterPrompt: any) => {
+            const promptName = `starter:${starterPrompt.id}`;
+            const promptInfo: PromptInfo = {
+                name: promptName,
+                title: starterPrompt.title,
+                description: starterPrompt.description,
+                source: 'starter',
+                metadata: {
+                    prompt: starterPrompt.prompt,
+                    category: starterPrompt.category,
+                    icon: starterPrompt.icon,
+                    priority: starterPrompt.priority,
+                    originalId: starterPrompt.id,
+                },
+            };
+            allPrompts.push(promptInfo);
+        });
+
+        this.promptsCache = allPrompts;
+        this.cacheValid = true;
+
+        logger.debug(`📝 Cached ${allPrompts.length} starter prompts`);
+    }
+
+    /**
+     * List all available starter prompts with pagination support
+     */
+    async listPrompts(_cursor?: string): Promise<PromptListResult> {
+        if (!this.cacheValid) {
+            this.buildPromptsCache();
+        }
+
+        return {
+            prompts: this.promptsCache,
+        };
+    }
+
+    /**
+     * Get a specific starter prompt by name
+     */
+    async getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult> {
+        if (!this.cacheValid) {
+            this.buildPromptsCache();
+        }
+
+        const promptInfo = this.promptsCache.find((p) => p.name === name);
+        if (!promptInfo) {
+            throw new Error(`Starter prompt not found: ${name}`);
+        }
+
+        const promptText = promptInfo.metadata?.prompt as string;
+        if (!promptText) {
+            throw new Error('Starter prompt missing prompt text');
+        }
+
+        logger.debug(`📝 Reading starter prompt: ${name}`);
+
+        // Apply arguments if provided (similar to internal provider)
+        let content = promptText;
+        if (args && typeof args === 'object') {
+            if (args._context) {
+                const contextString = String(args._context);
+                content = `Context: ${contextString}\n\n${content}`;
+            } else if (Object.keys(args).length > 0) {
+                const argContext = Object.entries(args)
+                    .map(([key, value]) => `${key}: ${value}`)
+                    .join(', ');
+                content = `Arguments: ${argContext}\n\n${content}`;
+            }
+        }
+
+        return {
+            description: promptInfo.description,
+            messages: [
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: content,
+                    },
+                },
+            ],
+        };
+    }
+
+    /**
+     * Check if a starter prompt exists
+     */
+    async hasPrompt(name: string): Promise<boolean> {
+        const prompts = await this.listPrompts();
+        return prompts.prompts.some((prompt) => prompt.name === name);
+    }
+
+    /**
+     * Get prompt definition (metadata only)
+     */
+    async getPromptDefinition(name: string): Promise<PromptDefinition | null> {
+        if (!this.cacheValid) {
+            this.buildPromptsCache();
+        }
+
+        const promptInfo = this.promptsCache.find((p) => p.name === name);
+        if (!promptInfo) {
+            return null;
+        }
+
+        return {
+            name: promptInfo.name,
+            ...(promptInfo.title && { title: promptInfo.title }),
+            ...(promptInfo.description && { description: promptInfo.description }),
+            ...(promptInfo.arguments && { arguments: promptInfo.arguments }),
+        };
+    }
+}

--- a/src/core/prompts/types.ts
+++ b/src/core/prompts/types.ts
@@ -1,0 +1,41 @@
+import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Represents a prompt with metadata
+ */
+export interface PromptInfo {
+    name: string;
+    description?: string;
+    source: 'mcp' | 'internal';
+    metadata?: Record<string, unknown>;
+}
+
+/**
+ * Set of prompts indexed by name
+ */
+export type PromptSet = Record<string, PromptInfo>;
+
+/**
+ * Interface for prompt providers
+ */
+export interface PromptProvider {
+    /**
+     * Get the source identifier for this provider
+     */
+    getSource(): string;
+
+    /**
+     * List all available prompts from this provider
+     */
+    listPrompts(): Promise<PromptInfo[]>;
+
+    /**
+     * Get a specific prompt by name
+     */
+    getPrompt(name: string, args?: Record<string, unknown>): Promise<GetPromptResult>;
+
+    /**
+     * Check if a prompt exists
+     */
+    hasPrompt(name: string): Promise<boolean>;
+}

--- a/src/core/prompts/types.ts
+++ b/src/core/prompts/types.ts
@@ -116,6 +116,11 @@ export interface PromptProvider {
     getSource(): string;
 
     /**
+     * Invalidate the provider's internal cache
+     */
+    invalidateCache(): void;
+
+    /**
      * List all available prompts from this provider with pagination support
      */
     listPrompts(cursor?: string): Promise<PromptListResult>;

--- a/src/core/prompts/types.ts
+++ b/src/core/prompts/types.ts
@@ -1,11 +1,94 @@
 import type { GetPromptResult } from '@modelcontextprotocol/sdk/types.js';
 
 /**
- * Represents a prompt with metadata
+ * MCP-compliant prompt argument definition
  */
-export interface PromptInfo {
+export interface PromptArgument {
     name: string;
     description?: string;
+    required: boolean;
+}
+
+/**
+ * MCP-compliant prompt definition
+ */
+export interface PromptDefinition {
+    name: string;
+    title?: string | undefined;
+    description?: string | undefined;
+    arguments?: PromptArgument[] | undefined;
+}
+
+/**
+ * Content types for prompt messages as per MCP spec
+ */
+export type PromptContentType = 'text' | 'image' | 'audio' | 'resource';
+
+/**
+ * Base content interface for prompt messages
+ */
+export interface PromptContent {
+    type: PromptContentType;
+}
+
+/**
+ * Text content for prompt messages
+ */
+export interface TextContent extends PromptContent {
+    type: 'text';
+    text: string;
+}
+
+/**
+ * Image content for prompt messages
+ */
+export interface ImageContent extends PromptContent {
+    type: 'image';
+    data: string; // base64-encoded image data
+    mimeType: string;
+}
+
+/**
+ * Audio content for prompt messages
+ */
+export interface AudioContent extends PromptContent {
+    type: 'audio';
+    data: string; // base64-encoded audio data
+    mimeType: string;
+}
+
+/**
+ * Embedded resource content for prompt messages
+ */
+export interface ResourceContent extends PromptContent {
+    type: 'resource';
+    resource: {
+        uri: string;
+        name: string;
+        title?: string;
+        mimeType: string;
+        text?: string;
+        data?: string; // base64-encoded blob data
+    };
+}
+
+/**
+ * Union type for all content types
+ */
+export type PromptMessageContent = TextContent | ImageContent | AudioContent | ResourceContent;
+
+/**
+ * Prompt message structure as per MCP spec
+ */
+export interface PromptMessage {
+    role: 'user' | 'assistant';
+    content: PromptMessageContent;
+}
+
+/**
+ * Enhanced prompt info with MCP-compliant structure
+ */
+export interface PromptInfo extends PromptDefinition {
     source: 'mcp' | 'internal';
     metadata?: Record<string, unknown>;
 }
@@ -14,6 +97,14 @@ export interface PromptInfo {
  * Set of prompts indexed by name
  */
 export type PromptSet = Record<string, PromptInfo>;
+
+/**
+ * Pagination support for prompt listing
+ */
+export interface PromptListResult {
+    prompts: PromptInfo[];
+    nextCursor?: string | undefined;
+}
 
 /**
  * Interface for prompt providers
@@ -25,9 +116,9 @@ export interface PromptProvider {
     getSource(): string;
 
     /**
-     * List all available prompts from this provider
+     * List all available prompts from this provider with pagination support
      */
-    listPrompts(): Promise<PromptInfo[]>;
+    listPrompts(cursor?: string): Promise<PromptListResult>;
 
     /**
      * Get a specific prompt by name
@@ -38,4 +129,9 @@ export interface PromptProvider {
      * Check if a prompt exists
      */
     hasPrompt(name: string): Promise<boolean>;
+
+    /**
+     * Get prompt definition (metadata only)
+     */
+    getPromptDefinition(name: string): Promise<PromptDefinition | null>;
 }

--- a/src/core/prompts/types.ts
+++ b/src/core/prompts/types.ts
@@ -89,7 +89,7 @@ export interface PromptMessage {
  * Enhanced prompt info with MCP-compliant structure
  */
 export interface PromptInfo extends PromptDefinition {
-    source: 'mcp' | 'internal';
+    source: 'mcp' | 'internal' | 'starter';
     metadata?: Record<string, unknown>;
 }
 

--- a/src/core/session/chat-session.test.ts
+++ b/src/core/session/chat-session.test.ts
@@ -124,7 +124,7 @@ describe('ChatSession', () => {
                 getLLMConfig: vi.fn().mockReturnValue(mockLLMConfig),
                 updateLLM: vi.fn().mockReturnValue({ isValid: true, errors: [], warnings: [] }),
             },
-            promptManager: {
+            systemPromptManager: {
                 getSystemPrompt: vi.fn().mockReturnValue('System prompt'),
             },
             mcpManager: {
@@ -245,7 +245,7 @@ describe('ChatSession', () => {
                 newConfig,
                 newConfig.router,
                 mockServices.toolManager,
-                mockServices.promptManager,
+                mockServices.systemPromptManager,
                 mockHistoryProvider,
                 chatSession.eventBus,
                 sessionId
@@ -269,7 +269,7 @@ describe('ChatSession', () => {
                 newConfig,
                 newConfig.router,
                 mockServices.toolManager,
-                mockServices.promptManager,
+                mockServices.systemPromptManager,
                 mockHistoryProvider,
                 chatSession.eventBus,
                 sessionId
@@ -388,7 +388,7 @@ describe('ChatSession', () => {
                 mockLLMConfig,
                 mockLLMConfig.router,
                 mockServices.toolManager,
-                mockServices.promptManager,
+                mockServices.systemPromptManager,
                 mockHistoryProvider,
                 chatSession.eventBus, // Session-specific event bus
                 sessionId

--- a/src/core/session/chat-session.ts
+++ b/src/core/session/chat-session.ts
@@ -3,7 +3,7 @@ import { createLLMService } from '../llm/services/factory.js';
 import type { ContextManager } from '@core/context/index.js';
 import type { IConversationHistoryProvider } from './history/types.js';
 import type { ILLMService } from '../llm/services/types.js';
-import type { PromptManager } from '../systemPrompt/manager.js';
+import type { SystemPromptManager } from '../systemPrompt/manager.js';
 import type { ToolManager } from '../tools/tool-manager.js';
 import type { ValidatedLLMConfig } from '@core/llm/schemas.js';
 import type { AgentStateManager } from '../agent/state-manager.js';
@@ -114,7 +114,7 @@ export class ChatSession {
     constructor(
         private services: {
             stateManager: AgentStateManager;
-            promptManager: PromptManager;
+            systemPromptManager: SystemPromptManager;
             toolManager: ToolManager;
             agentEventBus: AgentEventBus;
             storage: StorageBackends;
@@ -191,7 +191,7 @@ export class ChatSession {
             llmConfig,
             llmConfig.router,
             this.services.toolManager,
-            this.services.promptManager,
+            this.services.systemPromptManager,
             this.historyProvider, // Pass history provider for service to use
             this.eventBus, // Use session event bus
             this.id
@@ -374,7 +374,7 @@ export class ChatSession {
                 newLLMConfig,
                 router,
                 this.services.toolManager,
-                this.services.promptManager,
+                this.services.systemPromptManager,
                 this.historyProvider, // Pass the SAME history provider - preserves conversation!
                 this.eventBus, // Use session event bus
                 this.id

--- a/src/core/session/session-manager.test.ts
+++ b/src/core/session/session-manager.test.ts
@@ -74,7 +74,7 @@ describe('SessionManager', () => {
                 getLLMConfig: vi.fn().mockReturnValue(mockLLMConfig),
                 updateLLM: vi.fn().mockReturnValue({ isValid: true, errors: [], warnings: [] }),
             },
-            promptManager: {
+            systemPromptManager: {
                 getSystemPrompt: vi.fn().mockReturnValue('System prompt'),
             },
             mcpManager: {

--- a/src/core/session/session-manager.ts
+++ b/src/core/session/session-manager.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'crypto';
 import { ChatSession } from './chat-session.js';
-import { PromptManager } from '../systemPrompt/manager.js';
+import { SystemPromptManager } from '../systemPrompt/manager.js';
 import { ToolManager } from '../tools/tool-manager.js';
 import { AgentEventBus } from '../events/index.js';
 import { logger } from '../logger/index.js';
@@ -53,7 +53,7 @@ export class SessionManager {
     constructor(
         private services: {
             stateManager: AgentStateManager;
-            promptManager: PromptManager;
+            systemPromptManager: SystemPromptManager;
             toolManager: ToolManager;
             agentEventBus: AgentEventBus;
             storage: StorageBackends;

--- a/src/core/systemPrompt/manager.test.ts
+++ b/src/core/systemPrompt/manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { PromptManager } from './manager.js';
+import { SystemPromptManager } from './manager.js';
 import { SystemPromptConfigSchema } from './schemas.js';
 import type { DynamicContributorContext } from './types.js';
 import * as registry from './registry.js';
@@ -15,7 +15,7 @@ vi.mock('./registry.js', () => ({
 
 const mockGetPromptGenerator = vi.mocked(registry.getPromptGenerator);
 
-describe('PromptManager', () => {
+describe('SystemPromptManager', () => {
     let mockContext: DynamicContributorContext;
 
     beforeEach(() => {
@@ -39,7 +39,7 @@ describe('PromptManager', () => {
     describe('Initialization', () => {
         it('should initialize with string config and create static contributor', () => {
             const config = SystemPromptConfigSchema.parse('You are a helpful assistant');
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
 
             const contributors = manager.getContributors();
             expect(contributors).toHaveLength(1);
@@ -49,7 +49,7 @@ describe('PromptManager', () => {
 
         it('should initialize with empty object config and apply defaults', () => {
             const config = SystemPromptConfigSchema.parse({});
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
 
             const contributors = manager.getContributors();
             expect(contributors).toHaveLength(1); // Only dateTime is enabled by default
@@ -78,7 +78,7 @@ describe('PromptManager', () => {
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const contributors = manager.getContributors();
 
             expect(contributors).toHaveLength(2);
@@ -106,7 +106,7 @@ describe('PromptManager', () => {
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const contributors = manager.getContributors();
 
             expect(contributors).toHaveLength(1);
@@ -122,7 +122,7 @@ describe('PromptManager', () => {
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const contributors = manager.getContributors();
 
             expect(contributors).toHaveLength(3);
@@ -145,7 +145,7 @@ describe('PromptManager', () => {
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe('Hello, I am Dexto!');
@@ -170,7 +170,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe(multilineContent);
@@ -193,7 +193,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(mockGetPromptGenerator).toHaveBeenCalledWith('dateTime');
@@ -217,7 +217,7 @@ You can help with:
 
             const error = (() => {
                 try {
-                    new PromptManager(config);
+                    new SystemPromptManager(config);
                     return null;
                 } catch (e) {
                     return e;
@@ -246,7 +246,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe('Time: 2023-01-01\nResources: file1.md, file2.md');
@@ -272,7 +272,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config, '/custom/config/dir');
+            const manager = new SystemPromptManager(config, '/custom/config/dir');
             const contributors = manager.getContributors();
 
             expect(contributors).toHaveLength(1);
@@ -293,7 +293,7 @@ You can help with:
             });
 
             const customConfigDir = '/custom/project/path';
-            const manager = new PromptManager(config, customConfigDir);
+            const manager = new SystemPromptManager(config, customConfigDir);
 
             // The FileContributor should receive the custom config directory
             expect(manager.getContributors()).toHaveLength(1);
@@ -322,7 +322,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe('Static content\nDynamic content');
@@ -350,7 +350,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             // Should be ordered by priority: 0, 5, 20
@@ -368,7 +368,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe('First line\nSecond line\nThird line');
@@ -382,7 +382,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const result = await manager.build(mockContext);
 
             expect(result).toBe('\nHas content');
@@ -409,7 +409,7 @@ You can help with:
                 mcpManager: {} as any, // Mock MCPManager
             };
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             await manager.build(customContext);
 
             expect(mockGenerator1).toHaveBeenCalledWith(customContext);
@@ -426,7 +426,7 @@ You can help with:
                 contributors: [{ id: 'failing', type: 'dynamic', priority: 0, source: 'dateTime' }],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
 
             await expect(manager.build(mockContext)).rejects.toThrow('Generator failed');
         });
@@ -438,7 +438,7 @@ You can help with:
             const originalCwd = process.cwd;
             process.cwd = vi.fn().mockReturnValue('/mocked/cwd');
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             expect(manager.getContributors()).toHaveLength(1);
 
             process.cwd = originalCwd;
@@ -457,7 +457,7 @@ You can help with:
             });
 
             const config = SystemPromptConfigSchema.parse({});
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
 
             // Only dateTime should be enabled by default, resources is disabled
             const contributors = manager.getContributors();
@@ -498,7 +498,7 @@ You can help with:
                 ],
             });
 
-            const manager = new PromptManager(config);
+            const manager = new SystemPromptManager(config);
             const contributors = manager.getContributors();
 
             expect(contributors).toHaveLength(3);

--- a/src/core/systemPrompt/manager.ts
+++ b/src/core/systemPrompt/manager.ts
@@ -8,17 +8,17 @@ import { logger } from '../logger/index.js';
 import { SystemPromptError } from './errors.js';
 
 /**
- * PromptManager orchestrates registration, loading, and composition
+ * SystemPromptManager orchestrates registration, loading, and composition
  * of both static and dynamic system-prompt contributors.
  */
-export class PromptManager {
+export class SystemPromptManager {
     private contributors: SystemPromptContributor[];
     private configDir: string;
 
     // TODO: move config dir logic somewhere else
     constructor(config: ValidatedSystemPromptConfig, configDir: string = process.cwd()) {
         this.configDir = configDir;
-        logger.debug(`[PromptManager] Initializing with configDir: ${configDir}`);
+        logger.debug(`[SystemPromptManager] Initializing with configDir: ${configDir}`);
 
         // Filter enabled contributors and create contributor instances
         const enabledContributors = config.contributors.filter((c) => c.enabled !== false);
@@ -43,7 +43,7 @@ export class PromptManager {
 
             case 'file': {
                 logger.debug(
-                    `[PromptManager] Creating FileContributor "${config.id}" with files: ${JSON.stringify(config.files)}`
+                    `[SystemPromptManager] Creating FileContributor "${config.id}" with files: ${JSON.stringify(config.files)}`
                 );
                 return new FileContributor(
                     config.id,

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -137,7 +137,7 @@ export async function createAgentServices(
 
     // 7. Initialize prompts manager for MCP and internal prompts
     const promptsDir = join(configDir, 'prompts');
-    const promptsManager = new PromptsManager(mcpManager, promptsDir);
+    const promptsManager = new PromptsManager(mcpManager, promptsDir, config);
     await promptsManager.initialize();
     logger.debug('PromptsManager initialized');
 

--- a/src/core/utils/service-initializer.ts
+++ b/src/core/utils/service-initializer.ts
@@ -24,7 +24,7 @@
 import { MCPManager } from '../mcp/manager.js';
 import { ToolManager } from '../tools/tool-manager.js';
 import { createToolConfirmationProvider } from '../tools/confirmation/factory.js';
-import { PromptManager } from '../systemPrompt/manager.js';
+import { SystemPromptManager } from '../systemPrompt/manager.js';
 import { PromptsManager } from '../prompts/index.js';
 import { AgentStateManager } from '../agent/state-manager.js';
 import { SessionManager } from '../session/index.js';
@@ -42,7 +42,7 @@ import { AgentEventBus } from '../events/index.js';
 export type AgentServices = {
     mcpManager: MCPManager;
     toolManager: ToolManager;
-    promptManager: PromptManager;
+    systemPromptManager: SystemPromptManager;
     promptsManager: PromptsManager;
     agentEventBus: AgentEventBus;
     stateManager: AgentStateManager;
@@ -131,9 +131,9 @@ export async function createAgentServices(
     // 6. Initialize prompt manager
     const configDir = configPath ? dirname(resolve(configPath)) : process.cwd();
     logger.debug(
-        `[ServiceInitializer] Creating PromptManager with configPath: ${configPath} → configDir: ${configDir}`
+        `[ServiceInitializer] Creating SystemPromptManager with configPath: ${configPath} → configDir: ${configDir}`
     );
-    const promptManager = new PromptManager(config.systemPrompt, configDir);
+    const systemPromptManager = new SystemPromptManager(config.systemPrompt, configDir);
 
     // 7. Initialize prompts manager for MCP and internal prompts
     const promptsDir = join(configDir, 'prompts');
@@ -149,7 +149,7 @@ export async function createAgentServices(
     const sessionManager = new SessionManager(
         {
             stateManager,
-            promptManager,
+            systemPromptManager,
             toolManager,
             agentEventBus,
             storage, // Add storage backends to session services
@@ -169,7 +169,7 @@ export async function createAgentServices(
     return {
         mcpManager,
         toolManager,
-        promptManager,
+        systemPromptManager,
         promptsManager,
         agentEventBus,
         stateManager,


### PR DESCRIPTION
This PR introduce a new `PromptsManager` to enable better interactive user experience by enabling support for loading prompts locally or via MCP Servers. These can be implemented as /commands or other UI/app features.

This also adds agent prompts - default prompts that can be defined in the agent recipe and used either as /commands or UI bubbles.

Having a centralized PromptsManager is also useful in scenarios like exposing dexto as an MCP Server - this makes all prompt templates from different sources available to the connecting MCP Client (Cursor, Claude, etc) (This will be implemented in a future PR)

Note: Earlier interface `PromptManager` has been renamed to `SystemPromptManager` to avoid confusion.


https://github.com/user-attachments/assets/7c7aec0e-e309-46a9-a09c-9d86d3894baa

