### PR TITLE
docs: fix 404 flash on docs with cleanurls in vercel.json

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "cleanUrls": true,
   "trailingSlash": false,
   "redirects": [
     {


### PR DESCRIPTION
Issue: Pages were returning 404 status before loading correctly, causing a brief "Page Not Found" flash.

Root cause: With trailingSlash: false, Docusaurus builds pages as .html files (e.g., intro.html), but Vercel wasn't configured to serve these files without the .html extension.

Solution: Add "cleanUrls": true to vercel.json, which tells Vercel to automatically serve .html files when requested without the extension.

Example:
- File: /docs/getting-started/intro.html
- URL: /docs/getting-started/intro
- Now works correctly with 200 status instead of 404

Fixes the 404 flash issue reported in production deployment.

### Release Note

- [x] No release needed (docs/chore/test-only/private package)
- [ ] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated URL formatting configuration to optimize link structure and remove trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->