### PR TITLE
Revert "chore: version packages"

### DIFF
--- a/.changeset/stupid-lions-grab.md
+++ b/.changeset/stupid-lions-grab.md
@@ -1,0 +1,7 @@
+---
+'@dexto/webui': patch
+'@dexto/core': patch
+'dexto': patch
+---
+
+Migrating to monorepo

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,9 +1,0 @@
-# dexto
-
-## 1.1.4
-
-### Patch Changes
-
-- ddce09b: Migrating to monorepo
-- Updated dependencies [ddce09b]
-    - @dexto/core@1.1.4

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dexto",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "type": "module",
   "bin": {
     "dexto": "./dist/index.js"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,7 +1,0 @@
-# @dexto/core
-
-## 1.1.4
-
-### Patch Changes
-
-- ddce09b: Migrating to monorepo

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexto/core",
-  "version": "1.1.4",
+  "version": "1.1.3",
   "private": false,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/webui/CHANGELOG.md
+++ b/packages/webui/CHANGELOG.md
@@ -1,9 +1,0 @@
-# @dexto/webui
-
-## 0.1.1
-
-### Patch Changes
-
-- ddce09b: Migrating to monorepo
-- Updated dependencies [ddce09b]
-    - @dexto/core@1.1.4

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dexto/webui",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Reverts truffle-ai/dexto#339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Synchronized package versions and release metadata to align with repository reorganization.
  * Added change tracking for upcoming patch releases and cleaned up outdated changelog entries.
  * No functional changes to the app, CLI, or APIs; behavior remains unchanged.
  * Maintenance-only update—end users should not notice any differences, and installs/upgrades remain compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->