### PR TITLE
feat: preserve cancelled messages in chat history

### DIFF
--- a/.changeset/preserve-cancelled-messages.md
+++ b/.changeset/preserve-cancelled-messages.md
@@ -1,0 +1,7 @@
+---
+'dexto': patch
+---
+
+Preserve cancelled messages in chat history instead of removing them
+
+When users cancel a streaming response (Ctrl+C or Escape), the partial message is now kept in the chat history with a [Cancelled] indicator, allowing users to reference the partial content that was generated before cancellation.

--- a/packages/cli/src/cli/ink-cli/components/chat/MessageItem.tsx
+++ b/packages/cli/src/cli/ink-cli/components/chat/MessageItem.tsx
@@ -43,6 +43,11 @@ export const MessageItem = memo(({ message }: MessageItemProps) => {
                     </Text>
                     <Box flexDirection="column" flexGrow={1}>
                         <Text color="white">{message.content || ' '}</Text>
+                        {message.isCancelled && (
+                            <Text color="yellow" dimColor>
+                                {'[Cancelled]'}
+                            </Text>
+                        )}
                     </Box>
                 </Box>
                 <Text>{''}</Text>

--- a/packages/cli/src/cli/ink-cli/state/reducer.ts
+++ b/packages/cli/src/cli/ink-cli/state/reducer.ts
@@ -221,7 +221,11 @@ export function cliReducer(state: CLIState, action: CLIAction): CLIState {
                 ...state,
                 streamingMessage: null,
                 messages: streamingId
-                    ? state.messages.filter((msg) => msg.id !== streamingId)
+                    ? state.messages.map((msg) =>
+                          msg.id === streamingId
+                              ? { ...msg, isStreaming: false, isCancelled: true }
+                              : msg
+                      )
                     : state.messages,
                 ui: {
                     ...state.ui,

--- a/packages/cli/src/cli/ink-cli/state/types.ts
+++ b/packages/cli/src/cli/ink-cli/state/types.ts
@@ -29,6 +29,7 @@ export interface Message {
     content: string;
     timestamp: Date;
     isStreaming?: boolean;
+    isCancelled?: boolean; // True if the message was cancelled by the user
     toolResult?: string; // Tool result preview (first 4-5 lines)
     toolStatus?: ToolStatus; // Status for tool messages (running/finished)
 }


### PR DESCRIPTION
Currently, when a user cancels a streaming message (Ctrl+C or Escape), the partial response is completely removed from the message history. This results in loss of potentially useful partial content.

Changes:
- Add isCancelled field to Message type
- Update STREAMING_CANCEL reducer to mark messages as cancelled instead of removing them
- Add visual [Cancelled] indicator in MessageItem component for cancelled messages

Benefits:
- Partial responses remain visible in chat history
- Users can reference partial content that was generated before cancellation
- Provides context for why a response was incomplete

### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [ ] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When users cancel streaming responses, partial messages are now preserved in the chat history with a [Cancelled] indicator instead of being removed
  * Users can now reference and review incomplete content from cancelled streams

* **UI Improvements**
  * Added visual styling for cancelled message indicators in the chat interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->