### PR TITLE
chore: remove redundant build step in publish action

### DIFF
--- a/.github/workflows/changesets-publish.yml
+++ b/.github/workflows/changesets-publish.yml
@@ -26,7 +26,6 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
       - name: Version / Publish with Changesets
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
### Release Note

- [x] No release needed (docs/chore/test-only/private package)
- [ ] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...


