### PR TITLE
Add github agent using custom github mcp

### DIFF
--- a/.changeset/chilly-boats-scream.md
+++ b/.changeset/chilly-boats-scream.md
@@ -1,0 +1,5 @@
+---
+'dexto': patch
+---
+
+Add github agent and update registry

--- a/agents/agent-registry.json
+++ b/agents/agent-registry.json
@@ -8,6 +8,13 @@
       "source": "database-agent/",
       "main": "database-agent.yml"
     },
+    "github-agent": {
+      "description": "GitHub operations agent powered by the OAuth-enabled GitHub MCP server",
+      "author": "Truffle AI",
+      "tags": ["github", "repositories", "collaboration", "devops", "mcp"],
+      "source": "github-agent/",
+      "main": "github-agent.yml"
+    },
     "talk2pdf-agent": {
       "description": "PDF document analysis and conversation",
       "author": "Truffle AI",

--- a/agents/agent-registry.json
+++ b/agents/agent-registry.json
@@ -9,7 +9,7 @@
       "main": "database-agent.yml"
     },
     "github-agent": {
-      "description": "GitHub operations agent powered by the OAuth-enabled GitHub MCP server",
+      "description": "GitHub operations agent for analyzing pull requests, issues, repos and more",
       "author": "Truffle AI",
       "tags": ["github", "repositories", "collaboration", "devops", "mcp"],
       "source": "github-agent/",

--- a/agents/github-agent/README.md
+++ b/agents/github-agent/README.md
@@ -1,0 +1,19 @@
+# GitHub Integration Agent
+
+This agent configuration connects Dexto to the GitHub OAuth MCP server so you can browse repositories, triage issues, and collaborate on pull requests without leaving chat.
+
+## Features
+- Read repository structure, files, issues, discussions, and pull requests directly from GitHub
+- Draft comments, reviews, releases, and task lists with confirmation before anything is posted
+- Receive time-aware guidance for project management and collaboration flows
+
+## Prerequisites
+- Access to GitHub Copilot with MCP HTTP endpoints enabled
+- Ability to complete the OAuth sign-in flow when Dexto requests it (a browser window opens automatically)
+
+## Usage
+```bash
+npm start -- --agent agents/github-agent/github-agent.yml
+```
+
+Once connected, ask the agent for repository insights or collaboration tasks. It will use the GitHub MCP server for all repository interactions.

--- a/agents/github-agent/README.md
+++ b/agents/github-agent/README.md
@@ -1,19 +1,57 @@
 # GitHub Integration Agent
 
-This agent configuration connects Dexto to the GitHub OAuth MCP server so you can browse repositories, triage issues, and collaborate on pull requests without leaving chat.
+Bring GitHub context into any workspace. This agent starts the `@truffle-ai/github-mcp-server` in `stdio` mode so the assistant can explore repositories, manage pull requests, and automate GitHub project workflows directly from chat.
 
-## Features
-- Read repository structure, files, issues, discussions, and pull requests directly from GitHub
-- Draft comments, reviews, releases, and task lists with confirmation before anything is posted
-- Receive time-aware guidance for project management and collaboration flows
+## What You Get
+- Full coverage of GitHub toolsets (repos, pull requests, issues, actions, discussions, notifications, security, projects, and more)
+- Automatic OAuth device-flow login with cached tokens, no personal access token required for most users
+- Safe-guarded write operations (issues, PRs, workflow runs, comments, etc.) that the agent confirms before executing
+- Optional read-only or scoped toolsets to limit the surface area for sensitive environments
 
-## Prerequisites
-- Access to GitHub Copilot with MCP HTTP endpoints enabled
-- Ability to complete the OAuth sign-in flow when Dexto requests it (a browser window opens automatically)
+## Requirements
+- Node.js 18+ with access to `npx`
+- A GitHub account with access to the repositories you plan to manage
+- Browser access to complete the one-time device-code OAuth prompt (opened automatically)
+- `OPENAI_API_KEY` (or another configured LLM key) exported in your shell for the agent
 
-## Usage
+## Run the Agent
 ```bash
 npm start -- --agent agents/github-agent/github-agent.yml
 ```
 
-Once connected, ask the agent for repository insights or collaboration tasks. It will use the GitHub MCP server for all repository interactions.
+The CLI launches `npx -y @truffle-ai/github-mcp-server stdio`. On first run you will see a device code and a browser window prompting you to authorize the "GitHub MCP Server" application. Approving the flow stores an access token at:
+
+```
+~/.config/truffle/github-mcp/<host>-token.json
+```
+
+Subsequent sessions reuse the cached token unless it expires or you delete the file. Once the server reports it is ready, start chatting with Dexto about repositories, issues, CI failures, releases, or team activity.
+
+## Optional Configuration
+You can tailor the underlying MCP server by exporting environment variables before starting Dexto:
+
+- `GITHUB_PERSONAL_ACCESS_TOKEN`: Provide a PAT (with `repo` and `read:user` at minimum) if you need to bypass OAuth or run in headless environments.
+- `GITHUB_TOOLSETS="repos,issues,pull_requests,actions"`: Restrict which groups of tools the agent loads. Available groups include `repos`, `issues`, `pull_requests`, `actions`, `notifications`, `discussions`, `projects`, `code_security`, `dependabot`, `secret_protection`, `security_advisories`, `users`, `orgs`, `gists`, `context`, and `experiments`.
+- `GITHUB_READ_ONLY=1`: Offer only read-only tools; write operations will be hidden.
+- `GITHUB_DYNAMIC_TOOLSETS=1`: Enable on-demand toolset discovery so the model only activates tools as needed.
+- `GITHUB_HOST=https://github.mycompany.com`: Point the agent at GitHub Enterprise Server or ghe.com tenants.
+- `GITHUB_LOG_FILE=~/github-mcp.log` and `GITHUB_ENABLE_COMMAND_LOGGING=1`: Persist detailed MCP command logs for auditing.
+- `GITHUB_CONTENT_WINDOW_SIZE=7500`: Increase the amount of content retrieved for large diffs or logs.
+
+Refer to the upstream [`github-mcp-server`](https://github.com/github/github-mcp-server) documentation for the full flag list (every CLI flag is mirrored as an environment variable using the `GITHUB_` prefix).
+
+## Switching to the Remote GitHub MCP Server (optional)
+If you prefer to connect to the GitHub-hosted remote MCP server instead of running the bundled binary, replace the `mcpServers.github` block in `github-agent.yml` with:
+
+```yaml
+mcpServers:
+  github:
+    type: http
+    url: https://api.githubcopilot.com/mcp/
+    connectionMode: strict
+```
+
+You can optionally add `headers` for PAT authentication if your host does not support OAuth. Restart Dexto after saving the change.
+
+## Resetting Authorization
+To force a new OAuth login, delete the cached token file (`rm ~/.config/truffle/github-mcp/*-token.json`) and relaunch the agent. The next startup will trigger a fresh device flow.

--- a/agents/github-agent/README.md
+++ b/agents/github-agent/README.md
@@ -31,6 +31,7 @@ Subsequent sessions reuse the cached token unless it expires or you delete the f
 You can tailor the underlying MCP server by exporting environment variables before starting Dexto:
 
 - `GITHUB_PERSONAL_ACCESS_TOKEN`: Provide a PAT (with `repo` and `read:user` at minimum) if you need to bypass OAuth or run in headless environments.
+- `GITHUB_OAUTH_SCOPES="repo read:user"`: Override the scopes requested during the OAuth device flow (space or comma separated). Use this to request additional permissions (e.g., `gist`) or limit scopes in tightly controlled environments.
 - `GITHUB_TOOLSETS="repos,issues,pull_requests,actions"`: Restrict which groups of tools the agent loads. Available groups include `repos`, `issues`, `pull_requests`, `actions`, `notifications`, `discussions`, `projects`, `code_security`, `dependabot`, `secret_protection`, `security_advisories`, `users`, `orgs`, `gists`, `context`, and `experiments`.
 - `GITHUB_READ_ONLY=1`: Offer only read-only tools; write operations will be hidden.
 - `GITHUB_DYNAMIC_TOOLSETS=1`: Enable on-demand toolset discovery so the model only activates tools as needed.

--- a/agents/github-agent/github-agent.yml
+++ b/agents/github-agent/github-agent.yml
@@ -1,0 +1,53 @@
+# GitHub Integration Agent configuration
+# Connects Dexto to GitHub via the OAuth-enabled HTTP MCP server
+
+mcpServers:
+  github:
+    # type: http
+    # url: https://api.githubcopilot.com/mcp/
+    # # timeout: 45000
+    # connectionMode: strict
+    type: stdio
+    command: npx
+    args:
+      - -y
+      - '@truffle-ai/github-mcp-server'
+      - stdio
+
+systemPrompt:
+  contributors:
+    - id: primary
+      type: static
+      priority: 0
+      content: |
+        You are the GitHub Integration Agent for Dexto. You interface with GitHub through the OAuth-protected Model Context Protocol server at https://api.githubcopilot.com/mcp/. Use it to inspect repositories, manage pull requests and issues, review code, and share insights while respecting GitHub permissions.
+
+        ## Core Responsibilities
+        - Discover repository structure, code, and metadata via the GitHub MCP tools
+        - Draft and triage issues, pull requests, release notes, and project boards
+        - Perform lightweight code reviews and highlight risky changes
+        - Provide step-by-step plans before executing write operations
+
+        ## Interaction Guidelines
+        - Clarify the repository, branch, or resource if the request is ambiguous
+        - For read-only queries, share concise results and provide links or references
+        - Before mutating state (creating issues, comments, reviews), confirm the intent and summarize the intended change
+        - When you cannot complete an action (missing scopes, repo not accessible), state it clearly and offer next steps
+
+        ## Tool Usage
+        - Prefer the GitHub MCP server for repository content instead of local filesystem copies
+        - Break down complex tasks into sequential MCP calls
+        - After each tool call, evaluate whether additional context is needed or a response can be given
+
+        Stay practical, cite GitHub resources when possible, and keep answers focused on the user’s goal.
+    - id: dateTime
+      type: dynamic
+      priority: 10
+      source: dateTime
+      enabled: true
+
+llm:
+  provider: openai
+  model: gpt-5-mini
+  apiKey: $OPENAI_API_KEY
+

--- a/agents/github-agent/github-agent.yml
+++ b/agents/github-agent/github-agent.yml
@@ -29,8 +29,9 @@ systemPrompt:
         - Present step-by-step plans before executing write operations or multi-step procedures
 
         ## Interaction Guidelines
+        - For queries related to starring repos, do not ask for confirmation, just star the repo
         - Confirm the repository, branch, or resource when a request is ambiguous or spans multiple contexts
-        - For read-only requests, respond concisely and include relevant references, links, or identifiers
+        - For read-only requests, respond concisely and include relevant references, links, or identifiers.
         - Before taking any action that modifies GitHub state, summarize the intended change and obtain confirmation
         - If you are blocked (missing scopes, inaccessible repository, conflicting state), say so clearly and offer next steps or alternatives
 

--- a/agents/github-agent/github-agent.yml
+++ b/agents/github-agent/github-agent.yml
@@ -13,6 +13,9 @@ mcpServers:
       - -y
       - '@truffle-ai/github-mcp-server'
       - stdio
+    # Optional: uncomment to override the default OAuth scopes requested during the device flow
+    # env:
+    #   GITHUB_OAUTH_SCOPES: 'repo read:user'
 
 systemPrompt:
   contributors:

--- a/agents/github-agent/github-agent.yml
+++ b/agents/github-agent/github-agent.yml
@@ -1,5 +1,5 @@
 # GitHub Integration Agent configuration
-# Connects Dexto to GitHub via the OAuth-enabled HTTP MCP server
+# Connects Dexto to GitHub via the bundled GitHub MCP server binary
 
 mcpServers:
   github:
@@ -20,26 +20,26 @@ systemPrompt:
       type: static
       priority: 0
       content: |
-        You are the GitHub Integration Agent for Dexto. You interface with GitHub through the OAuth-protected Model Context Protocol server at https://api.githubcopilot.com/mcp/. Use it to inspect repositories, manage pull requests and issues, review code, and share insights while respecting GitHub permissions.
+        You are the GitHub Integration Agent for Dexto. Collaborate with users on GitHub repositories by leveraging the GitHub tools available in this runtime. Inspect repositories, manage pull requests and issues, coordinate releases, and share actionable guidance while honoring GitHub permissions and organizational policies.
 
         ## Core Responsibilities
-        - Discover repository structure, code, and metadata via the GitHub MCP tools
-        - Draft and triage issues, pull requests, release notes, and project boards
-        - Perform lightweight code reviews and highlight risky changes
-        - Provide step-by-step plans before executing write operations
+        - Surface repository structure, history, and code insights that help users understand the current state of their projects
+        - Draft, triage, and refine issues, pull requests, project boards, and release notes on request
+        - Perform focused code reviews, flag risky changes, and suggest remediation steps or next actions
+        - Present step-by-step plans before executing write operations or multi-step procedures
 
         ## Interaction Guidelines
-        - Clarify the repository, branch, or resource if the request is ambiguous
-        - For read-only queries, share concise results and provide links or references
-        - Before mutating state (creating issues, comments, reviews), confirm the intent and summarize the intended change
-        - When you cannot complete an action (missing scopes, repo not accessible), state it clearly and offer next steps
+        - Confirm the repository, branch, or resource when a request is ambiguous or spans multiple contexts
+        - For read-only requests, respond concisely and include relevant references, links, or identifiers
+        - Before taking any action that modifies GitHub state, summarize the intended change and obtain confirmation
+        - If you are blocked (missing scopes, inaccessible repository, conflicting state), say so clearly and offer next steps or alternatives
 
         ## Tool Usage
-        - Prefer the GitHub MCP server for repository content instead of local filesystem copies
-        - Break down complex tasks into sequential MCP calls
-        - After each tool call, evaluate whether additional context is needed or a response can be given
+        - Prefer live GitHub data from the provided tools instead of relying on local filesystem copies or stale context
+        - Break complex objectives into sequential tool calls, narrating progress so the user can follow along
+        - After each tool interaction, decide whether additional context is needed or if you can deliver a confident answer
 
-        Stay practical, cite GitHub resources when possible, and keep answers focused on the user’s goal.
+        Stay practical, keep responses focused on the user’s goal, and highlight any assumptions or risks you notice.
     - id: dateTime
       type: dynamic
       priority: 10

--- a/packages/cli/scripts/copy-agents.ts
+++ b/packages/cli/scripts/copy-agents.ts
@@ -22,6 +22,7 @@ const AGENTS_TO_COPY = [
     'triage-demo/',
     'podcast-agent/',
     'nano-banana-agent/',
+    'github-agent/',
 ];
 
 const SOURCE_DIR = join(__dirname, '../../../agents');


### PR DESCRIPTION
Custom github agent mcp in @truffle-ai/github-mcp-server 

### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [x] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a GitHub Integration Agent for exploring repositories, issues, PRs, discussions, and assisting with lightweight code reviews and draft comments.

- Documentation
  - Added a README describing setup, token/auth flow, usage, and configuration for the GitHub integration.

- Chores
  - Added a patch-level changeset noting the new agent and registry update; updated CLI agent copy behavior to include the new agent in distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->