### PR TITLE
fix: changsets publish wflow again

### DIFF
--- a/.github/workflows/changesets-publish.yml
+++ b/.github/workflows/changesets-publish.yml
@@ -32,8 +32,8 @@ jobs:
         with:
           title: 'chore: version packages'
           commit: 'chore: version packages'
-          version: pnpm -w changeset version && pnpm -w install --no-frozen-lockfile
-          publish: pnpm -w build && pnpm -w changeset publish
+          version: pnpm run changeset:version
+          publish: pnpm run changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
         "typecheck": "turbo run typecheck",
         "typecheck:core": "tsc --noEmit -p packages/core/tsconfig.json",
         "typecheck:watch": "turbo run typecheck --watch",
-        "unlink-cli": "pnpm rm dexto --global 2>/dev/null || true && npm uninstall -g dexto 2>/dev/null || true"
+        "unlink-cli": "pnpm rm dexto --global 2>/dev/null || true && npm uninstall -g dexto 2>/dev/null || true",
+        "changeset:version": "pnpm -w changeset version && pnpm -w install --no-frozen-lockfile",
+        "changeset:publish": "pnpm -w build && pnpm -w changeset publish"
     },
     "keywords": [
         "mcp",


### PR DESCRIPTION
### Release Note

- [x] No release needed (docs/chore/test-only/private package)
- [ ] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to use project-level scripts for versioning and publishing.
  * Added dedicated release scripts to the project configuration to centralize release steps.
  * Minor formatting tidy-up in existing scripts entries.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->