### PR TITLE
WebUI refinements for MCP registry ui, connection flow and minor bug fixes  

### DIFF
--- a/.changeset/gentle-numbers-report.md
+++ b/.changeset/gentle-numbers-report.md
@@ -1,0 +1,6 @@
+---
+'@dexto/webui': patch
+'dexto': patch
+---
+
+Updated WebUI for MCP connection flow and other minor updates

--- a/packages/cli/src/api/server.ts
+++ b/packages/cli/src/api/server.ts
@@ -34,7 +34,7 @@ import {
     isRouterSupportedForModel,
 } from '@dexto/core';
 import type { ProviderInfo, LLMProvider } from '@dexto/core';
-import { getProviderKeyStatus, saveProviderApiKey } from '@dexto/core';
+import { getProviderKeyStatus, saveProviderApiKey, getPrimaryApiKeyEnvVar } from '@dexto/core';
 import { errorHandler } from './middleware/errorHandler.js';
 import { McpServerConfigSchema } from '@dexto/core';
 import { sendWebSocketError, sendWebSocketValidationError } from './websocket-error-handler.js';
@@ -1300,12 +1300,13 @@ export async function initializeApi(
                 llm: {
                     provider: llm.provider,
                     model: llm.model,
-                    ...(apiKeyRef && { apiKey: apiKeyRef }),
+                    apiKey: apiKeyRef || `$${getPrimaryApiKeyEnvVar(llm.provider as LLMProvider)}`,
                 },
                 systemPrompt,
             };
 
             const yamlContent = yamlStringify(agentConfig);
+            logger.info(`Creating agent config for ${name}:`, { agentConfig, yamlContent });
 
             // Create temporary file
             const tmpDir = os.tmpdir();

--- a/packages/webui/components/AgentSelector/CreateAgentModal.tsx
+++ b/packages/webui/components/AgentSelector/CreateAgentModal.tsx
@@ -103,18 +103,18 @@ export default function CreateAgentModal({ open, onOpenChange, onAgentCreated }:
       newErrors['llm.model'] = 'Model is required';
     }
 
-    // System Prompt validation - check if at least one contributor has content
+    // System Prompt validation - check if at least one static contributor has content
+    // Note: This modal only supports static contributors; dynamic/file contributors are not handled
     const systemPrompt = config.systemPrompt;
     if (systemPrompt && typeof systemPrompt === 'object' && 'contributors' in systemPrompt) {
       const contributors = systemPrompt.contributors;
       if (Array.isArray(contributors)) {
         const hasContent = contributors.some((c: Record<string, unknown>) => {
           if (c.type === 'static' && typeof c.content === 'string' && c.content.trim()) return true;
-          if (c.type === 'dynamic' || c.type === 'file') return true;
           return false;
         });
         if (!hasContent) {
-          newErrors.systemPrompt = 'At least one contributor with content is required';
+          newErrors.systemPrompt = 'At least one static contributor with content is required';
         }
       }
     } else if (typeof systemPrompt === 'string' && !systemPrompt.trim()) {
@@ -140,7 +140,7 @@ export default function CreateAgentModal({ open, onOpenChange, onAgentCreated }:
         const contributors = config.systemPrompt.contributors;
         if (Array.isArray(contributors)) {
           // Find the first static contributor with content
-          const staticContributor = contributors.find((c: any) => c.type === 'static' && c.content);
+          const staticContributor = contributors.find((c: Record<string, unknown>) => c.type === 'static' && c.content);
           if (staticContributor && 'content' in staticContributor && typeof staticContributor.content === 'string') {
             systemPromptContent = staticContributor.content.trim();
           }

--- a/packages/webui/components/AgentSelector/CreateAgentModal.tsx
+++ b/packages/webui/components/AgentSelector/CreateAgentModal.tsx
@@ -134,6 +134,26 @@ export default function CreateAgentModal({ open, onOpenChange, onAgentCreated }:
     setCreateError(null);
 
     try {
+      // Extract system prompt content from contributors
+      let systemPromptContent = '';
+      if (config.systemPrompt && typeof config.systemPrompt === 'object' && 'contributors' in config.systemPrompt) {
+        const contributors = config.systemPrompt.contributors;
+        if (Array.isArray(contributors)) {
+          // Find the first static contributor with content
+          const staticContributor = contributors.find((c: any) => c.type === 'static' && c.content);
+          if (staticContributor && 'content' in staticContributor && typeof staticContributor.content === 'string') {
+            systemPromptContent = staticContributor.content.trim();
+          }
+        }
+      } else if (typeof config.systemPrompt === 'string') {
+        systemPromptContent = config.systemPrompt.trim();
+      }
+      
+      // Ensure we have a valid system prompt
+      if (!systemPromptContent) {
+        systemPromptContent = 'You are a helpful AI assistant.';
+      }
+
       const response = await fetch('/api/agents/custom/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -150,7 +170,7 @@ export default function CreateAgentModal({ open, onOpenChange, onAgentCreated }:
             model: config.llm?.model?.trim(),
             ...(config.llm?.apiKey?.trim() && { apiKey: config.llm.apiKey.trim() }),
           },
-          systemPrompt: config.systemPrompt,
+          systemPrompt: systemPromptContent,
         }),
       });
 

--- a/packages/webui/components/ChatApp.tsx
+++ b/packages/webui/components/ChatApp.tsx
@@ -427,8 +427,9 @@ export default function ChatApp() {
         setTimeout(() => setSuccessMessage(null), 4000);
         setServerRegistryOpen(false);
         return 'connected';
-      } catch (err: any) {
-        throw new Error(err?.message || 'Failed to install server');
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : 'Failed to install server';
+        throw new Error(message);
       } finally {
         setIsRegistryBusy(false);
       }
@@ -1030,7 +1031,6 @@ export default function ChatApp() {
             setSuccessMessage(`Added ${name}`);
             setTimeout(() => setSuccessMessage(null), 4000);
             connectPrefill?.onCloseRegistryModal?.();
-            setServerRegistryOpen(false);
             setIsRegistryBusy(false);
             setConnectPrefill(null);
           }}

--- a/packages/webui/components/ChatApp.tsx
+++ b/packages/webui/components/ChatApp.tsx
@@ -710,7 +710,7 @@ export default function ChatApp() {
                                   <DropdownMenuContent align="end">
                     <DropdownMenuItem onClick={() => setServerRegistryOpen(true)}>
                       <Server className="h-4 w-4 mr-2" />
-                      Browse MCP Registry
+                      Connect MCPs
                     </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setExportOpen(true)}>
                     <Download className="h-4 w-4 mr-2" />
@@ -927,6 +927,7 @@ export default function ChatApp() {
           isOpen={isServerRegistryOpen}
           onClose={() => setServerRegistryOpen(false)}
           onInstallServer={handleInstallServer}
+          onOpenConnectModal={() => setModalOpen(true)}
         />
 
         {/* Export Configuration Modal */}

--- a/packages/webui/components/ConnectServerModal.tsx
+++ b/packages/webui/components/ConnectServerModal.tsx
@@ -40,7 +40,7 @@ export default function ConnectServerModal({ isOpen, onClose, onServerConnected,
     const [envPairs, setEnvPairs] = useState<Array<{key: string; value: string; id: string}>>([]);
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
-    const [persistToAgent, setPersistToAgent] = useState(true);
+    const [persistToAgent, setPersistToAgent] = useState(false);
 
     // Helper function to convert header pairs to record
     const headersToRecord = (pairs: Array<{key: string; value: string; id: string}>): Record<string, string> => {

--- a/packages/webui/components/ServerRegistryModal.tsx
+++ b/packages/webui/components/ServerRegistryModal.tsx
@@ -35,7 +35,8 @@ import {
     Users,
     Plus,
     ArrowUpRight,
-    Tag
+    Tag,
+    PlusCircle
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -43,12 +44,14 @@ interface ServerRegistryModalProps {
     isOpen: boolean;
     onClose: () => void;
     onInstallServer: (entry: ServerRegistryEntry) => Promise<void>;
+    onOpenConnectModal?: () => void;
 }
 
 export default function ServerRegistryModal({ 
     isOpen, 
     onClose, 
-    onInstallServer 
+    onInstallServer,
+    onOpenConnectModal
 }: ServerRegistryModalProps) {
     const [entries, setEntries] = useState<ServerRegistryEntry[]>([]);
     const [filteredEntries, setFilteredEntries] = useState<ServerRegistryEntry[]>([]);
@@ -228,23 +231,25 @@ export default function ServerRegistryModal({
 
     return (
         <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-            <DialogContent className="!max-w-none w-[90vw] max-h-[85vh] overflow-hidden flex flex-col !sm:max-w-none">
-                <DialogHeader className="pb-6 border-b">
-                    <DialogTitle className="flex items-center gap-3 text-xl font-semibold">
-                        <div className="p-2 rounded-lg bg-primary/10 border border-primary/20">
+            <DialogContent className="!max-w-none w-[90vw] max-h-[85vh] overflow-hidden flex flex-col !sm:max-w-none p-0">
+                <DialogHeader className="pb-6 border-b px-6 pt-6">
+                    <div className="flex items-start gap-3">
+                        <div className="p-2 rounded-lg bg-primary/10 border border-primary/20 flex-shrink-0">
                             <Server className="h-5 w-5 text-primary" />
                         </div>
-                        <div>
-                            <div className="text-xl">MCP Server Registry</div>
-                            <div className="text-sm font-normal text-muted-foreground mt-1">
+                        <div className="flex-1 min-w-0">
+                            <DialogTitle className="text-xl font-semibold leading-tight mb-1.5">
+                                MCP Server Registry
+                            </DialogTitle>
+                            <DialogDescription className="text-sm text-muted-foreground leading-relaxed">
                                 Discover and add powerful integrations to your AI assistant
-                            </div>
+                            </DialogDescription>
                         </div>
-                    </DialogTitle>
+                    </div>
                 </DialogHeader>
 
                 {/* Search and View Controls */}
-                <div className="flex gap-4 mb-6">
+                <div className="flex gap-3 mb-6 px-6 pt-6">
                     <div className="relative flex-1">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none z-10" />
                         <Input
@@ -254,6 +259,18 @@ export default function ServerRegistryModal({
                             className="pl-10 h-10 border-border/40 focus:border-primary/50 bg-background shadow-sm"
                         />
                     </div>
+                    <Button
+                        onClick={() => {
+                            onClose(); // Close registry modal first
+                            onOpenConnectModal?.(); // Then open connect modal
+                        }}
+                        size="sm"
+                        variant="outline"
+                        className="h-10 text-sm font-medium border-2 hover:bg-primary/10 hover:text-primary hover:border-primary/30 whitespace-nowrap"
+                    >
+                        <PlusCircle className="mr-2 h-4 w-4" />
+                        Connect Custom
+                    </Button>
                     <div className="flex bg-muted/80 rounded-lg p-1 border border-border/40">
                         <Button
                             variant={viewMode === 'grid' ? 'secondary' : 'ghost'}
@@ -293,7 +310,7 @@ export default function ServerRegistryModal({
                 </div>
 
                 {/* Content */}
-                <div className="flex-1 overflow-y-auto -mx-2 px-2">
+                <div className="flex-1 overflow-y-auto px-6">
                     {error && (
                         <Alert variant="destructive" className="mb-6 border-red-200/50 bg-red-50/50">
                             <AlertDescription className="text-red-800">{error}</AlertDescription>

--- a/packages/webui/components/ServersPanel.tsx
+++ b/packages/webui/components/ServersPanel.tsx
@@ -2,9 +2,8 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import { Button } from './ui/button';
-import { X, PlusCircle, Server, ListChecks, ChevronRight, RefreshCw, AlertTriangle, ChevronDown, Terminal, Trash2, Package } from 'lucide-react';
+import { X, Server, ListChecks, RefreshCw, AlertTriangle, ChevronDown, Trash2, Package } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import Link from 'next/link';
 import type { McpServer, McpTool, ServerRegistryEntry } from '@/types';
 import type { McpServerConfig } from '@dexto/core';
 import { serverRegistry } from '@/lib/serverRegistry';
@@ -342,21 +341,12 @@ export default function ServersPanel({ isOpen, onClose, onOpenConnectModal, onOp
       {/* Add Server Actions */}
       <div className="px-4 py-3 space-y-2 border-b border-border/30">
         <Button 
-          onClick={onOpenConnectModal} 
-          className="w-full h-9 text-sm font-medium"
-          size="sm"
-        >
-          <PlusCircle className="mr-2 h-4 w-4" />
-          Connect Server
-        </Button>
-        <Button 
           onClick={() => setIsRegistryModalOpen(true)} 
-          variant="outline" 
           className="w-full h-9 text-sm font-medium"
           size="sm"
         >
           <Package className="mr-2 h-4 w-4" />
-          Browse Registry
+          Connect MCPs
         </Button>
       </div>
 
@@ -552,6 +542,7 @@ export default function ServersPanel({ isOpen, onClose, onOpenConnectModal, onOp
         isOpen={isRegistryModalOpen}
         onClose={() => setIsRegistryModalOpen(false)}
         onInstallServer={handleInstallServer}
+        onOpenConnectModal={onOpenConnectModal}
       />
     </aside>
   );

--- a/packages/webui/components/hooks/useGreeting.ts
+++ b/packages/webui/components/hooks/useGreeting.ts
@@ -9,42 +9,43 @@ export function useGreeting(sessionId?: string | null) {
     const [error, setError] = useState<string | null>(null);
     const [agentVersion, setAgentVersion] = useState(0);
 
-    const fetchGreeting = async (signal: AbortSignal) => {
-        setIsLoading(true);
-        setError(null);
-
-        try {
-            const url = sessionId
-                ? `/api/greeting?sessionId=${encodeURIComponent(sessionId)}`
-                : '/api/greeting';
-
-            const response = await fetch(url, { signal });
-
-            if (!response.ok) {
-                const msg = `Failed to fetch greeting: HTTP ${response.status} ${response.statusText}`;
-                setGreeting(null);
-                setError(msg);
-                return;
-            }
-
-            const data: GreetingResponse = await response.json();
-            setGreeting(data.greeting ?? null);
-        } catch (err) {
-            // Ignore abort errors
-            if ((err as any)?.name === 'AbortError') return;
-            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch greeting';
-            setError(errorMessage);
-            console.error(`Error fetching greeting: ${errorMessage}`);
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
     useEffect(() => {
         const controller = new AbortController();
         const { signal } = controller;
 
-        fetchGreeting(signal);
+        const fetchGreeting = async () => {
+            setIsLoading(true);
+            setError(null);
+
+            try {
+                const url = sessionId
+                    ? `/api/greeting?sessionId=${encodeURIComponent(sessionId)}`
+                    : '/api/greeting';
+
+                const response = await fetch(url, { signal });
+
+                if (!response.ok) {
+                    const msg = `Failed to fetch greeting: HTTP ${response.status} ${response.statusText}`;
+                    setGreeting(null);
+                    setError(msg);
+                    return;
+                }
+
+                const data: GreetingResponse = await response.json();
+                setGreeting(data.greeting ?? null);
+            } catch (err) {
+                // Ignore abort errors
+                if ((err as any)?.name === 'AbortError') return;
+                const errorMessage =
+                    err instanceof Error ? err.message : 'Failed to fetch greeting';
+                setError(errorMessage);
+                console.error(`Error fetching greeting: ${errorMessage}`);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchGreeting();
         return () => controller.abort();
     }, [sessionId, agentVersion]);
 

--- a/packages/webui/components/hooks/useGreeting.ts
+++ b/packages/webui/components/hooks/useGreeting.ts
@@ -7,45 +7,60 @@ export function useGreeting(sessionId?: string | null) {
     const [greeting, setGreeting] = useState<string | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [agentVersion, setAgentVersion] = useState(0);
+
+    const fetchGreeting = async (signal: AbortSignal) => {
+        setIsLoading(true);
+        setError(null);
+
+        try {
+            const url = sessionId
+                ? `/api/greeting?sessionId=${encodeURIComponent(sessionId)}`
+                : '/api/greeting';
+
+            const response = await fetch(url, { signal });
+
+            if (!response.ok) {
+                const msg = `Failed to fetch greeting: HTTP ${response.status} ${response.statusText}`;
+                setGreeting(null);
+                setError(msg);
+                return;
+            }
+
+            const data: GreetingResponse = await response.json();
+            setGreeting(data.greeting ?? null);
+        } catch (err) {
+            // Ignore abort errors
+            if ((err as any)?.name === 'AbortError') return;
+            const errorMessage = err instanceof Error ? err.message : 'Failed to fetch greeting';
+            setError(errorMessage);
+            console.error(`Error fetching greeting: ${errorMessage}`);
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     useEffect(() => {
         const controller = new AbortController();
         const { signal } = controller;
-        const fetchGreeting = async () => {
-            setIsLoading(true);
-            setError(null);
 
-            try {
-                const url = sessionId
-                    ? `/api/greeting?sessionId=${encodeURIComponent(sessionId)}`
-                    : '/api/greeting';
+        fetchGreeting(signal);
+        return () => controller.abort();
+    }, [sessionId, agentVersion]);
 
-                const response = await fetch(url, { signal });
-
-                if (!response.ok) {
-                    const msg = `Failed to fetch greeting: HTTP ${response.status} ${response.statusText}`;
-                    setGreeting(null);
-                    setError(msg);
-                    return;
-                }
-
-                const data: GreetingResponse = await response.json();
-                setGreeting(data.greeting ?? null);
-            } catch (err) {
-                // Ignore abort errors
-                if ((err as any)?.name === 'AbortError') return;
-                const errorMessage =
-                    err instanceof Error ? err.message : 'Failed to fetch greeting';
-                setError(errorMessage);
-                console.error(`Error fetching greeting: ${errorMessage}`);
-            } finally {
-                setIsLoading(false);
-            }
+    // Listen for agent switching events to refresh greeting
+    useEffect(() => {
+        const handleAgentSwitched = () => {
+            setAgentVersion((prev) => prev + 1);
         };
 
-        fetchGreeting();
-        return () => controller.abort();
-    }, [sessionId]);
+        if (typeof window !== 'undefined') {
+            window.addEventListener('dexto:agentSwitched', handleAgentSwitched);
+            return () => {
+                window.removeEventListener('dexto:agentSwitched', handleAgentSwitched);
+            };
+        }
+    }, []);
 
     return { greeting, isLoading, error };
 }

--- a/packages/webui/components/ui/dialog.tsx
+++ b/packages/webui/components/ui/dialog.tsx
@@ -46,11 +46,17 @@ function DialogOverlay({
   )
 }
 
+interface DialogContentProps
+  extends React.ComponentProps<typeof DialogPrimitive.Content> {
+  hideCloseButton?: boolean;
+}
+
 function DialogContent({
   className,
   children,
+  hideCloseButton = false,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: DialogContentProps) {
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -63,10 +69,12 @@ function DialogContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
-          <XIcon />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {!hideCloseButton && (
+          <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )

--- a/packages/webui/components/ui/key-value-editor.tsx
+++ b/packages/webui/components/ui/key-value-editor.tsx
@@ -36,40 +36,20 @@ export function KeyValueEditor({
   keyLabel = 'Key',
   valueLabel = 'Value'
 }: KeyValueEditorProps) {
-  // Ensure we always have at least one empty pair for editing
-  useEffect(() => {
-    if (pairs.length === 0) {
-      const initialPair: KeyValuePair = {
-        key: '',
-        value: '',
-        id: `kv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-      };
-      onChange([initialPair]);
-    }
-  }, [pairs.length]); // Remove onChange from dependencies to prevent infinite loops
 
   const addPair = () => {
     const newPair: KeyValuePair = {
       key: '',
       value: '',
-      id: `kv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+      id: `kv-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
     };
     onChange([...pairs, newPair]);
   };
 
   const removePair = (id: string) => {
     const filteredPairs = pairs.filter(pair => pair.id !== id);
-    // If removing would leave us with no pairs, keep at least one empty pair
-    if (filteredPairs.length === 0) {
-      const emptyPair: KeyValuePair = {
-        key: '',
-        value: '',
-        id: `kv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
-      };
-      onChange([emptyPair]);
-    } else {
-      onChange(filteredPairs);
-    }
+    // Allow removing all pairs - don't force an empty pair
+    onChange(filteredPairs);
   };
 
   const updatePair = (id: string, field: 'key' | 'value', newValue: string) => {
@@ -85,15 +65,17 @@ export function KeyValueEditor({
       )}
       
       <div className="space-y-2">
-        {/* Header row */}
-        <div className="grid grid-cols-12 gap-2 items-center text-xs text-muted-foreground">
-          <div className="col-span-5">{keyLabel}</div>
-          <div className="col-span-6">{valueLabel}</div>
-          <div className="col-span-1"></div>
-        </div>
+        {/* Header row - only show if there are pairs */}
+        {pairs.length > 0 && (
+          <div className="grid grid-cols-12 gap-2 items-center text-xs text-muted-foreground">
+            <div className="col-span-5">{keyLabel}</div>
+            <div className="col-span-6">{valueLabel}</div>
+            <div className="col-span-1"></div>
+          </div>
+        )}
 
         {/* Key-value pair rows */}
-        {pairs.map((pair, index) => (
+        {pairs.map((pair) => (
           <div key={pair.id} className="grid grid-cols-12 gap-2 items-center">
             <Input
               placeholder={placeholder.key}
@@ -114,7 +96,7 @@ export function KeyValueEditor({
               variant="ghost"
               size="sm"
               onClick={() => removePair(pair.id)}
-              disabled={disabled || (pairs.length === 1 && !pair.key && !pair.value)}
+              disabled={disabled}
               className="col-span-1 h-8 w-8 p-0"
             >
               <Trash2 className="h-4 w-4" />

--- a/packages/webui/lib/serverConfig.ts
+++ b/packages/webui/lib/serverConfig.ts
@@ -1,0 +1,85 @@
+import type { McpServerConfig } from '@dexto/core';
+import type { ServerRegistryEntry } from '@/types';
+
+const PLACEHOLDER_EXACT_MATCHES = new Set([
+    'placeholder',
+    'your-api-key',
+    'your_api_key',
+    'enter-your-token',
+    'xxx',
+    '...',
+    'todo',
+]);
+
+const PLACEHOLDER_SUBSTRINGS = [
+    'your-',
+    'your_',
+    'your ',
+    'enter-',
+    'enter_',
+    'enter ',
+    'placeholder',
+    'api_key',
+    'api-key',
+    'api key',
+    'secret',
+    'token',
+    'password',
+    'xxx',
+    '...',
+];
+
+const PLACEHOLDER_PREFIX_PATTERNS = [/^your[\s_-]?/, /^enter[\s_-]?/];
+
+export function hasEmptyOrPlaceholderValue(obj: Record<string, string>): boolean {
+    return Object.values(obj).some((value) => {
+        if (!value || value.trim() === '') {
+            return true;
+        }
+
+        const normalized = value.trim().toLowerCase();
+
+        if (PLACEHOLDER_EXACT_MATCHES.has(normalized)) {
+            return true;
+        }
+
+        if (PLACEHOLDER_PREFIX_PATTERNS.some((pattern) => pattern.test(normalized))) {
+            return true;
+        }
+
+        return PLACEHOLDER_SUBSTRINGS.some((token) => normalized.includes(token));
+    });
+}
+
+export function buildConfigFromRegistryEntry(entry: ServerRegistryEntry): McpServerConfig {
+    const baseTimeout = entry.config.timeout ?? 30000;
+
+    switch (entry.config.type) {
+        case 'stdio':
+            return {
+                type: 'stdio',
+                command: entry.config.command ?? '',
+                args: entry.config.args ?? [],
+                env: entry.config.env ?? {},
+                timeout: baseTimeout,
+                connectionMode: 'lenient',
+            };
+        case 'sse':
+            return {
+                type: 'sse',
+                url: entry.config.url ?? '',
+                headers: entry.config.headers ?? {},
+                timeout: baseTimeout,
+                connectionMode: 'lenient',
+            };
+        case 'http':
+        default:
+            return {
+                type: 'http',
+                url: entry.config.url ?? '',
+                headers: entry.config.headers ?? {},
+                timeout: baseTimeout,
+                connectionMode: 'lenient',
+            };
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Agent YAML will reference env-var API keys when no explicit ref is provided; existing env vars are preserved.
  - Improved MCP connect flow: prefill modal when credentials required; direct connect otherwise. ServersPanel/registry support external triggers, post-connect callbacks, and install outcome signaling.
  - Dialog content can hide its close button; greeting refreshes when agents switch.

- Bug Fixes
  - Agent switching validates availability and surfaces clearer errors; installs avoid auto-switch and handle busy/disable-close states.

- UI/UX
  - “Browse MCP Registry” → “Connect MCPs”; “Save to agent configuration file” unchecked by default; system prompt requires a static contributor; key-value editor allows zero pairs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->