### PR TITLE
Update tsup config to not bundle and to fix @core alias with post build script

### DIFF
--- a/.changeset/common-maps-deny.md
+++ b/.changeset/common-maps-deny.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Update build to not bundle

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -267,7 +267,7 @@ async function bootstrapAgentFromGlobalOpts() {
     const shutdown = async () => {
         try {
             await agent.stop();
-        } catch (err) {
+        } catch (_err) {
             // Ignore shutdown errors
         }
     };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,7 +46,7 @@
     "@types/json-schema": "^7.0.15"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/fix-dist-aliases.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint . --ext .ts"
   },

--- a/packages/core/scripts/fix-dist-aliases.mjs
+++ b/packages/core/scripts/fix-dist-aliases.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, extname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DIST_DIR = resolve(__dirname, '../dist');
+const PROCESS_EXTENSIONS = new Set(['.js', '.cjs', '.mjs']);
+const IMPORT_PATTERN = /(['"])@core\/([^'\"]+)\1/g;
+
+function collectFiles(root) {
+    const entries = readdirSync(root);
+    const files = [];
+    for (const entry of entries) {
+        const fullPath = join(root, entry);
+        const stats = statSync(fullPath);
+        if (stats.isDirectory()) {
+            files.push(...collectFiles(fullPath));
+        } else {
+            files.push(fullPath);
+        }
+    }
+    return files;
+}
+
+function resolveImport(fromFile, subpath) {
+    const fromExt = extname(fromFile);
+    const preferredExt = fromExt === '.cjs' ? '.cjs' : '.js';
+    const candidateBase = subpath.endsWith('.js') ? subpath.slice(0, -3) : subpath;
+
+    const candidates = [
+        `${candidateBase}${preferredExt}`,
+        `${candidateBase}.js`,
+        candidateBase,
+    ];
+
+    for (const candidate of candidates) {
+        const absolute = resolve(DIST_DIR, candidate);
+        if (existsSync(absolute)) {
+            let relativePath = relative(dirname(fromFile), absolute).replace(/\\/g, '/');
+            if (!relativePath.startsWith('.')) {
+                relativePath = `./${relativePath}`;
+            }
+            return relativePath;
+        }
+    }
+
+    return null;
+}
+
+function rewriteAliases(filePath) {
+    const ext = extname(filePath);
+    if (!PROCESS_EXTENSIONS.has(ext)) {
+        return false;
+    }
+
+    const original = readFileSync(filePath, 'utf8');
+    let modified = false;
+    const updated = original.replace(IMPORT_PATTERN, (match, quote, requested) => {
+        const resolved = resolveImport(filePath, requested);
+        if (!resolved) {
+            console.warn(`⚠️  Unable to resolve alias @core/${requested} in ${filePath}`);
+            return match;
+        }
+        modified = true;
+        return `${quote}${resolved}${quote}`;
+    });
+
+    if (modified) {
+        writeFileSync(filePath, updated, 'utf8');
+    }
+
+    return modified;
+}
+
+function main() {
+    if (!existsSync(DIST_DIR)) {
+        console.error(`❌ dist directory not found at ${DIST_DIR}`);
+        process.exit(1);
+    }
+
+    const files = collectFiles(DIST_DIR);
+    let changed = 0;
+    for (const file of files) {
+        if (rewriteAliases(file)) {
+            changed += 1;
+        }
+    }
+    console.log(`ℹ️  Fixed alias imports in ${changed} files.`);
+}
+
+main();

--- a/packages/core/scripts/fix-dist-aliases.mjs
+++ b/packages/core/scripts/fix-dist-aliases.mjs
@@ -38,11 +38,10 @@ function resolveImport(fromFile, subpath) {
 
     const candidates = [];
     for (const base of bases) {
-        candidates.push(
-            `${base}${preferredExt}`,
-            `${base}.js`,
-            base,
-        );
+        const exts = Array.from(new Set([preferredExt, '.mjs', '.js', '.cjs']));
+        for (const ext of exts) {
+            candidates.push(`${base}${ext}`);
+        }
     }
 
     for (const candidate of candidates) {

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -8,5 +8,13 @@ export default defineConfig([
         dts: true,
         platform: 'node',
         bundle: false,
+        clean: true,
+        esbuildOptions(options) {
+            // Suppress empty import meta warnings which tsup anyway fixes
+            options.logOverride = {
+                ...(options.logOverride ?? {}),
+                'empty-import-meta': 'silent',
+            };
+        },
     },
 ]);

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,41 +1,12 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig([
-    // Node build - Full @dexto/core for server-side use
     {
-        entry: {
-            index: 'src/index.ts',
-        },
+        entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.integration.test.ts'],
         format: ['cjs', 'esm'],
         outDir: 'dist',
         dts: true,
-        shims: true,
-        bundle: true,
         platform: 'node',
-        noExternal: ['chalk', 'boxen'],
-        external: [
-            'better-sqlite3',
-            'pg',
-            'redis',
-            'winston',
-            'logform',
-            '@colors/colors',
-            'yaml',
-            'fs-extra',
-            'dotenv',
-            'cross-spawn',
-            'tiktoken',
-        ],
-    },
-    // Browser build - Minimal exports for type safety
-    {
-        entry: {
-            'index.browser': 'src/index.browser.ts',
-        },
-        format: ['cjs', 'esm'],
-        outDir: 'dist',
-        dts: true,
-        shims: true,
-        bundle: true,
+        bundle: false,
     },
 ]);


### PR DESCRIPTION
This should improve tree-shaking in consumer dependencies

Trying this out

### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [x] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution of internal imports in built output to prevent broken imports; added warnings when aliases can’t be resolved.

* **Chores**
  * Switched core to an unbundled Node-focused build and removed the browser bundle.
  * Excluded test files from build outputs.
  * Added an automated post-build step that fixes published import paths.
  * Prepared a patch release declaration for the core package.

* **Refactor**
  * Minor internal rename in CLI shutdown handling (no behavioral change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->