### PR TITLE
feat: add skip setup flag for mcp mode funnel

### DIFF
--- a/.changeset/eight-comics-turn.md
+++ b/.changeset/eight-comics-turn.md
@@ -1,0 +1,5 @@
+---
+'dexto': patch
+---
+
+Add skip setup flag

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -87,6 +87,7 @@ program
     .option('-s, --strict', 'Require all server connections to succeed')
     .option('--no-verbose', 'Disable verbose output')
     .option('--no-interactive', 'Disable interactive prompts and API key setup')
+    .option('--skip-setup', 'Skip global setup validation (useful for MCP mode, automation)')
     .option('-m, --model <model>', 'Specify the LLM model to use')
     .option('--router <router>', 'Specify the LLM router to use (vercel or in-built)')
     .option('--auto-approve', 'Always approve tool executions without confirmation prompts')
@@ -671,13 +672,14 @@ program
                         }
 
                         // Check setup state and auto-trigger if needed
-                        if (await requiresSetup()) {
+                        // Skip if --skip-setup flag is set (for MCP mode, automation, etc.)
+                        if (!opts.skipSetup && (await requiresSetup())) {
                             if (opts.interactive === false) {
                                 console.error(
                                     '❌ Setup required but --no-interactive flag is set.'
                                 );
                                 console.error(
-                                    '💡 Run `dexto setup` to configure preferences first.'
+                                    '💡 Run `dexto setup` first, or use --skip-setup to bypass global setup.'
                                 );
                                 safeExit('main', 1, 'setup-required-non-interactive');
                             }


### PR DESCRIPTION
this allows first time users to run dexto agents with npx in mcp mode without friction

also fixed landing page args in cursor

### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [x] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...


