### PR TITLE
Update CLI session commands

### DIFF
--- a/.changeset/icy-maps-accept.md
+++ b/.changeset/icy-maps-accept.md
@@ -1,0 +1,11 @@
+---
+'dexto': patch
+---
+
+Simplify CLI session management with -c/-r flags and streamlined session commands 
+
+- Add -c/--continue flag to resume most recent session 
+- Add -r/--resume <sessionId> flag to resume specific session 
+- Remove redundant session commands (new, switch, current) 
+- Update default behavior to create new sessions 
+- Simplify help text and command descriptions

--- a/packages/cli/src/cli/cli.ts
+++ b/packages/cli/src/cli/cli.ts
@@ -13,7 +13,7 @@ import { DextoRuntimeError, DextoValidationError, ErrorScope, LLMErrorCode } fro
  * Find and load the most recent session based on lastActivity.
  * This provides better UX than always loading the "default" session.
  */
-async function loadMostRecentSession(agent: DextoAgent): Promise<void> {
+export async function loadMostRecentSession(agent: DextoAgent): Promise<void> {
     try {
         const sessionIds = await agent.listSessions();
 
@@ -54,7 +54,7 @@ async function loadMostRecentSession(agent: DextoAgent): Promise<void> {
  * @param agent The DextoAgent instance providing access to all required services
  */
 async function _initCli(agent: DextoAgent): Promise<void> {
-    await loadMostRecentSession(agent);
+    // Note: Session loading is now handled by the main CLI logic, not here
     registerGracefulShutdown(agent);
 
     // Gather startup information

--- a/packages/cli/src/cli/commands/helpers/formatters.ts
+++ b/packages/cli/src/cli/commands/helpers/formatters.ts
@@ -2,7 +2,7 @@
  * Session Formatting Utilities
  *
  * This module contains formatting functions for session-related CLI output.
- * Extracted from commands.ts as part of CLI refactoring to improve code organization.
+ * Shared between interactive and non-interactive session commands.
  */
 
 import chalk from 'chalk';

--- a/packages/cli/src/cli/commands/interactive-commands/session/index.ts
+++ b/packages/cli/src/cli/commands/interactive-commands/session/index.ts
@@ -13,7 +13,7 @@
  */
 
 export { sessionCommand, historyCommand, searchCommand } from './session-commands.js';
-export { formatSessionInfo, formatHistoryMessage } from './helpers/formatters.js';
+export { formatSessionInfo, formatHistoryMessage } from '../../helpers/formatters.js';
 
 // Export all session commands as a convenient array
 import { sessionCommand, historyCommand, searchCommand } from './session-commands.js';

--- a/packages/cli/src/cli/commands/interactive-commands/session/session-commands.ts
+++ b/packages/cli/src/cli/commands/interactive-commands/session/session-commands.ts
@@ -21,7 +21,7 @@
 import chalk from 'chalk';
 import { logger, DextoAgent, type SessionMetadata } from '@dexto/core';
 import { CommandDefinition } from '../command-parser.js';
-import { formatSessionInfo, formatHistoryMessage } from './helpers/formatters.js';
+import { formatSessionInfo, formatHistoryMessage } from '../../helpers/formatters.js';
 
 /**
  * Helper to get current session info
@@ -98,7 +98,9 @@ export const sessionCommand: CommandDefinition = {
                                 return { id, metadata };
                             } catch (e) {
                                 logger.error(
-                                    `Failed to fetch metadata for session ${id}: ${e instanceof Error ? e.message : String(e)}`
+                                    `Failed to fetch metadata for session ${id}: ${e instanceof Error ? e.message : String(e)}`,
+                                    null,
+                                    'red'
                                 );
                                 return { id, metadata: undefined as SessionMetadata | undefined };
                             }
@@ -143,7 +145,9 @@ export const sessionCommand: CommandDefinition = {
                         console.log(chalk.dim('   Use /session list to see available sessions'));
                     } else {
                         logger.error(
-                            `Failed to get session history: ${error instanceof Error ? error.message : String(error)}`
+                            `Failed to get session history: ${error instanceof Error ? error.message : String(error)}`,
+                            null,
+                            'red'
                         );
                     }
                 }
@@ -180,7 +184,9 @@ export const sessionCommand: CommandDefinition = {
                     console.log(chalk.green(`✅ Deleted session: ${chalk.bold(sessionId)}`));
                 } catch (error) {
                     logger.error(
-                        `Failed to delete session: ${error instanceof Error ? error.message : String(error)}`
+                        `Failed to delete session: ${error instanceof Error ? error.message : String(error)}`,
+                        null,
+                        'red'
                     );
                 }
                 return true;
@@ -239,9 +245,7 @@ export const sessionCommand: CommandDefinition = {
         }
 
         console.log(chalk.red(`❌ Unknown session subcommand: ${subcommand}`));
-        console.log(
-            chalk.dim('Available subcommands: list, new, switch, current, history, delete, help')
-        );
+        console.log(chalk.dim('Available subcommands: list, history, delete, help'));
         console.log(chalk.dim('💡 Use /session help for detailed command descriptions'));
         return true;
     },

--- a/packages/cli/src/cli/commands/interactive-commands/session/session-commands.ts
+++ b/packages/cli/src/cli/commands/interactive-commands/session/session-commands.ts
@@ -54,7 +54,9 @@ async function displaySessionHistory(sessionId: string, agent: DextoAgent): Prom
 
     console.log(chalk.dim(`\n  Total: ${history.length} messages`));
     console.log(
-        chalk.dim('  💡 Use /clear to reset session or /session switch to change sessions\n')
+        chalk.dim(
+            '  💡 Use /clear to reset session or dexto -r <id> to resume a different session\n'
+        )
     );
 }
 
@@ -81,7 +83,9 @@ export const sessionCommand: CommandDefinition = {
 
                     if (sessionIds.length === 0) {
                         console.log(
-                            chalk.dim('  No sessions found. Use /session new to create one.\n')
+                            chalk.dim(
+                                '  No sessions found. Run `dexto` to start a new session, or use `dexto -c`/`dexto -r <id>`.\n'
+                            )
                         );
                         return true;
                     }
@@ -112,81 +116,10 @@ export const sessionCommand: CommandDefinition = {
                     console.log(
                         chalk.dim(`\n  Total: ${displayed} of ${sessionIds.length} sessions`)
                     );
-                    console.log(chalk.dim('  💡 Use /session switch <id> to change sessions\n'));
+                    console.log(chalk.dim('  💡 Use `dexto -r <id>` to resume a session\n'));
                 } catch (error) {
                     logger.error(
                         `Failed to list sessions: ${error instanceof Error ? error.message : String(error)}`
-                    );
-                }
-                return true;
-            },
-        },
-        {
-            name: 'new',
-            description: 'Create a new session',
-            usage: '/session new [id]',
-            handler: async (args: string[], agent: DextoAgent) => {
-                try {
-                    const sessionId = args[0]; // Optional custom ID
-                    const session = await agent.createSession(sessionId);
-
-                    console.log(chalk.green(`✅ Created new session: ${chalk.bold(session.id)}`));
-
-                    // Switch to the new session
-                    await agent.loadSessionAsDefault(session.id);
-                    console.log(chalk.yellow(`🔄 Switched to new session`));
-                } catch (error) {
-                    logger.error(
-                        `Failed to create session: ${error instanceof Error ? error.message : String(error)}`
-                    );
-                }
-                return true;
-            },
-        },
-        {
-            name: 'switch',
-            description: 'Switch to a different session',
-            usage: '/session switch <id>',
-            handler: async (args: string[], agent: DextoAgent) => {
-                if (args.length === 0) {
-                    console.log(chalk.red('❌ Session ID required. Usage: /session switch <id>'));
-                    return true;
-                }
-
-                try {
-                    const sessionId = args[0]!; // Safe to assert non-null since we checked args.length
-
-                    await agent.loadSessionAsDefault(sessionId);
-
-                    const metadata = await agent.getSessionMetadata(sessionId);
-                    console.log(chalk.green(`✅ Switched to session: ${chalk.bold(sessionId)}`));
-
-                    if (metadata && metadata.messageCount > 0) {
-                        console.log(chalk.dim(`   ${metadata.messageCount} messages in history`));
-                    } else {
-                        console.log(chalk.dim('   New session - no previous messages'));
-                    }
-                } catch (error) {
-                    logger.error(
-                        `Failed to switch session: ${error instanceof Error ? error.message : String(error)}`
-                    );
-                }
-                return true;
-            },
-        },
-        {
-            name: 'current',
-            description: 'Show current session',
-            usage: '/session current',
-            handler: async (args: string[], agent: DextoAgent) => {
-                try {
-                    const current = await getCurrentSessionInfo(agent);
-                    console.log(chalk.blue('\n📍 Current Session:\n'));
-                    console.log('  ' + formatSessionInfo(current.id, current.metadata, true));
-                    console.log();
-                } catch (error) {
-                    logger.error(
-                        `Failed to get current session: ${error instanceof Error ? error.message : String(error)}`
                     );
                 }
                 return true;
@@ -265,15 +198,6 @@ export const sessionCommand: CommandDefinition = {
                     `  ${chalk.yellow('/session list')} - List all sessions with their status and activity`
                 );
                 console.log(
-                    `  ${chalk.yellow('/session new')} ${chalk.blue('[name]')} - Create a new session (optional custom name)`
-                );
-                console.log(
-                    `  ${chalk.yellow('/session switch')} ${chalk.blue('<id>')} - Switch to a different session`
-                );
-                console.log(
-                    `  ${chalk.yellow('/session current')} - Show current session info and message count`
-                );
-                console.log(
                     `  ${chalk.yellow('/session history')} - Display session history for current session`
                 );
                 console.log(
@@ -284,8 +208,12 @@ export const sessionCommand: CommandDefinition = {
                 console.log(
                     chalk.dim('\n💡 Sessions allow you to maintain separate chat sessions')
                 );
-                console.log(chalk.dim('💡 Use /session switch <id> to change sessions'));
-                console.log(chalk.dim('💡 Session names can be custom or auto-generated UUIDs\n'));
+                console.log(chalk.dim('💡 Use `dexto -r <id>` to resume a different session'));
+                console.log(
+                    chalk.dim(
+                        '💡 Use `dexto` to start a new session or `dexto -c` to continue most recent\n'
+                    )
+                );
 
                 return true;
             },

--- a/packages/cli/src/cli/commands/session-commands.ts
+++ b/packages/cli/src/cli/commands/session-commands.ts
@@ -7,10 +7,7 @@
 
 import chalk from 'chalk';
 import { logger, DextoAgent, type SessionMetadata } from '@dexto/core';
-import {
-    formatSessionInfo,
-    formatHistoryMessage,
-} from './interactive-commands/session/helpers/formatters.js';
+import { formatSessionInfo, formatHistoryMessage } from './helpers/formatters.js';
 
 /**
  * Escape special regex characters in a string to prevent ReDoS attacks
@@ -226,7 +223,7 @@ export async function handleSessionSearchCommand(
 
         // Precompile safe regex for highlighting (only if query is not empty)
         const highlightRegex = query.trim()
-            ? new RegExp(`(${escapeRegExp(query.trim())})`, 'gi')
+            ? new RegExp(`(${escapeRegExp(query.trim().slice(0, 256))})`, 'gi')
             : null;
 
         // Display results

--- a/packages/cli/src/cli/commands/session-commands.ts
+++ b/packages/cli/src/cli/commands/session-commands.ts
@@ -1,0 +1,224 @@
+/**
+ * Non-Interactive Session Management Commands
+ *
+ * This module provides CLI commands for managing sessions outside of interactive mode.
+ * These commands allow users to manage sessions via direct CLI invocation.
+ */
+
+import chalk from 'chalk';
+import { logger, DextoAgent, type SessionMetadata } from '@dexto/core';
+import {
+    formatSessionInfo,
+    formatHistoryMessage,
+} from './interactive-commands/session/helpers/formatters.js';
+
+/**
+ * Helper to get current session info
+ */
+async function getCurrentSessionInfo(
+    agent: DextoAgent
+): Promise<{ id: string; metadata: SessionMetadata | undefined }> {
+    const currentId = agent.getCurrentSessionId();
+    const metadata = await agent.getSessionMetadata(currentId);
+    return { id: currentId, metadata };
+}
+
+/**
+ * Helper to display session history with consistent formatting
+ */
+async function displaySessionHistory(sessionId: string, agent: DextoAgent): Promise<void> {
+    console.log(chalk.blue(`\n💬 Session History for: ${chalk.bold(sessionId)}\n`));
+
+    const history = await agent.getSessionHistory(sessionId);
+
+    if (history.length === 0) {
+        console.log(chalk.dim('  No messages in this session yet.\n'));
+        return;
+    }
+
+    // Display each message with formatting
+    history.forEach((message, index) => {
+        console.log(formatHistoryMessage(message, index));
+    });
+
+    console.log(chalk.dim(`\n  Total: ${history.length} messages`));
+}
+
+/**
+ * List all available sessions
+ */
+export async function handleSessionListCommand(agent: DextoAgent): Promise<void> {
+    try {
+        console.log(chalk.bold.blue('\n📋 Sessions:\n'));
+
+        const sessionIds = await agent.listSessions();
+        const current = await getCurrentSessionInfo(agent);
+
+        if (sessionIds.length === 0) {
+            console.log(chalk.dim('  No sessions found. Use `dexto session new` to create one.\n'));
+            return;
+        }
+
+        // Fetch metadata concurrently; errors do not abort listing
+        const entries = await Promise.all(
+            sessionIds.map(async (id) => {
+                try {
+                    const metadata = await agent.getSessionMetadata(id);
+                    return { id, metadata };
+                } catch (e) {
+                    logger.error(
+                        `Failed to fetch metadata for session ${id}: ${e instanceof Error ? e.message : String(e)}`
+                    );
+                    return { id, metadata: undefined as SessionMetadata | undefined };
+                }
+            })
+        );
+
+        let displayed = 0;
+        for (const { id, metadata } of entries) {
+            if (!metadata) continue;
+            const isCurrent = id === current.id;
+            console.log(`  ${formatSessionInfo(id, metadata, isCurrent)}`);
+            displayed++;
+        }
+
+        console.log(chalk.dim(`\n  Total: ${displayed} of ${sessionIds.length} sessions`));
+        console.log(chalk.dim('  💡 Use `dexto -r <id>` to resume a session\n'));
+    } catch (error) {
+        logger.error(
+            `Failed to list sessions: ${error instanceof Error ? error.message : String(error)}`
+        );
+        throw error;
+    }
+}
+
+/**
+ * Show session history
+ */
+export async function handleSessionHistoryCommand(
+    agent: DextoAgent,
+    sessionId?: string
+): Promise<void> {
+    try {
+        // Use provided session ID or current session
+        const targetSessionId = sessionId || agent.getCurrentSessionId();
+        await displaySessionHistory(targetSessionId, agent);
+    } catch (error) {
+        if (error instanceof Error && error.message.includes('not found')) {
+            console.log(chalk.red(`❌ Session not found: ${sessionId || 'current'}`));
+            console.log(chalk.dim('   Use `dexto session list` to see available sessions'));
+        } else {
+            logger.error(
+                `Failed to get session history: ${error instanceof Error ? error.message : String(error)}`
+            );
+        }
+        throw error;
+    }
+}
+
+/**
+ * Delete a session
+ */
+export async function handleSessionDeleteCommand(
+    agent: DextoAgent,
+    sessionId: string
+): Promise<void> {
+    try {
+        const current = await getCurrentSessionInfo(agent);
+
+        // Check if trying to delete current session
+        if (sessionId === current.id) {
+            console.log(chalk.yellow('⚠️  Cannot delete the currently active session.'));
+            console.log(chalk.dim('   Switch to another session first, then delete this one.'));
+            return;
+        }
+
+        await agent.deleteSession(sessionId);
+        console.log(chalk.green(`✅ Deleted session: ${chalk.bold(sessionId)}`));
+    } catch (error) {
+        logger.error(
+            `Failed to delete session: ${error instanceof Error ? error.message : String(error)}`
+        );
+        throw error;
+    }
+}
+
+/**
+ * Search session history
+ */
+export async function handleSessionSearchCommand(
+    agent: DextoAgent,
+    query: string,
+    options: {
+        sessionId?: string;
+        role?: 'user' | 'assistant' | 'system' | 'tool';
+        limit?: number;
+    } = {}
+): Promise<void> {
+    try {
+        const searchOptions: {
+            limit: number;
+            sessionId?: string;
+            role?: 'user' | 'assistant' | 'system' | 'tool';
+        } = {
+            limit: options.limit || 10,
+        };
+
+        if (options.sessionId) {
+            searchOptions.sessionId = options.sessionId;
+        }
+        if (options.role) {
+            searchOptions.role = options.role;
+        }
+
+        console.log(chalk.blue(`🔍 Searching for: "${query}"`));
+        if (searchOptions.sessionId) {
+            console.log(chalk.dim(`   Session: ${searchOptions.sessionId}`));
+        }
+        if (searchOptions.role) {
+            console.log(chalk.dim(`   Role: ${searchOptions.role}`));
+        }
+        console.log(chalk.dim(`   Limit: ${searchOptions.limit}`));
+        console.log();
+
+        const results = await agent.searchMessages(query, searchOptions);
+
+        if (results.results.length === 0) {
+            console.log(chalk.yellow('📭 No messages found matching your search'));
+            return;
+        }
+
+        console.log(
+            chalk.green(`✅ Found ${results.total} result${results.total === 1 ? '' : 's'}`)
+        );
+        if (results.hasMore) {
+            console.log(chalk.dim(`   Showing first ${results.results.length} results`));
+        }
+        console.log();
+
+        // Display results
+        results.results.forEach((result, index) => {
+            const roleColor =
+                result.message.role === 'user'
+                    ? chalk.blue
+                    : result.message.role === 'assistant'
+                      ? chalk.green
+                      : chalk.yellow;
+
+            console.log(
+                `${chalk.dim(`${index + 1}.`)} ${chalk.cyan(result.sessionId)} ${roleColor(`[${result.message.role}]`)}`
+            );
+            console.log(
+                `   ${result.context.replace(new RegExp(`(${query})`, 'gi'), chalk.inverse('$1'))}`
+            );
+            console.log();
+        });
+
+        if (results.hasMore) {
+            console.log(chalk.dim('💡 Use --limit to see more results'));
+        }
+    } catch (error) {
+        logger.error(`Search failed: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+    }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -262,6 +262,19 @@ async function bootstrapAgentFromGlobalOpts() {
     const mergedConfig = applyCLIOverrides(rawConfig, globalOpts);
     const agent = new DextoAgent(mergedConfig, globalOpts.agent);
     await agent.start();
+
+    // Register graceful shutdown
+    const shutdown = async () => {
+        try {
+            await agent.stop();
+        } catch (err) {
+            // Ignore shutdown errors
+        }
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
+
     return agent;
 }
 
@@ -276,6 +289,7 @@ sessionCommand
             const agent = await bootstrapAgentFromGlobalOpts();
 
             await handleSessionListCommand(agent);
+            await agent.stop();
             process.exit(0);
         } catch (err) {
             console.error(`❌ dexto session list command failed: ${err}`);
@@ -292,6 +306,7 @@ sessionCommand
             const agent = await bootstrapAgentFromGlobalOpts();
 
             await handleSessionHistoryCommand(agent, sessionId);
+            await agent.stop();
             process.exit(0);
         } catch (err) {
             console.error(`❌ dexto session history command failed: ${err}`);
@@ -308,6 +323,7 @@ sessionCommand
             const agent = await bootstrapAgentFromGlobalOpts();
 
             await handleSessionDeleteCommand(agent, sessionId);
+            await agent.stop();
             process.exit(0);
         } catch (err) {
             console.error(`❌ dexto session delete command failed: ${err}`);
@@ -358,6 +374,7 @@ program
             }
 
             await handleSessionSearchCommand(agent, query, searchOptions);
+            await agent.stop();
             process.exit(0);
         } catch (err) {
             console.error(`❌ dexto search command failed: ${err}`);


### PR DESCRIPTION
  Simplify CLI session management with -c/-r flags and streamlined session commands
  
  - Add -c/--continue flag to resume most recent session
  - Add -r/--resume <sessionId> flag to resume specific session  
  - Remove redundant session commands (new, switch, current)
  - Update default behavior to create new sessions
  - Simplify help text and command descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added session management commands: session list, session history, session delete, and session search.
  - Added -c/--continue to resume the most recent session and -r/--resume <sessionId> to resume a specific session.

- Changes
  - Default now creates a new session when none is resumed; startup supports resume/continue flows.
  - Removed redundant session subcommands: new, switch, current.
  - Improved error handling, summaries, and user-facing CLI messages.

- Documentation
  - Updated CLI help text, descriptions, and usage examples for session workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->