### PR TITLE
perf(fs-tools): Improve filesystem context gathering tools

### DIFF
--- a/agents/coding-agent/coding-agent.yml
+++ b/agents/coding-agent/coding-agent.yml
@@ -72,7 +72,7 @@ systemPrompt:
         
         ## Guidelines
         - Always read relevant code before making changes to understand context
-        - Use glob_files to find files and grep_content to search within files
+        - Use list_directory to map folders, find_paths to locate likely targets, glob_files for precise patterns, and grep_content for content search
         - Test changes when possible using bash_exec
         - Follow the project's existing code style and conventions
         - Provide clear explanations for your code decisions
@@ -119,6 +119,8 @@ permissions:
       - ask_user
       - read_file      # Read files without approval
       - read_media_file      # Read files without approval
+      - list_directory # List folders without approval
+      - find_paths     # Find likely paths without approval
       - glob_files     # Search for files without approval
       - grep_content   # Search within files without approval
       - bash_output    # Check background process output

--- a/agents/explore-agent/explore-agent.yml
+++ b/agents/explore-agent/explore-agent.yml
@@ -44,7 +44,7 @@ systemPrompt:
 
         ## Guidelines
         - Start with list_directory or find_paths, then narrow down
-        - Use glob for exact pattern discovery and grep for content search
+        - Use glob_files for exact pattern discovery and grep_content for content search
         - Try multiple naming conventions (camelCase, snake_case, kebab-case, PascalCase)
         - Check common locations: src/, lib/, packages/, tests/, config/
         - Report what you found AND what you didn't find

--- a/agents/explore-agent/explore-agent.yml
+++ b/agents/explore-agent/explore-agent.yml
@@ -18,6 +18,8 @@ systemPrompt:
 
         ## Available Tools
         You have access to read-only tools:
+        - `list_directory` - List a folder without reading file contents
+        - `find_paths` - Find likely files or directories by name/path fragments
         - `glob_files` - Find files matching patterns (e.g., "src/**/*.ts", "*.config.js")
         - `grep_content` - Search for text/patterns within files
         - `read_file` - Read file contents
@@ -41,8 +43,8 @@ systemPrompt:
         - Provide detailed analysis with evidence
 
         ## Guidelines
-        - Start with broad searches, then narrow down
-        - Use glob for file discovery, grep for content search
+        - Start with list_directory or find_paths, then narrow down
+        - Use glob for exact pattern discovery and grep for content search
         - Try multiple naming conventions (camelCase, snake_case, kebab-case, PascalCase)
         - Check common locations: src/, lib/, packages/, tests/, config/
         - Report what you found AND what you didn't find
@@ -81,7 +83,7 @@ permissions:
 # Tools - unified tool factory configuration (builtins + custom tool providers)
 tools:
   - type: filesystem-tools
-    enabledTools: ["read_file", "glob_files", "grep_content"]  # Read-only tools only
+    enabledTools: ["read_file", "list_directory", "find_paths", "glob_files", "grep_content"]  # Read-only tools only
     allowedPaths: ["."]
     blockedPaths:
       # Version control

--- a/packages/tools-filesystem/src/filesystem-service.test.ts
+++ b/packages/tools-filesystem/src/filesystem-service.test.ts
@@ -206,6 +206,31 @@ describe('FileSystemService', () => {
             expect(result.startLine).toBe(2);
             expect(result.nextOffset).toBe(4);
         });
+
+        it('preserves CRLF and trailing newline for full-file reads', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const testFile = path.join(tempDir, 'crlf.txt');
+            await fs.writeFile(testFile, 'a\r\nb\r\n', 'utf-8');
+
+            const result = await fileSystemService.readFile(testFile);
+
+            expect(result.content).toBe('a\r\nb\r\n');
+            expect(result.lines).toBe(2);
+            expect(result.truncated).toBe(false);
+        });
     });
 
     describe('Path Discovery', () => {
@@ -566,6 +591,33 @@ describe('FileSystemService', () => {
 
                 expect(result.success).toBe(true);
                 expect(result.backupPath).toBeDefined();
+            });
+
+            it('preserves original line endings and final newline when editing', async () => {
+                const fileSystemService = new FileSystemService(
+                    {
+                        allowedPaths: [tempDir],
+                        blockedPaths: [],
+                        blockedExtensions: [],
+                        maxFileSize: 10 * 1024 * 1024,
+                        workingDirectory: tempDir,
+                        enableBackups: false,
+                        backupRetentionDays: 7,
+                    },
+                    mockLogger
+                );
+                await fileSystemService.initialize();
+
+                const testFile = path.join(tempDir, 'crlf-edit.txt');
+                await fs.writeFile(testFile, 'a\r\nb\r\n', 'utf-8');
+
+                await fileSystemService.editFile(testFile, {
+                    oldString: 'a',
+                    newString: 'A',
+                });
+
+                const updatedContent = await fs.readFile(testFile, 'utf-8');
+                expect(updatedContent).toBe('A\r\nb\r\n');
             });
         });
     });

--- a/packages/tools-filesystem/src/filesystem-service.test.ts
+++ b/packages/tools-filesystem/src/filesystem-service.test.ts
@@ -200,7 +200,7 @@ describe('FileSystemService', () => {
                 limit: 2,
             });
 
-            expect(result.content).toBe('two\nthree');
+            expect(result.content).toBe('two\nthree\n');
             expect(result.lines).toBe(2);
             expect(result.truncated).toBe(true);
             expect(result.startLine).toBe(2);
@@ -230,6 +230,36 @@ describe('FileSystemService', () => {
             expect(result.content).toBe('a\r\nb\r\n');
             expect(result.lines).toBe(2);
             expect(result.truncated).toBe(false);
+        });
+
+        it('preserves exact separators for paginated CRLF reads', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const testFile = path.join(tempDir, 'crlf-paged.txt');
+            await fs.writeFile(testFile, 'a\r\nb\r\nc\r\n', 'utf-8');
+
+            const result = await fileSystemService.readFile(testFile, {
+                offset: 2,
+                limit: 1,
+            });
+
+            expect(result.content).toBe('b\r\n');
+            expect(result.lines).toBe(1);
+            expect(result.truncated).toBe(true);
+            expect(result.startLine).toBe(2);
+            expect(result.nextOffset).toBe(3);
         });
     });
 

--- a/packages/tools-filesystem/src/filesystem-service.test.ts
+++ b/packages/tools-filesystem/src/filesystem-service.test.ts
@@ -176,6 +176,99 @@ describe('FileSystemService', () => {
                 /Use read_file instead/
             );
         });
+
+        it('paginates text reads with startLine and nextOffset metadata', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const testFile = path.join(tempDir, 'paged.txt');
+            await fs.writeFile(testFile, 'one\ntwo\nthree\nfour');
+
+            const result = await fileSystemService.readFile(testFile, {
+                offset: 2,
+                limit: 2,
+            });
+
+            expect(result.content).toBe('two\nthree');
+            expect(result.lines).toBe(2);
+            expect(result.truncated).toBe(true);
+            expect(result.startLine).toBe(2);
+            expect(result.nextOffset).toBe(4);
+        });
+    });
+
+    describe('Path Discovery', () => {
+        it('finds likely file and directory matches from path fragments', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const featureDir = path.join(tempDir, 'src', 'feature-area');
+            const targetFile = path.join(featureDir, 'target-service.ts');
+            await fs.mkdir(featureDir, { recursive: true });
+            await fs.writeFile(targetFile, 'export const value = 1;\n');
+
+            const fileResult = await fileSystemService.findPaths('target service');
+            expect(fileResult.matches[0]?.path).toBe(targetFile);
+            expect(fileResult.matches[0]?.pathType).toBe('file');
+
+            const directoryResult = await fileSystemService.findPaths('feature-area', {
+                pathType: 'directory',
+            });
+            expect(directoryResult.matches[0]?.path).toBe(featureDir);
+            expect(directoryResult.matches[0]?.pathType).toBe('directory');
+        });
+    });
+
+    describe('Search Semantics', () => {
+        it('treats patterns as literal text by default and supports regex mode', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const testFile = path.join(tempDir, 'search.txt');
+            await fs.writeFile(testFile, 'foo.bar\nfooXbar\n');
+
+            const literalResult = await fileSystemService.searchContent('foo.bar');
+            expect(literalResult.matches).toHaveLength(1);
+            expect(literalResult.matches[0]?.line).toBe('foo.bar');
+
+            const regexResult = await fileSystemService.searchContent('foo.bar', {
+                literal: false,
+            });
+            expect(regexResult.matches).toHaveLength(2);
+        });
     });
 
     describe('Backup Behavior', () => {

--- a/packages/tools-filesystem/src/filesystem-service.test.ts
+++ b/packages/tools-filesystem/src/filesystem-service.test.ts
@@ -230,14 +230,20 @@ describe('FileSystemService', () => {
             await fs.writeFile(targetFile, 'export const value = 1;\n');
 
             const fileResult = await fileSystemService.findPaths('target service');
-            expect(fileResult.matches[0]?.path).toBe(targetFile);
-            expect(fileResult.matches[0]?.pathType).toBe('file');
+            expect(
+                fileResult.matches.some(
+                    (match) => match.path === targetFile && match.pathType === 'file'
+                )
+            ).toBe(true);
 
             const directoryResult = await fileSystemService.findPaths('feature-area', {
                 pathType: 'directory',
             });
-            expect(directoryResult.matches[0]?.path).toBe(featureDir);
-            expect(directoryResult.matches[0]?.pathType).toBe('directory');
+            expect(
+                directoryResult.matches.some(
+                    (match) => match.path === featureDir && match.pathType === 'directory'
+                )
+            ).toBe(true);
         });
     });
 

--- a/packages/tools-filesystem/src/filesystem-service.test.ts
+++ b/packages/tools-filesystem/src/filesystem-service.test.ts
@@ -245,6 +245,35 @@ describe('FileSystemService', () => {
                 )
             ).toBe(true);
         });
+
+        it('returns empty directories when searching for directory paths', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const emptyDir = path.join(tempDir, 'src', 'empty-feature');
+            await fs.mkdir(emptyDir, { recursive: true });
+
+            const result = await fileSystemService.findPaths('empty feature', {
+                pathType: 'directory',
+            });
+
+            expect(
+                result.matches.some(
+                    (match) => match.path === emptyDir && match.pathType === 'directory'
+                )
+            ).toBe(true);
+        });
     });
 
     describe('Search Semantics', () => {
@@ -274,6 +303,31 @@ describe('FileSystemService', () => {
                 literal: false,
             });
             expect(regexResult.matches).toHaveLength(2);
+        });
+
+        it('rejects unsafe regex patterns before invoking search backends', async () => {
+            const fileSystemService = new FileSystemService(
+                {
+                    allowedPaths: [tempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemService.initialize();
+
+            const testFile = path.join(tempDir, 'unsafe-search.txt');
+            await fs.writeFile(testFile, 'aaaaaaaaaaaaaaaaaaaa\n');
+
+            await expect(
+                fileSystemService.searchContent('(a+)+$', {
+                    literal: false,
+                })
+            ).rejects.toThrow(/catastrophic backtracking|Invalid pattern/i);
         });
     });
 

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -86,6 +86,33 @@ function countTextLines(content: string): number {
     return /(?:\r\n|\n|\r)$/.test(content) ? lineBreaks.length : lineBreaks.length + 1;
 }
 
+function extractCompleteLineSegment(content: string): { segment: string; rest: string } | null {
+    for (let index = 0; index < content.length; index += 1) {
+        const char = content[index];
+        if (char === '\n') {
+            return {
+                segment: content.slice(0, index + 1),
+                rest: content.slice(index + 1),
+            };
+        }
+        if (char !== '\r') {
+            continue;
+        }
+
+        if (index + 1 >= content.length) {
+            return null;
+        }
+
+        const delimiterLength = content[index + 1] === '\n' ? 2 : 1;
+        return {
+            segment: content.slice(0, index + delimiterLength),
+            rest: content.slice(index + delimiterLength),
+        };
+    }
+
+    return null;
+}
+
 /**
  * FileSystemService - Handles all file system operations with security checks
  *
@@ -329,45 +356,69 @@ export class FileSystemService {
             const stream = createReadStream(normalizedPath, {
                 encoding,
             });
-            const rl = createInterface({
-                input: stream,
-                crlfDelay: Infinity,
-            });
-
-            const selectedLines: string[] = [];
+            const selectedParts: string[] = [];
+            let pendingContent = '';
             let lineNumber = 0;
+            let selectedLineCount = 0;
             let truncated = false;
+            let shouldStop = false;
+
+            const processLineSegment = (segment: string): void => {
+                lineNumber += 1;
+
+                if (lineNumber < startLine) {
+                    return;
+                }
+
+                if (limit !== undefined && selectedLineCount >= limit) {
+                    truncated = true;
+                    shouldStop = true;
+                    return;
+                }
+
+                selectedParts.push(segment);
+                selectedLineCount += 1;
+            };
 
             try {
-                for await (const line of rl) {
-                    lineNumber += 1;
+                for await (const chunk of stream) {
+                    pendingContent += chunk;
 
-                    if (lineNumber < startLine) {
-                        continue;
+                    while (true) {
+                        const extracted = extractCompleteLineSegment(pendingContent);
+                        if (!extracted) {
+                            break;
+                        }
+
+                        pendingContent = extracted.rest;
+                        processLineSegment(extracted.segment);
+                        if (shouldStop) {
+                            break;
+                        }
                     }
 
-                    if (limit !== undefined && selectedLines.length >= limit) {
-                        truncated = true;
+                    if (shouldStop) {
                         break;
                     }
-
-                    selectedLines.push(line);
                 }
             } finally {
-                rl.close();
                 stream.destroy();
             }
 
-            const returnedContent = selectedLines.join('\n');
+            if (!shouldStop && pendingContent.length > 0) {
+                processLineSegment(pendingContent);
+            }
+
+            const returnedContent = selectedParts.join('');
             return {
                 content: returnedContent,
-                lines: selectedLines.length,
+                lines: selectedLineCount,
                 encoding,
                 mimeType,
                 truncated,
                 size: Buffer.byteLength(returnedContent, encoding),
                 startLine,
-                nextOffset: truncated ? startLine + selectedLines.length : undefined,
+                nextOffset: truncated ? startLine + selectedLineCount : undefined,
             };
         } catch (error) {
             if (isFilesystemRuntimeError(error)) {

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -43,7 +43,12 @@ import {
 import { PathValidator } from './path-validator.js';
 import { FileSystemError } from './errors.js';
 import { detectMimeType, getMediaFileKind, isLikelyBinary, isTextMimeType } from './mime-utils.js';
-import { ripgrepFiles, ripgrepSearch } from './ripgrep-utils.js';
+import {
+    isRipgrepAvailable,
+    ripgrepFiles,
+    ripgrepSearch,
+    ripgrepWalkFiles,
+} from './ripgrep-utils.js';
 
 const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
 const DEFAULT_MAX_RESULTS = 1000;
@@ -66,6 +71,19 @@ function normalizeStatSize(size: number | bigint): number {
 
 function isFilesystemRuntimeError(error: unknown): error is DextoRuntimeError {
     return error instanceof DextoRuntimeError && error.scope === 'filesystem';
+}
+
+function countTextLines(content: string): number {
+    if (content.length === 0) {
+        return 0;
+    }
+
+    const lineBreaks = content.match(/\r\n|\n|\r/g);
+    if (!lineBreaks) {
+        return 1;
+    }
+
+    return /(?:\r\n|\n|\r)$/.test(content) ? lineBreaks.length : lineBreaks.length + 1;
 }
 
 /**
@@ -294,6 +312,19 @@ export class FileSystemService {
 
             const limit = options.limit;
             const startLine = options.offset && options.offset > 0 ? options.offset : 1;
+            if (startLine === 1 && limit === undefined) {
+                const fullContent = await fs.readFile(normalizedPath, encoding);
+                return {
+                    content: fullContent,
+                    lines: countTextLines(fullContent),
+                    encoding,
+                    mimeType,
+                    truncated: false,
+                    size: Buffer.byteLength(fullContent, encoding),
+                    startLine,
+                    nextOffset: undefined,
+                };
+            }
 
             const stream = createReadStream(normalizedPath, {
                 encoding,
@@ -628,59 +659,75 @@ export class FileSystemService {
         const searchPath = validation.normalizedPath;
         const maxResults = options.maxResults ?? DEFAULT_MAX_RESULTS;
         const pathType = options.pathType ?? 'all';
-        const candidateCap = Math.max(maxResults * 20, 5000);
 
-        let filePaths: string[];
-        const ripgrepResult = await ripgrepFiles({
-            cwd: searchPath,
-            maxResults: candidateCap,
-        });
-        if (ripgrepResult) {
-            filePaths = ripgrepResult.paths;
-        } else {
-            filePaths = [];
-            const pendingDirectories = [searchPath];
+        const ripgrepAvailable = await isRipgrepAvailable();
+        const seenCandidates = new Set<string>();
+        const scoredMatches: PathMatch[] = [];
+        let totalMatches = 0;
 
-            while (pendingDirectories.length > 0 && filePaths.length < candidateCap) {
-                const currentDirectory = pendingDirectories.pop();
-                if (!currentDirectory) {
-                    continue;
-                }
-
-                let entries;
-                try {
-                    entries = await fs.readdir(currentDirectory, { withFileTypes: true });
-                } catch {
-                    continue;
-                }
-
-                for (const entry of entries) {
-                    const entryPath = path.join(currentDirectory, entry.name);
-                    if (!this.pathValidator.isPathAllowedQuick(entryPath)) {
-                        continue;
-                    }
-
-                    if (entry.isDirectory()) {
-                        pendingDirectories.push(entryPath);
-                        continue;
-                    }
-
-                    if (!entry.isFile()) {
-                        continue;
-                    }
-
-                    filePaths.push(entryPath);
-                    if (filePaths.length >= candidateCap) {
-                        break;
-                    }
-                }
+        const sortMatches = (left: PathMatch, right: PathMatch): number => {
+            if (right.score !== left.score) {
+                return right.score - left.score;
             }
-        }
+            if (left.path.length !== right.path.length) {
+                return left.path.length - right.path.length;
+            }
+            return left.path.localeCompare(right.path);
+        };
 
-        const inventory = new Map<string, 'file' | 'directory'>();
+        const considerCandidate = (
+            candidatePath: string,
+            candidateType: 'file' | 'directory'
+        ): void => {
+            if (pathType !== 'all' && candidateType !== pathType) {
+                return;
+            }
+
+            const relativePath =
+                path.relative(searchPath, candidatePath) || path.basename(candidatePath);
+            const score = this.scorePathQuery(query, relativePath);
+            if (score === null) {
+                return;
+            }
+
+            totalMatches += 1;
+            scoredMatches.push({
+                path: candidatePath,
+                pathType: candidateType,
+                score,
+            });
+            scoredMatches.sort(sortMatches);
+            if (scoredMatches.length > maxResults) {
+                scoredMatches.pop();
+            }
+        };
+
+        const registerCandidate = async (
+            candidatePath: string,
+            candidateType: 'file' | 'directory'
+        ): Promise<void> => {
+            if (!this.pathValidator.isPathAllowedQuick(candidatePath)) {
+                return;
+            }
+
+            const validationResult = await this.pathValidator.validatePath(candidatePath);
+            if (!validationResult.isValid || !validationResult.normalizedPath) {
+                return;
+            }
+
+            const key = `${candidateType}:${validationResult.normalizedPath}`;
+            if (seenCandidates.has(key)) {
+                return;
+            }
+            seenCandidates.add(key);
+
+            considerCandidate(validationResult.normalizedPath, candidateType);
+        };
+
+        await registerCandidate(searchPath, 'directory');
         const pendingDirectories = [searchPath];
 
-        while (pendingDirectories.length > 0 && inventory.size < candidateCap) {
+        while (pendingDirectories.length > 0) {
             const currentDirectory = pendingDirectories.pop();
             if (!currentDirectory) {
                 continue;
@@ -694,86 +741,39 @@ export class FileSystemService {
             }
 
             for (const entry of entries) {
-                if (!entry.isDirectory()) {
+                const entryPath = path.join(currentDirectory, entry.name);
+                if (!this.pathValidator.isPathAllowedQuick(entryPath)) {
                     continue;
                 }
 
-                const directoryPath = path.join(currentDirectory, entry.name);
-                if (!this.pathValidator.isPathAllowedQuick(directoryPath)) {
+                if (entry.isDirectory()) {
+                    await registerCandidate(entryPath, 'directory');
+                    pendingDirectories.push(entryPath);
                     continue;
                 }
 
-                const directoryValidation = await this.pathValidator.validatePath(directoryPath);
-                if (!directoryValidation.isValid || !directoryValidation.normalizedPath) {
+                if (ripgrepAvailable || !entry.isFile()) {
                     continue;
                 }
 
-                inventory.set(directoryValidation.normalizedPath, 'directory');
-                if (inventory.size >= candidateCap) {
-                    break;
-                }
-                pendingDirectories.push(directoryValidation.normalizedPath);
+                await registerCandidate(entryPath, 'file');
             }
         }
 
-        for (const filePath of filePaths) {
-            if (inventory.size >= candidateCap) {
-                break;
-            }
-            const validationResult = await this.pathValidator.validatePath(filePath);
-            if (!validationResult.isValid || !validationResult.normalizedPath) {
-                continue;
-            }
-
-            inventory.set(validationResult.normalizedPath, 'file');
-
-            let currentDir = path.dirname(validationResult.normalizedPath);
-            while (currentDir !== searchPath && currentDir.startsWith(searchPath + path.sep)) {
-                if (this.pathValidator.isPathAllowedQuick(currentDir)) {
-                    inventory.set(currentDir, 'directory');
-                }
-                const parent = path.dirname(currentDir);
-                if (parent === currentDir) {
-                    break;
-                }
-                currentDir = parent;
-            }
-        }
-
-        const scoredMatches: PathMatch[] = [];
-        for (const [candidatePath, candidateType] of inventory) {
-            if (pathType !== 'all' && candidateType !== pathType) {
-                continue;
-            }
-
-            const relativePath =
-                path.relative(searchPath, candidatePath) || path.basename(candidatePath);
-            const score = this.scorePathQuery(query, relativePath);
-            if (score === null) {
-                continue;
-            }
-
-            scoredMatches.push({
-                path: candidatePath,
-                pathType: candidateType,
-                score,
+        if (ripgrepAvailable) {
+            await ripgrepWalkFiles({
+                cwd: searchPath,
+                onPath: async (filePath) => {
+                    await registerCandidate(filePath, 'file');
+                    return true;
+                },
             });
         }
 
-        scoredMatches.sort((left, right) => {
-            if (right.score !== left.score) {
-                return right.score - left.score;
-            }
-            if (left.path.length !== right.path.length) {
-                return left.path.length - right.path.length;
-            }
-            return left.path.localeCompare(right.path);
-        });
-
         return {
-            matches: scoredMatches.slice(0, maxResults),
-            totalMatches: scoredMatches.length,
-            truncated: scoredMatches.length > maxResults,
+            matches: scoredMatches,
+            totalMatches,
+            truncated: totalMatches > maxResults,
             searchPath,
         };
     }

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -628,25 +628,59 @@ export class FileSystemService {
         const searchPath = validation.normalizedPath;
         const maxResults = options.maxResults ?? DEFAULT_MAX_RESULTS;
         const pathType = options.pathType ?? 'all';
+        const candidateCap = Math.max(maxResults * 20, 5000);
 
         let filePaths: string[];
-        const ripgrepResult = await ripgrepFiles({ cwd: searchPath });
+        const ripgrepResult = await ripgrepFiles({
+            cwd: searchPath,
+            maxResults: candidateCap,
+        });
         if (ripgrepResult) {
             filePaths = ripgrepResult.paths;
         } else {
-            const files = await glob('**/*', {
-                cwd: searchPath,
-                absolute: true,
-                nodir: true,
-                follow: false,
-            });
-            filePaths = files;
+            filePaths = [];
+            const pendingDirectories = [searchPath];
+
+            while (pendingDirectories.length > 0 && filePaths.length < candidateCap) {
+                const currentDirectory = pendingDirectories.pop();
+                if (!currentDirectory) {
+                    continue;
+                }
+
+                let entries;
+                try {
+                    entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+                } catch {
+                    continue;
+                }
+
+                for (const entry of entries) {
+                    const entryPath = path.join(currentDirectory, entry.name);
+                    if (!this.pathValidator.isPathAllowedQuick(entryPath)) {
+                        continue;
+                    }
+
+                    if (entry.isDirectory()) {
+                        pendingDirectories.push(entryPath);
+                        continue;
+                    }
+
+                    if (!entry.isFile()) {
+                        continue;
+                    }
+
+                    filePaths.push(entryPath);
+                    if (filePaths.length >= candidateCap) {
+                        break;
+                    }
+                }
+            }
         }
 
         const inventory = new Map<string, 'file' | 'directory'>();
         const pendingDirectories = [searchPath];
 
-        while (pendingDirectories.length > 0) {
+        while (pendingDirectories.length > 0 && inventory.size < candidateCap) {
             const currentDirectory = pendingDirectories.pop();
             if (!currentDirectory) {
                 continue;
@@ -675,11 +709,17 @@ export class FileSystemService {
                 }
 
                 inventory.set(directoryValidation.normalizedPath, 'directory');
+                if (inventory.size >= candidateCap) {
+                    break;
+                }
                 pendingDirectories.push(directoryValidation.normalizedPath);
             }
         }
 
         for (const filePath of filePaths) {
+            if (inventory.size >= candidateCap) {
+                break;
+            }
             const validationResult = await this.pathValidator.validatePath(filePath);
             if (!validationResult.isValid || !validationResult.normalizedPath) {
                 continue;

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -5,7 +5,9 @@
  */
 
 import * as fs from 'node:fs/promises';
+import { createReadStream } from 'node:fs';
 import * as path from 'node:path';
+import { createInterface } from 'node:readline';
 import { glob } from 'glob';
 import safeRegex from 'safe-regex';
 import { DextoRuntimeError, getDextoPath, Logger, DextoLogComponent } from '@dexto/core';
@@ -26,8 +28,11 @@ import {
     EditOperation,
     FileMetadata,
     DirectoryEntry,
+    FindPathsOptions,
+    FindPathsResult,
     ListDirectoryOptions,
     ListDirectoryResult,
+    PathMatch,
     CreateDirectoryOptions,
     CreateDirectoryResult,
     DeletePathOptions,
@@ -38,12 +43,30 @@ import {
 import { PathValidator } from './path-validator.js';
 import { FileSystemError } from './errors.js';
 import { detectMimeType, getMediaFileKind, isLikelyBinary, isTextMimeType } from './mime-utils.js';
+import { ripgrepFiles, ripgrepSearch } from './ripgrep-utils.js';
 
 const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
 const DEFAULT_MAX_RESULTS = 1000;
 const DEFAULT_MAX_SEARCH_RESULTS = 100;
 const DEFAULT_MAX_LIST_RESULTS = 5000;
 const DEFAULT_LIST_CONCURRENCY = 16;
+
+function getErrnoCode(error: unknown): string | undefined {
+    if (typeof error !== 'object' || error === null) {
+        return undefined;
+    }
+
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+}
+
+function normalizeStatSize(size: number | bigint): number {
+    return typeof size === 'bigint' ? Number(size) : size;
+}
+
+function isFilesystemRuntimeError(error: unknown): error is DextoRuntimeError {
+    return error instanceof DextoRuntimeError && error.scope === 'filesystem';
+}
 
 /**
  * FileSystemService - Handles all file system operations with security checks
@@ -198,34 +221,34 @@ export class FileSystemService {
         return validation.normalizedPath;
     }
 
-    private async readNormalizedFile(
-        normalizedPath: string,
-        options: ReadFileOptions = {}
-    ): Promise<FileContent> {
-        // Check if file exists
+    private async ensureReadableFile(
+        normalizedPath: string
+    ): Promise<Awaited<ReturnType<typeof fs.stat>>> {
         try {
             const stats = await fs.stat(normalizedPath);
+            const fileSize = normalizeStatSize(stats.size);
 
             if (!stats.isFile()) {
                 throw FileSystemError.invalidPath(normalizedPath, 'Path is not a file');
             }
 
-            // Check file size
-            if (stats.size > this.config.maxFileSize) {
+            if (fileSize > this.config.maxFileSize) {
                 throw FileSystemError.fileTooLarge(
                     normalizedPath,
-                    stats.size,
+                    fileSize,
                     this.config.maxFileSize
                 );
             }
+
+            return stats;
         } catch (error) {
-            if (error instanceof DextoRuntimeError && error.scope === 'filesystem') {
+            if (isFilesystemRuntimeError(error)) {
                 throw error;
             }
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            if (getErrnoCode(error) === 'ENOENT') {
                 throw FileSystemError.fileNotFound(normalizedPath);
             }
-            if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+            if (getErrnoCode(error) === 'EACCES') {
                 throw FileSystemError.permissionDenied(normalizedPath, 'read');
             }
             if (error instanceof DextoRuntimeError) {
@@ -236,13 +259,25 @@ export class FileSystemService {
                 error instanceof Error ? error.message : String(error)
             );
         }
+    }
 
-        // Read file
+    private async readNormalizedFile(
+        normalizedPath: string,
+        options: ReadFileOptions = {}
+    ): Promise<FileContent> {
+        const stats = await this.ensureReadableFile(normalizedPath);
+
         try {
             const encoding = options.encoding || DEFAULT_ENCODING;
-            const rawContent = await fs.readFile(normalizedPath);
-            const mimeType = detectMimeType(normalizedPath, rawContent);
-            const binaryLike = isLikelyBinary(rawContent);
+            const probeSize = Math.min(normalizeStatSize(stats.size), 8192);
+            const handle = await fs.open(normalizedPath, 'r');
+            const probe = Buffer.alloc(probeSize);
+            const { bytesRead } = await handle.read(probe, 0, probeSize, 0);
+            await handle.close();
+
+            const sample = probe.subarray(0, bytesRead);
+            const mimeType = detectMimeType(normalizedPath, sample);
+            const binaryLike = isLikelyBinary(sample);
             const canReadAsText =
                 !binaryLike && (isTextMimeType(mimeType) || mimeType === 'image/svg+xml');
 
@@ -253,23 +288,39 @@ export class FileSystemService {
                 );
             }
 
-            const content = rawContent.toString(encoding);
-            const lines = content.split('\n');
-
-            // Handle offset (1-based per types) and limit
             const limit = options.limit;
-            const offset1 = options.offset; // 1-based if provided
+            const startLine = options.offset && options.offset > 0 ? options.offset : 1;
 
-            let selectedLines: string[];
+            const stream = createReadStream(normalizedPath, {
+                encoding,
+            });
+            const rl = createInterface({
+                input: stream,
+                crlfDelay: Infinity,
+            });
+
+            const selectedLines: string[] = [];
+            let lineNumber = 0;
             let truncated = false;
 
-            if ((offset1 && offset1 > 0) || limit !== undefined) {
-                const start = offset1 && offset1 > 0 ? Math.max(0, offset1 - 1) : 0;
-                const end = limit !== undefined ? start + limit : lines.length;
-                selectedLines = lines.slice(start, end);
-                truncated = end < lines.length;
-            } else {
-                selectedLines = lines;
+            try {
+                for await (const line of rl) {
+                    lineNumber += 1;
+
+                    if (lineNumber < startLine) {
+                        continue;
+                    }
+
+                    if (limit !== undefined && selectedLines.length >= limit) {
+                        truncated = true;
+                        break;
+                    }
+
+                    selectedLines.push(line);
+                }
+            } finally {
+                rl.close();
+                stream.destroy();
             }
 
             const returnedContent = selectedLines.join('\n');
@@ -280,9 +331,11 @@ export class FileSystemService {
                 mimeType,
                 truncated,
                 size: Buffer.byteLength(returnedContent, encoding),
+                startLine,
+                nextOffset: truncated ? startLine + selectedLines.length : undefined,
             };
         } catch (error) {
-            if (error instanceof DextoRuntimeError && error.scope === 'filesystem') {
+            if (isFilesystemRuntimeError(error)) {
                 throw error;
             }
             throw FileSystemError.readFailed(
@@ -312,15 +365,16 @@ export class FileSystemService {
 
         try {
             const stats = await fs.stat(normalizedPath);
+            const fileSize = normalizeStatSize(stats.size);
 
             if (!stats.isFile()) {
                 throw FileSystemError.invalidPath(normalizedPath, 'Path is not a file');
             }
 
-            if (stats.size > this.config.maxFileSize) {
+            if (fileSize > this.config.maxFileSize) {
                 throw FileSystemError.fileTooLarge(
                     normalizedPath,
-                    stats.size,
+                    fileSize,
                     this.config.maxFileSize
                 );
             }
@@ -340,16 +394,16 @@ export class FileSystemService {
                 mimeType,
                 filename: path.basename(normalizedPath),
                 kind: getMediaFileKind(mimeType),
-                size: stats.size,
+                size: fileSize,
             };
         } catch (error) {
-            if (error instanceof DextoRuntimeError && error.scope === 'filesystem') {
+            if (isFilesystemRuntimeError(error)) {
                 throw error;
             }
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            if (getErrnoCode(error) === 'ENOENT') {
                 throw FileSystemError.fileNotFound(normalizedPath);
             }
-            if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+            if (getErrnoCode(error) === 'EACCES') {
                 throw FileSystemError.permissionDenied(normalizedPath, 'read');
             }
             throw FileSystemError.readFailed(
@@ -384,61 +438,41 @@ export class FileSystemService {
 
         const cwd: string = options.cwd || this.config.workingDirectory || process.cwd();
         const maxResults = options.maxResults || DEFAULT_MAX_RESULTS;
+        const includeMetadata = options.includeMetadata !== false;
 
         try {
-            // Execute glob search
+            const ripgrepResult = await ripgrepFiles({
+                cwd,
+                globs: [pattern],
+                maxResults,
+            });
+            if (ripgrepResult) {
+                const files = await this.collectValidatedFileMetadata(
+                    ripgrepResult.paths,
+                    includeMetadata
+                );
+                return {
+                    files,
+                    truncated: ripgrepResult.truncated,
+                    totalFound: files.length,
+                };
+            }
+
             const files = await glob(pattern, {
                 cwd,
                 absolute: true,
-                nodir: true, // Only files
-                follow: false, // Don't follow symlinks
+                nodir: true,
+                follow: false,
             });
 
-            // Validate each path and collect metadata
-            const validFiles: FileMetadata[] = [];
-
-            for (const file of files) {
-                // Validate path (async for non-blocking symlink resolution)
-                const validation = await this.pathValidator.validatePath(file);
-                if (!validation.isValid || !validation.normalizedPath) {
-                    this.logger.debug(`Skipping invalid path: ${file}`);
-                    continue;
-                }
-
-                // Get metadata if requested
-                if (options.includeMetadata !== false) {
-                    try {
-                        const stats = await fs.stat(validation.normalizedPath);
-                        validFiles.push({
-                            path: validation.normalizedPath,
-                            size: stats.size,
-                            modified: stats.mtime,
-                            isDirectory: stats.isDirectory(),
-                        });
-                    } catch (error) {
-                        this.logger.debug(
-                            `Failed to stat file ${file}: ${error instanceof Error ? error.message : String(error)}`
-                        );
-                    }
-                } else {
-                    validFiles.push({
-                        path: validation.normalizedPath,
-                        size: 0,
-                        modified: new Date(),
-                        isDirectory: false,
-                    });
-                }
-
-                // Check if we've reached the limit
-                if (validFiles.length >= maxResults) {
-                    break;
-                }
-            }
-
-            const limited = validFiles.length >= maxResults;
+            const limitedFiles = files.slice(0, maxResults);
+            const validFiles = await this.collectValidatedFileMetadata(
+                limitedFiles,
+                includeMetadata
+            );
             return {
                 files: validFiles,
-                truncated: limited,
+                truncated: files.length > maxResults,
                 totalFound: validFiles.length,
             };
         } catch (error) {
@@ -447,6 +481,222 @@ export class FileSystemService {
                 error instanceof Error ? error.message : String(error)
             );
         }
+    }
+
+    private async collectValidatedFileMetadata(
+        filePaths: string[],
+        includeMetadata: boolean
+    ): Promise<FileMetadata[]> {
+        const entries = await this.mapWithConcurrency(
+            filePaths,
+            DEFAULT_LIST_CONCURRENCY,
+            async (filePath) => {
+                const validation = await this.pathValidator.validatePath(filePath);
+                if (!validation.isValid || !validation.normalizedPath) {
+                    this.logger.debug(`Skipping invalid path: ${filePath}`);
+                    return null;
+                }
+
+                if (!includeMetadata) {
+                    return {
+                        path: validation.normalizedPath,
+                        size: 0,
+                        modified: new Date(0),
+                        isDirectory: false,
+                    } satisfies FileMetadata;
+                }
+
+                try {
+                    const stats = await fs.stat(validation.normalizedPath);
+                    if (!stats.isFile()) {
+                        return null;
+                    }
+
+                    return {
+                        path: validation.normalizedPath,
+                        size: normalizeStatSize(stats.size),
+                        modified: stats.mtime,
+                        isDirectory: false,
+                    } satisfies FileMetadata;
+                } catch (error) {
+                    this.logger.debug(
+                        `Failed to stat file ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+                    );
+                    return null;
+                }
+            }
+        );
+
+        return entries.filter(Boolean) as FileMetadata[];
+    }
+
+    private subsequenceScore(query: string, candidate: string): number | null {
+        let score = 0;
+        let queryIndex = 0;
+        let lastMatch = -1;
+
+        for (let candidateIndex = 0; candidateIndex < candidate.length; candidateIndex += 1) {
+            if (candidate[candidateIndex] !== query[queryIndex]) {
+                continue;
+            }
+
+            score += lastMatch >= 0 ? Math.max(1, 12 - (candidateIndex - lastMatch)) : 12;
+            lastMatch = candidateIndex;
+            queryIndex += 1;
+
+            if (queryIndex === query.length) {
+                return score - candidate.length;
+            }
+        }
+
+        return null;
+    }
+
+    private scorePathQuery(query: string, candidatePath: string): number | null {
+        const normalizedQuery = query.trim().toLowerCase();
+        if (!normalizedQuery) {
+            return null;
+        }
+
+        const normalizedPath = candidatePath.toLowerCase();
+        const baseName = path.basename(candidatePath).toLowerCase();
+        const baseNameStem = path.parse(baseName).name.toLowerCase();
+        const compactQuery = normalizedQuery.replace(/[\s._/-]+/g, '');
+        const compactPath = normalizedPath.replace(/[\s._/-]+/g, '');
+        const compactBaseName = baseNameStem.replace(/[\s._/-]+/g, '');
+
+        if (baseName === normalizedQuery) {
+            return 1200 - candidatePath.length;
+        }
+        if (normalizedPath === normalizedQuery) {
+            return 1100 - candidatePath.length;
+        }
+        if (baseName.startsWith(normalizedQuery)) {
+            return 1000 - baseName.length;
+        }
+        if (compactQuery && compactBaseName === compactQuery) {
+            return 980 - baseNameStem.length;
+        }
+        if (compactQuery && compactBaseName.startsWith(compactQuery)) {
+            return 940 - compactBaseName.length;
+        }
+
+        const baseIndex = baseName.indexOf(normalizedQuery);
+        if (baseIndex >= 0) {
+            return 900 - baseIndex * 10 - baseName.length;
+        }
+        const compactBaseIndex = compactBaseName.indexOf(compactQuery);
+        if (compactQuery && compactBaseIndex >= 0) {
+            return 860 - compactBaseIndex * 10 - compactBaseName.length;
+        }
+
+        const pathIndex = normalizedPath.indexOf(normalizedQuery);
+        if (pathIndex >= 0) {
+            return 800 - pathIndex * 2 - normalizedPath.length;
+        }
+        const compactPathIndex = compactPath.indexOf(compactQuery);
+        if (compactQuery && compactPathIndex >= 0) {
+            return 760 - compactPathIndex * 2 - compactPath.length;
+        }
+
+        const baseScore = this.subsequenceScore(compactQuery || normalizedQuery, compactBaseName);
+        if (baseScore !== null) {
+            return 700 + baseScore;
+        }
+
+        const pathScore = this.subsequenceScore(compactQuery || normalizedQuery, compactPath);
+        if (pathScore !== null) {
+            return 500 + pathScore;
+        }
+
+        return null;
+    }
+
+    async findPaths(query: string, options: FindPathsOptions = {}): Promise<FindPathsResult> {
+        await this.ensureInitialized();
+
+        const basePath: string = options.path || this.config.workingDirectory || process.cwd();
+        const validation = await this.pathValidator.validatePath(basePath);
+        if (!validation.isValid || !validation.normalizedPath) {
+            throw FileSystemError.invalidPath(basePath, validation.error || 'Unknown error');
+        }
+
+        const searchPath = validation.normalizedPath;
+        const maxResults = options.maxResults ?? DEFAULT_MAX_RESULTS;
+        const pathType = options.pathType ?? 'all';
+
+        let filePaths: string[];
+        const ripgrepResult = await ripgrepFiles({ cwd: searchPath });
+        if (ripgrepResult) {
+            filePaths = ripgrepResult.paths;
+        } else {
+            const files = await glob('**/*', {
+                cwd: searchPath,
+                absolute: true,
+                nodir: true,
+                follow: false,
+            });
+            filePaths = files;
+        }
+
+        const inventory = new Map<string, 'file' | 'directory'>();
+        for (const filePath of filePaths) {
+            const validationResult = await this.pathValidator.validatePath(filePath);
+            if (!validationResult.isValid || !validationResult.normalizedPath) {
+                continue;
+            }
+
+            inventory.set(validationResult.normalizedPath, 'file');
+
+            let currentDir = path.dirname(validationResult.normalizedPath);
+            while (currentDir !== searchPath && currentDir.startsWith(searchPath + path.sep)) {
+                if (this.pathValidator.isPathAllowedQuick(currentDir)) {
+                    inventory.set(currentDir, 'directory');
+                }
+                const parent = path.dirname(currentDir);
+                if (parent === currentDir) {
+                    break;
+                }
+                currentDir = parent;
+            }
+        }
+
+        const scoredMatches: PathMatch[] = [];
+        for (const [candidatePath, candidateType] of inventory) {
+            if (pathType !== 'all' && candidateType !== pathType) {
+                continue;
+            }
+
+            const relativePath =
+                path.relative(searchPath, candidatePath) || path.basename(candidatePath);
+            const score = this.scorePathQuery(query, relativePath);
+            if (score === null) {
+                continue;
+            }
+
+            scoredMatches.push({
+                path: candidatePath,
+                pathType: candidateType,
+                score,
+            });
+        }
+
+        scoredMatches.sort((left, right) => {
+            if (right.score !== left.score) {
+                return right.score - left.score;
+            }
+            if (left.path.length !== right.path.length) {
+                return left.path.length - right.path.length;
+            }
+            return left.path.localeCompare(right.path);
+        });
+
+        return {
+            matches: scoredMatches.slice(0, maxResults),
+            totalMatches: scoredMatches.length,
+            truncated: scoredMatches.length > maxResults,
+            searchPath,
+        };
     }
 
     /**
@@ -471,13 +721,13 @@ export class FileSystemService {
                 throw FileSystemError.invalidPath(normalizedPath, 'Path is not a directory');
             }
         } catch (error) {
-            if (error instanceof DextoRuntimeError && error.scope === 'filesystem') {
+            if (isFilesystemRuntimeError(error)) {
                 throw error;
             }
-            if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+            if (getErrnoCode(error) === 'ENOENT') {
                 throw FileSystemError.directoryNotFound(normalizedPath);
             }
-            if ((error as NodeJS.ErrnoException).code === 'EACCES') {
+            if (getErrnoCode(error) === 'EACCES') {
                 throw FileSystemError.permissionDenied(normalizedPath, 'read');
             }
             throw FileSystemError.listFailed(
@@ -555,7 +805,7 @@ export class FileSystemService {
                             name: entry.entry.name,
                             path: entry.normalizedPath,
                             isDirectory: entry.entry.isDirectory(),
-                            size: stat.size,
+                            size: normalizeStatSize(stat.size),
                             modified: stat.mtime,
                         } satisfies DirectoryEntry;
                     } catch {
@@ -659,7 +909,7 @@ export class FileSystemService {
             const created = recursive ? typeof firstCreated === 'string' : true;
             return { path: normalizedPath, created };
         } catch (error) {
-            const code = (error as NodeJS.ErrnoException).code;
+            const code = getErrnoCode(error);
             if (code === 'EEXIST') {
                 try {
                     const stat = await fs.stat(normalizedPath);
@@ -700,7 +950,7 @@ export class FileSystemService {
             await fs.rm(normalizedPath, { recursive: options.recursive ?? false, force: false });
             return { path: normalizedPath, deleted: true };
         } catch (error) {
-            const code = (error as NodeJS.ErrnoException).code;
+            const code = getErrnoCode(error);
             if (code === 'ENOENT') {
                 throw FileSystemError.fileNotFound(normalizedPath);
             }
@@ -744,7 +994,7 @@ export class FileSystemService {
                 `Target already exists: ${normalizedTo}`
             );
         } catch (error) {
-            const code = (error as NodeJS.ErrnoException).code;
+            const code = getErrnoCode(error);
             if (!code) {
                 throw error;
             }
@@ -764,7 +1014,7 @@ export class FileSystemService {
             await fs.rename(normalizedFrom, normalizedTo);
             return { from: normalizedFrom, to: normalizedTo };
         } catch (error) {
-            const code = (error as NodeJS.ErrnoException).code;
+            const code = getErrnoCode(error);
             if (code === 'ENOENT') {
                 throw FileSystemError.fileNotFound(normalizedFrom);
             }
@@ -786,7 +1036,8 @@ export class FileSystemService {
 
         const basePath: string = options.path || this.config.workingDirectory || process.cwd();
         let searchPath: string;
-        let globPattern: string;
+        let globPattern: string | undefined;
+        let targetPath: string | undefined;
 
         const baseValidation = await this.pathValidator.validatePath(basePath);
         if (!baseValidation.isValid || !baseValidation.normalizedPath) {
@@ -799,38 +1050,87 @@ export class FileSystemService {
             const stats = await fs.stat(resolvedPath);
 
             if (stats.isFile()) {
-                // If path is a file, extract directory and use filename in glob pattern
                 searchPath = path.dirname(resolvedPath);
-                const fileName = path.basename(resolvedPath);
-                // Escape special glob characters in filename
-                const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-                globPattern = options.glob || escapedFileName;
+                targetPath = path.basename(resolvedPath);
+                globPattern = targetPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
             } else {
-                // If path is a directory, use it as-is
                 searchPath = resolvedPath;
                 globPattern = options.glob || '**/*';
             }
         } catch {
-            // If stat fails, assume it's a directory (for backwards compatibility)
             searchPath = resolvedPath;
             globPattern = options.glob || '**/*';
         }
 
         const maxResults = options.maxResults || DEFAULT_MAX_SEARCH_RESULTS;
         const contextLines = options.contextLines || 0;
+        const literal = options.literal !== false;
 
         try {
-            // Validate regex pattern for ReDoS safety before creating RegExp
-            // See: https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS
-            if (!safeRegex(pattern)) {
+            const ripgrepOptions: Parameters<typeof ripgrepSearch>[0] = {
+                cwd: searchPath,
+                pattern,
+                literal,
+                maxResults,
+            };
+            if (typeof options.caseInsensitive === 'boolean') {
+                ripgrepOptions.caseInsensitive = options.caseInsensitive;
+            }
+            if (targetPath) {
+                ripgrepOptions.targetPath = targetPath;
+            } else if (options.glob) {
+                ripgrepOptions.globs = [options.glob];
+            }
+
+            const ripgrepResult = await ripgrepSearch(ripgrepOptions);
+            if (ripgrepResult) {
+                const matches = await this.mapWithConcurrency(
+                    ripgrepResult.matches,
+                    Math.min(DEFAULT_LIST_CONCURRENCY, Math.max(1, ripgrepResult.matches.length)),
+                    async (match) => {
+                        const validation = await this.pathValidator.validatePath(match.file);
+                        if (!validation.isValid || !validation.normalizedPath) {
+                            return null;
+                        }
+
+                        let context: { before: string[]; after: string[] } | undefined;
+                        if (contextLines > 0) {
+                            context = await this.readContextWindow(
+                                validation.normalizedPath,
+                                match.lineNumber,
+                                contextLines
+                            );
+                        }
+
+                        return {
+                            file: validation.normalizedPath,
+                            lineNumber: match.lineNumber,
+                            line: match.line,
+                            ...(context ? { context } : {}),
+                        } satisfies SearchMatch;
+                    }
+                );
+
+                const filteredMatches = matches.filter(Boolean) as SearchMatch[];
+                return {
+                    matches: filteredMatches,
+                    totalMatches: filteredMatches.length,
+                    truncated: ripgrepResult.truncated,
+                    filesSearched: ripgrepResult.filesSearched,
+                };
+            }
+
+            const flags = options.caseInsensitive ? 'i' : '';
+            const regexPattern = literal ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : pattern;
+
+            if (!literal && !safeRegex(regexPattern)) {
                 throw FileSystemError.invalidPattern(
                     pattern,
                     'Pattern may cause catastrophic backtracking (ReDoS). Please simplify the regex.'
                 );
             }
 
-            const flags = options.caseInsensitive ? 'i' : '';
-            const regex = new RegExp(pattern, flags);
+            const regex = new RegExp(regexPattern, flags);
 
             // Find files to search
             const globResult = await this.globFiles(globPattern, {
@@ -916,6 +1216,49 @@ export class FileSystemService {
                 error instanceof Error ? error.message : String(error)
             );
         }
+    }
+
+    private async readContextWindow(
+        normalizedPath: string,
+        lineNumber: number,
+        contextLines: number
+    ): Promise<{ before: string[]; after: string[] }> {
+        const before: string[] = [];
+        const after: string[] = [];
+
+        const startLine = Math.max(1, lineNumber - contextLines);
+        const endLine = lineNumber + contextLines;
+
+        const stream = createReadStream(normalizedPath, {
+            encoding: DEFAULT_ENCODING,
+        });
+        const rl = createInterface({
+            input: stream,
+            crlfDelay: Infinity,
+        });
+
+        let currentLine = 0;
+        try {
+            for await (const line of rl) {
+                currentLine += 1;
+                if (currentLine < startLine) {
+                    continue;
+                }
+                if (currentLine > endLine) {
+                    break;
+                }
+                if (currentLine < lineNumber) {
+                    before.push(line);
+                } else if (currentLine > lineNumber) {
+                    after.push(line);
+                }
+            }
+        } finally {
+            rl.close();
+            stream.destroy();
+        }
+
+        return { before, after };
     }
 
     /**

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -272,8 +272,12 @@ export class FileSystemService {
             const probeSize = Math.min(normalizeStatSize(stats.size), 8192);
             const handle = await fs.open(normalizedPath, 'r');
             const probe = Buffer.alloc(probeSize);
-            const { bytesRead } = await handle.read(probe, 0, probeSize, 0);
-            await handle.close();
+            let bytesRead = 0;
+            try {
+                ({ bytesRead } = await handle.read(probe, 0, probeSize, 0));
+            } finally {
+                await handle.close();
+            }
 
             const sample = probe.subarray(0, bytesRead);
             const mimeType = detectMimeType(normalizedPath, sample);
@@ -438,7 +442,7 @@ export class FileSystemService {
 
         const cwd: string = options.cwd || this.config.workingDirectory || process.cwd();
         const maxResults = options.maxResults || DEFAULT_MAX_RESULTS;
-        const includeMetadata = options.includeMetadata !== false;
+        const includeMetadata = options.includeMetadata === true;
 
         try {
             const ripgrepResult = await ripgrepFiles({
@@ -1095,11 +1099,15 @@ export class FileSystemService {
 
                         let context: { before: string[]; after: string[] } | undefined;
                         if (contextLines > 0) {
-                            context = await this.readContextWindow(
-                                validation.normalizedPath,
-                                match.lineNumber,
-                                contextLines
-                            );
+                            try {
+                                context = await this.readContextWindow(
+                                    validation.normalizedPath,
+                                    match.lineNumber,
+                                    contextLines
+                                );
+                            } catch {
+                                return null;
+                            }
                         }
 
                         return {

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -644,6 +644,41 @@ export class FileSystemService {
         }
 
         const inventory = new Map<string, 'file' | 'directory'>();
+        const pendingDirectories = [searchPath];
+
+        while (pendingDirectories.length > 0) {
+            const currentDirectory = pendingDirectories.pop();
+            if (!currentDirectory) {
+                continue;
+            }
+
+            let entries;
+            try {
+                entries = await fs.readdir(currentDirectory, { withFileTypes: true });
+            } catch {
+                continue;
+            }
+
+            for (const entry of entries) {
+                if (!entry.isDirectory()) {
+                    continue;
+                }
+
+                const directoryPath = path.join(currentDirectory, entry.name);
+                if (!this.pathValidator.isPathAllowedQuick(directoryPath)) {
+                    continue;
+                }
+
+                const directoryValidation = await this.pathValidator.validatePath(directoryPath);
+                if (!directoryValidation.isValid || !directoryValidation.normalizedPath) {
+                    continue;
+                }
+
+                inventory.set(directoryValidation.normalizedPath, 'directory');
+                pendingDirectories.push(directoryValidation.normalizedPath);
+            }
+        }
+
         for (const filePath of filePaths) {
             const validationResult = await this.pathValidator.validatePath(filePath);
             if (!validationResult.isValid || !validationResult.normalizedPath) {
@@ -1069,8 +1104,16 @@ export class FileSystemService {
         const maxResults = options.maxResults || DEFAULT_MAX_SEARCH_RESULTS;
         const contextLines = options.contextLines || 0;
         const literal = options.literal !== false;
+        const regexPattern = literal ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : pattern;
 
         try {
+            if (!literal && !safeRegex(regexPattern)) {
+                throw FileSystemError.invalidPattern(
+                    pattern,
+                    'Pattern may cause catastrophic backtracking (ReDoS). Please simplify the regex.'
+                );
+            }
+
             const ripgrepOptions: Parameters<typeof ripgrepSearch>[0] = {
                 cwd: searchPath,
                 pattern,
@@ -1129,15 +1172,6 @@ export class FileSystemService {
             }
 
             const flags = options.caseInsensitive ? 'i' : '';
-            const regexPattern = literal ? pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : pattern;
-
-            if (!literal && !safeRegex(regexPattern)) {
-                throw FileSystemError.invalidPattern(
-                    pattern,
-                    'Pattern may cause catastrophic backtracking (ReDoS). Please simplify the regex.'
-                );
-            }
-
             const regex = new RegExp(regexPattern, flags);
 
             // Find files to search

--- a/packages/tools-filesystem/src/find-paths-tool.ts
+++ b/packages/tools-filesystem/src/find-paths-tool.ts
@@ -7,7 +7,7 @@ import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
 
 const FindPathsInputSchema = z
     .object({
-        query: z.string().min(1).describe('Filename or path fragment to search for'),
+        query: z.string().trim().min(1).describe('Filename or path fragment to search for'),
         path: z
             .string()
             .optional()

--- a/packages/tools-filesystem/src/find-paths-tool.ts
+++ b/packages/tools-filesystem/src/find-paths-tool.ts
@@ -1,0 +1,101 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import { createLocalToolCallHeader, defineTool, truncateForHeader } from '@dexto/core';
+import type { SearchDisplayData, Tool, ToolExecutionContext } from '@dexto/core';
+import type { FileSystemServiceGetter } from './file-tool-types.js';
+import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
+
+const FindPathsInputSchema = z
+    .object({
+        query: z.string().min(1).describe('Filename or path fragment to search for'),
+        path: z
+            .string()
+            .optional()
+            .describe('Base directory to search from (defaults to the working directory)'),
+        path_type: z
+            .enum(['file', 'directory', 'all'])
+            .optional()
+            .default('all')
+            .describe('Restrict results to files, directories, or both (default: all)'),
+        max_results: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .default(100)
+            .describe('Maximum number of matches to return (default: 100)'),
+    })
+    .strict();
+
+export function createFindPathsTool(
+    getFileSystemService: FileSystemServiceGetter
+): Tool<typeof FindPathsInputSchema> {
+    return defineTool({
+        id: 'find_paths',
+        aliases: ['find'],
+        description:
+            'Find likely file or directory paths using exact, prefix, substring, and fuzzy matching over the workspace path inventory.',
+        inputSchema: FindPathsInputSchema,
+
+        presentation: {
+            describeHeader: (input) =>
+                createLocalToolCallHeader({
+                    title: 'Find Paths',
+                    argsText: truncateForHeader(
+                        [input.query, input.path ? `path=${input.path}` : null]
+                            .filter(Boolean)
+                            .join(', '),
+                        140
+                    ),
+                }),
+        },
+
+        ...createDirectoryAccessApprovalHandlers({
+            toolName: 'find_paths',
+            operation: 'read',
+            inputSchema: FindPathsInputSchema,
+            getFileSystemService,
+            resolvePaths: (input, fileSystemService) => {
+                const baseDir = fileSystemService.getWorkingDirectory();
+                const resolvedPath = path.resolve(baseDir, input.path || '.');
+                return { path: resolvedPath, parentDir: resolvedPath };
+            },
+        }),
+
+        async execute(input, context: ToolExecutionContext) {
+            const fileSystemService = await getFileSystemService(context);
+            const baseDir = fileSystemService.getWorkingDirectory();
+            const resolvedPath = path.resolve(baseDir, input.path || '.');
+
+            const result = await fileSystemService.findPaths(input.query, {
+                path: resolvedPath,
+                pathType: input.path_type,
+                maxResults: input.max_results,
+            });
+
+            const _display: SearchDisplayData = {
+                type: 'search',
+                pattern: input.query,
+                matches: result.matches.map((match) => ({
+                    file: match.path,
+                    line: 0,
+                    content: match.path,
+                })),
+                totalMatches: result.totalMatches,
+                truncated: result.truncated,
+            };
+
+            return {
+                matches: result.matches.map((match) => ({
+                    path: match.path,
+                    path_type: match.pathType,
+                    score: match.score,
+                })),
+                total_matches: result.totalMatches,
+                truncated: result.truncated,
+                search_path: result.searchPath,
+                _display,
+            };
+        },
+    });
+}

--- a/packages/tools-filesystem/src/glob-files-tool.ts
+++ b/packages/tools-filesystem/src/glob-files-tool.ts
@@ -28,6 +28,11 @@ const GlobFilesInputSchema = z
             .optional()
             .default(1000)
             .describe('Maximum number of results to return (default: 1000)'),
+        include_metadata: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe('Include size and modified-time metadata (default: false)'),
     })
     .strict();
 
@@ -41,7 +46,7 @@ export function createGlobFilesTool(
         id: 'glob_files',
         aliases: ['glob'],
         description:
-            'Find files matching a glob pattern. Supports standard glob syntax like **/*.js for recursive matches, *.ts for files in current directory, and src/**/*.tsx for nested paths. Returns array of file paths with metadata (size, modified date). Results are limited to allowed paths only.',
+            'Find files matching a glob pattern. Returns paths by default and can include metadata when requested.',
         inputSchema: GlobFilesInputSchema,
 
         presentation: {
@@ -73,7 +78,7 @@ export function createGlobFilesTool(
             const resolvedFileSystemService = await getFileSystemService(context);
 
             // Input is validated by provider before reaching here
-            const { pattern, path: searchPath, max_results } = input;
+            const { pattern, path: searchPath, max_results, include_metadata } = input;
 
             // Resolve the search directory consistently with directory-approval path handling
             const baseDir = resolvedFileSystemService.getWorkingDirectory();
@@ -83,7 +88,7 @@ export function createGlobFilesTool(
             const result = await resolvedFileSystemService.globFiles(pattern, {
                 cwd: resolvedSearchPath,
                 maxResults: max_results,
-                includeMetadata: true,
+                includeMetadata: include_metadata,
             });
 
             // Build display data (reuse SearchDisplayData for file list)
@@ -102,8 +107,12 @@ export function createGlobFilesTool(
             return {
                 files: result.files.map((file) => ({
                     path: file.path,
-                    size: file.size,
-                    modified: file.modified.toISOString(),
+                    ...(include_metadata
+                        ? {
+                              size: file.size,
+                              modified: file.modified.toISOString(),
+                          }
+                        : {}),
                 })),
                 total_found: result.totalFound,
                 truncated: result.truncated,

--- a/packages/tools-filesystem/src/grep-content-tool.ts
+++ b/packages/tools-filesystem/src/grep-content-tool.ts
@@ -14,7 +14,12 @@ import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
 
 const GrepContentInputSchema = z
     .object({
-        pattern: z.string().describe('Regular expression pattern to search for'),
+        pattern: z.string().describe('Text or regex pattern to search for'),
+        mode: z
+            .enum(['literal', 'regex'])
+            .optional()
+            .default('literal')
+            .describe('Interpret pattern as literal text or regex (default: literal)'),
         path: z
             .string()
             .optional()
@@ -57,7 +62,7 @@ export function createGrepContentTool(
         id: 'grep_content',
         aliases: ['grep'],
         description:
-            'Search for text patterns in files using regular expressions. Returns matching lines with file path, line number, and optional context lines. Use glob parameter to filter specific file types (e.g., "*.ts"). Supports case-insensitive search. Great for finding code patterns, function definitions, or specific text across multiple files.',
+            'Search file contents. Literal matching is the default because it is faster and safer for common lookups; regex mode is available when you need pattern syntax.',
         inputSchema: GrepContentInputSchema,
 
         presentation: {
@@ -92,6 +97,7 @@ export function createGrepContentTool(
             // Input is validated by provider before reaching here
             const {
                 pattern,
+                mode,
                 path: searchPath,
                 glob,
                 context_lines,
@@ -105,6 +111,7 @@ export function createGrepContentTool(
             const result = await resolvedFileSystemService.searchContent(pattern, {
                 path: resolvedSearchPath,
                 glob,
+                literal: mode !== 'regex',
                 contextLines: context_lines,
                 caseInsensitive: case_insensitive,
                 maxResults: max_results,
@@ -141,6 +148,7 @@ export function createGrepContentTool(
                 total_matches: result.totalMatches,
                 files_searched: result.filesSearched,
                 truncated: result.truncated,
+                mode,
                 _display,
             };
         },

--- a/packages/tools-filesystem/src/index.ts
+++ b/packages/tools-filesystem/src/index.ts
@@ -2,7 +2,7 @@
  * @dexto/tools-filesystem
  *
  * FileSystem tools factory for Dexto agents.
- * Provides file operation tools: read text, read media, write, edit, glob, grep.
+ * Provides file operation tools: read text, read media, list, find, write, edit, glob, grep.
  */
 
 // Main factory export (image-compatible)
@@ -24,6 +24,9 @@ export type {
     ReadFileOptions,
     GlobOptions,
     GlobResult,
+    FindPathsOptions,
+    FindPathsResult,
+    PathMatch,
     GrepOptions,
     SearchResult,
     SearchMatch,
@@ -48,6 +51,8 @@ export type {
 // Tool implementations (for custom integrations)
 export { createReadFileTool } from './read-file-tool.js';
 export { createReadMediaFileTool } from './read-media-file-tool.js';
+export { createListDirectoryTool } from './list-directory-tool.js';
+export { createFindPathsTool } from './find-paths-tool.js';
 export { createWriteFileTool } from './write-file-tool.js';
 export { createEditFileTool } from './edit-file-tool.js';
 export { createGlobFilesTool } from './glob-files-tool.js';

--- a/packages/tools-filesystem/src/list-directory-tool.ts
+++ b/packages/tools-filesystem/src/list-directory-tool.ts
@@ -1,0 +1,105 @@
+import * as path from 'node:path';
+import { z } from 'zod';
+import { createLocalToolCallHeader, defineTool, truncateForHeader } from '@dexto/core';
+import type { SearchDisplayData, Tool, ToolExecutionContext } from '@dexto/core';
+import type { FileSystemServiceGetter } from './file-tool-types.js';
+import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
+
+const ListDirectoryInputSchema = z
+    .object({
+        path: z
+            .string()
+            .optional()
+            .describe('Directory to list (defaults to the working directory)'),
+        include_hidden: z
+            .boolean()
+            .optional()
+            .default(true)
+            .describe('Include hidden files and directories (default: true)'),
+        include_metadata: z
+            .boolean()
+            .optional()
+            .default(false)
+            .describe('Include entry size and modified time metadata (default: false)'),
+        max_entries: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .default(200)
+            .describe('Maximum number of entries to return (default: 200)'),
+    })
+    .strict();
+
+export function createListDirectoryTool(
+    getFileSystemService: FileSystemServiceGetter
+): Tool<typeof ListDirectoryInputSchema> {
+    return defineTool({
+        id: 'list_directory',
+        description:
+            'List the direct children of a directory without reading file contents. Use this before broader glob or grep searches when you need a quick map of a folder.',
+        inputSchema: ListDirectoryInputSchema,
+
+        presentation: {
+            describeHeader: (input) =>
+                createLocalToolCallHeader({
+                    title: 'List Directory',
+                    argsText: truncateForHeader(input.path ?? '.', 140),
+                }),
+        },
+
+        ...createDirectoryAccessApprovalHandlers({
+            toolName: 'list_directory',
+            operation: 'read',
+            inputSchema: ListDirectoryInputSchema,
+            getFileSystemService,
+            resolvePaths: (input, fileSystemService) => {
+                const baseDir = fileSystemService.getWorkingDirectory();
+                const resolvedPath = path.resolve(baseDir, input.path || '.');
+                return { path: resolvedPath, parentDir: resolvedPath };
+            },
+        }),
+
+        async execute(input, context: ToolExecutionContext) {
+            const fileSystemService = await getFileSystemService(context);
+            const baseDir = fileSystemService.getWorkingDirectory();
+            const resolvedPath = path.resolve(baseDir, input.path || '.');
+
+            const result = await fileSystemService.listDirectory(resolvedPath, {
+                includeHidden: input.include_hidden,
+                includeMetadata: input.include_metadata,
+                maxEntries: input.max_entries,
+            });
+
+            const _display: SearchDisplayData = {
+                type: 'search',
+                pattern: result.path,
+                matches: result.entries.map((entry) => ({
+                    file: entry.path,
+                    line: 0,
+                    content: entry.name,
+                })),
+                totalMatches: result.totalEntries,
+                truncated: result.truncated,
+            };
+
+            return {
+                path: result.path,
+                entries: result.entries.map((entry) => ({
+                    name: entry.name,
+                    path: entry.path,
+                    is_directory: entry.isDirectory,
+                    ...(input.include_metadata
+                        ? {
+                              size: entry.size,
+                              modified: entry.modified.toISOString(),
+                          }
+                        : {}),
+                })),
+                total_entries: result.totalEntries,
+                truncated: result.truncated,
+                _display,
+            };
+        },
+    });
+}

--- a/packages/tools-filesystem/src/read-file-tool.ts
+++ b/packages/tools-filesystem/src/read-file-tool.ts
@@ -89,6 +89,10 @@ export function createReadFileTool(
                 encoding: result.encoding,
                 truncated: result.truncated,
                 size: result.size,
+                ...(typeof result.startLine === 'number' ? { start_line: result.startLine } : {}),
+                ...(typeof result.nextOffset === 'number'
+                    ? { next_offset: result.nextOffset }
+                    : {}),
                 ...(result.mimeType && { mimeType: result.mimeType }),
                 _display,
             };

--- a/packages/tools-filesystem/src/ripgrep-utils.ts
+++ b/packages/tools-filesystem/src/ripgrep-utils.ts
@@ -154,6 +154,30 @@ export async function ripgrepFiles(options: {
     };
 }
 
+export async function ripgrepWalkFiles(options: {
+    cwd: string;
+    globs?: string[];
+    onPath: (absolutePath: string) => boolean | Promise<boolean>;
+}): Promise<{ terminatedEarly: boolean } | null> {
+    if (!(await isRipgrepAvailable())) {
+        return null;
+    }
+
+    const args = ['--files', '--hidden', '--glob=!.git/*'];
+    for (const glob of options.globs ?? []) {
+        args.push(`--glob=${glob}`);
+    }
+
+    const result = await runRipgrepLines(args, {
+        cwd: options.cwd,
+        onLine: (line) => options.onPath(path.resolve(options.cwd, line)),
+    });
+
+    return {
+        terminatedEarly: result.terminatedEarly,
+    };
+}
+
 export async function ripgrepSearch(options: {
     cwd: string;
     pattern: string;

--- a/packages/tools-filesystem/src/ripgrep-utils.ts
+++ b/packages/tools-filesystem/src/ripgrep-utils.ts
@@ -177,6 +177,8 @@ export async function ripgrepSearch(options: {
     }
     if (options.literal) {
         args.push('-F');
+    } else {
+        args.push('-P');
     }
     for (const glob of options.globs ?? []) {
         args.push(`--glob=${glob}`);
@@ -186,46 +188,59 @@ export async function ripgrepSearch(options: {
         args.push(options.targetPath);
     }
 
-    const result = await runRipgrepLines(args, {
-        cwd: options.cwd,
-        onLine: (line) => {
-            let event: RipgrepJsonEvent;
-            try {
-                event = JSON.parse(line) as RipgrepJsonEvent;
-            } catch {
-                return true;
-            }
-
-            if (event.type === 'begin') {
-                const relativePath = event.data?.path?.text;
-                if (relativePath) {
-                    files.add(path.resolve(options.cwd, relativePath));
+    let result: RipgrepRunResult;
+    try {
+        result = await runRipgrepLines(args, {
+            cwd: options.cwd,
+            onLine: (line) => {
+                let event: RipgrepJsonEvent;
+                try {
+                    event = JSON.parse(line) as RipgrepJsonEvent;
+                } catch {
+                    return true;
                 }
-                return true;
-            }
 
-            if (event.type !== 'match') {
-                return true;
-            }
+                if (event.type === 'begin') {
+                    const relativePath = event.data?.path?.text;
+                    if (relativePath) {
+                        files.add(path.resolve(options.cwd, relativePath));
+                    }
+                    return true;
+                }
 
-            const relativePath = event.data?.path?.text;
-            const lineNumber = event.data?.line_number;
-            const lineText = event.data?.lines?.text;
-            if (!relativePath || typeof lineNumber !== 'number' || typeof lineText !== 'string') {
-                return true;
-            }
+                if (event.type !== 'match') {
+                    return true;
+                }
 
-            const absolutePath = path.resolve(options.cwd, relativePath);
-            files.add(absolutePath);
-            matches.push({
-                file: absolutePath,
-                lineNumber,
-                line: lineText.replace(/\r?\n$/, ''),
-            });
+                const relativePath = event.data?.path?.text;
+                const lineNumber = event.data?.line_number;
+                const lineText = event.data?.lines?.text;
+                if (
+                    !relativePath ||
+                    typeof lineNumber !== 'number' ||
+                    typeof lineText !== 'string'
+                ) {
+                    return true;
+                }
 
-            return matches.length < limit;
-        },
-    });
+                const absolutePath = path.resolve(options.cwd, relativePath);
+                files.add(absolutePath);
+                matches.push({
+                    file: absolutePath,
+                    lineNumber,
+                    line: lineText.replace(/\r?\n$/, ''),
+                });
+
+                return matches.length < limit;
+            },
+        });
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!options.literal && /pcre2|look-around|backreferences?/i.test(message)) {
+            return null;
+        }
+        throw error;
+    }
 
     return {
         matches,

--- a/packages/tools-filesystem/src/ripgrep-utils.ts
+++ b/packages/tools-filesystem/src/ripgrep-utils.ts
@@ -1,0 +1,235 @@
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import { createInterface } from 'node:readline';
+
+const STDERR_LIMIT = 8192;
+
+let ripgrepAvailabilityPromise: Promise<boolean> | null = null;
+
+type LineCollector = (line: string) => boolean | Promise<boolean>;
+
+type RipgrepRunResult = {
+    terminatedEarly: boolean;
+    exitCode: number | null;
+    stderr: string;
+};
+
+export type RipgrepMatch = {
+    file: string;
+    lineNumber: number;
+    line: string;
+};
+
+type RipgrepJsonEvent = {
+    type?: string;
+    data?: {
+        path?: {
+            text?: string;
+        };
+        line_number?: number;
+        lines?: {
+            text?: string;
+        };
+    };
+};
+
+function appendStderr(current: string, chunk: string): string {
+    const next = current + chunk;
+    if (next.length <= STDERR_LIMIT) {
+        return next;
+    }
+    return next.slice(0, STDERR_LIMIT);
+}
+
+async function runRipgrepLines(
+    args: string[],
+    options: {
+        cwd: string;
+        onLine: LineCollector;
+    }
+): Promise<RipgrepRunResult> {
+    const child = spawn('rg', args, {
+        cwd: options.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    let exitCode: number | null = null;
+    let terminatedEarly = false;
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+        stderr = appendStderr(stderr, chunk.toString());
+    });
+
+    const closePromise = new Promise<void>((resolve, reject) => {
+        child.once('error', reject);
+        child.once('close', (code) => {
+            exitCode = code;
+            resolve();
+        });
+    });
+
+    const rl = createInterface({
+        input: child.stdout,
+        crlfDelay: Infinity,
+    });
+
+    try {
+        for await (const line of rl) {
+            if (!line) {
+                continue;
+            }
+
+            const shouldContinue = await options.onLine(line);
+            if (!shouldContinue) {
+                terminatedEarly = true;
+                child.kill();
+                break;
+            }
+        }
+    } finally {
+        rl.close();
+        child.stdout.destroy();
+    }
+
+    await closePromise;
+
+    if (!terminatedEarly && exitCode !== 0 && exitCode !== 1) {
+        const message = stderr.trim() || `ripgrep exited with code ${exitCode ?? 'unknown'}`;
+        throw new Error(message);
+    }
+
+    return {
+        terminatedEarly,
+        exitCode,
+        stderr,
+    };
+}
+
+export async function isRipgrepAvailable(): Promise<boolean> {
+    if (ripgrepAvailabilityPromise) {
+        return ripgrepAvailabilityPromise;
+    }
+
+    ripgrepAvailabilityPromise = new Promise((resolve) => {
+        const child = spawn('rg', ['--version'], {
+            stdio: 'ignore',
+        });
+
+        child.once('error', () => resolve(false));
+        child.once('close', (code) => resolve(code === 0));
+    });
+
+    return ripgrepAvailabilityPromise;
+}
+
+export async function ripgrepFiles(options: {
+    cwd: string;
+    globs?: string[];
+    maxResults?: number;
+}): Promise<{ paths: string[]; truncated: boolean } | null> {
+    if (!(await isRipgrepAvailable())) {
+        return null;
+    }
+
+    const limit = options.maxResults ?? Number.POSITIVE_INFINITY;
+    const paths: string[] = [];
+
+    const args = ['--files', '--hidden', '--glob=!.git/*'];
+    for (const glob of options.globs ?? []) {
+        args.push(`--glob=${glob}`);
+    }
+
+    const result = await runRipgrepLines(args, {
+        cwd: options.cwd,
+        onLine: (line) => {
+            paths.push(path.resolve(options.cwd, line));
+            return paths.length < limit;
+        },
+    });
+
+    return {
+        paths,
+        truncated: result.terminatedEarly,
+    };
+}
+
+export async function ripgrepSearch(options: {
+    cwd: string;
+    pattern: string;
+    globs?: string[];
+    targetPath?: string;
+    caseInsensitive?: boolean;
+    literal?: boolean;
+    maxResults?: number;
+}): Promise<{ matches: RipgrepMatch[]; filesSearched: number; truncated: boolean } | null> {
+    if (!(await isRipgrepAvailable())) {
+        return null;
+    }
+
+    const limit = options.maxResults ?? Number.POSITIVE_INFINITY;
+    const matches: RipgrepMatch[] = [];
+    const files = new Set<string>();
+
+    const args = ['--json', '--hidden', '--no-messages', '-n', '--glob=!.git/*'];
+    if (options.caseInsensitive) {
+        args.push('-i');
+    }
+    if (options.literal) {
+        args.push('-F');
+    }
+    for (const glob of options.globs ?? []) {
+        args.push(`--glob=${glob}`);
+    }
+    args.push('--', options.pattern);
+    if (options.targetPath) {
+        args.push(options.targetPath);
+    }
+
+    const result = await runRipgrepLines(args, {
+        cwd: options.cwd,
+        onLine: (line) => {
+            let event: RipgrepJsonEvent;
+            try {
+                event = JSON.parse(line) as RipgrepJsonEvent;
+            } catch {
+                return true;
+            }
+
+            if (event.type === 'begin') {
+                const relativePath = event.data?.path?.text;
+                if (relativePath) {
+                    files.add(path.resolve(options.cwd, relativePath));
+                }
+                return true;
+            }
+
+            if (event.type !== 'match') {
+                return true;
+            }
+
+            const relativePath = event.data?.path?.text;
+            const lineNumber = event.data?.line_number;
+            const lineText = event.data?.lines?.text;
+            if (!relativePath || typeof lineNumber !== 'number' || typeof lineText !== 'string') {
+                return true;
+            }
+
+            const absolutePath = path.resolve(options.cwd, relativePath);
+            files.add(absolutePath);
+            matches.push({
+                file: absolutePath,
+                lineNumber,
+                line: lineText.replace(/\r?\n$/, ''),
+            });
+
+            return matches.length < limit;
+        },
+    });
+
+    return {
+        matches,
+        filesSearched: files.size,
+        truncated: result.terminatedEarly,
+    };
+}

--- a/packages/tools-filesystem/src/tool-factory-config.ts
+++ b/packages/tools-filesystem/src/tool-factory-config.ts
@@ -25,6 +25,8 @@ const DEFAULT_BACKUP_RETENTION_DAYS = 7;
 export const FILESYSTEM_TOOL_NAMES = [
     'read_file',
     'read_media_file',
+    'list_directory',
+    'find_paths',
     'write_file',
     'edit_file',
     'glob_files',

--- a/packages/tools-filesystem/src/tool-factory.ts
+++ b/packages/tools-filesystem/src/tool-factory.ts
@@ -4,6 +4,8 @@ import { ToolError } from '@dexto/core';
 import { FileSystemService } from './filesystem-service.js';
 import { createReadFileTool } from './read-file-tool.js';
 import { createReadMediaFileTool } from './read-media-file-tool.js';
+import { createListDirectoryTool } from './list-directory-tool.js';
+import { createFindPathsTool } from './find-paths-tool.js';
 import { createWriteFileTool } from './write-file-tool.js';
 import { createEditFileTool } from './edit-file-tool.js';
 import { createGlobFilesTool } from './glob-files-tool.js';
@@ -21,7 +23,7 @@ export const fileSystemToolsFactory: ToolFactory<FileSystemToolsConfig> = {
     configSchema: FileSystemToolsConfigSchema,
     metadata: {
         displayName: 'Filesystem Tools',
-        description: 'File system operations (read text/media, write, edit, glob, grep)',
+        description: 'File system operations (read, list, find, search, write, edit, media reads)',
         category: 'filesystem',
     },
     create: (config) => {
@@ -119,6 +121,8 @@ export const fileSystemToolsFactory: ToolFactory<FileSystemToolsConfig> = {
         const toolCreators: Record<FileSystemToolName, () => Tool> = {
             read_file: () => createReadFileTool(getFileSystemService),
             read_media_file: () => createReadMediaFileTool(getFileSystemService),
+            list_directory: () => createListDirectoryTool(getFileSystemService),
+            find_paths: () => createFindPathsTool(getFileSystemService),
             write_file: () => createWriteFileTool(getFileSystemService),
             edit_file: () => createEditFileTool(getFileSystemService),
             glob_files: () => createGlobFilesTool(getFileSystemService),

--- a/packages/tools-filesystem/src/types.ts
+++ b/packages/tools-filesystem/src/types.ts
@@ -29,6 +29,8 @@ export interface FileContent {
     mimeType?: string;
     truncated: boolean;
     size: number;
+    startLine?: number | undefined;
+    nextOffset?: number | undefined;
 }
 
 /**
@@ -179,6 +181,8 @@ export interface GrepOptions {
     path?: string | undefined;
     /** Glob pattern to filter files */
     glob?: string | undefined;
+    /** Treat pattern as literal text instead of regex */
+    literal?: boolean | undefined;
     /** Number of context lines before/after match */
     contextLines?: number | undefined;
     /** Case-insensitive search */
@@ -197,6 +201,37 @@ export interface SearchResult {
     totalMatches: number;
     truncated: boolean;
     filesSearched: number;
+}
+
+/**
+ * Match result for path discovery.
+ */
+export interface PathMatch {
+    path: string;
+    pathType: 'file' | 'directory';
+    score: number;
+}
+
+/**
+ * Options for path discovery.
+ */
+export interface FindPathsOptions {
+    /** Base directory to search */
+    path?: string | undefined;
+    /** Restrict results to a specific path type */
+    pathType?: 'file' | 'directory' | 'all' | undefined;
+    /** Maximum number of matches to return */
+    maxResults?: number | undefined;
+}
+
+/**
+ * Path discovery result.
+ */
+export interface FindPathsResult {
+    matches: PathMatch[];
+    totalMatches: number;
+    truncated: boolean;
+    searchPath: string;
 }
 
 /**

--- a/packages/tools-process/src/bash-exec-tool.ts
+++ b/packages/tools-process/src/bash-exec-tool.ts
@@ -57,7 +57,8 @@ export function createBashExecTool(
         description: `Execute a shell command in the project root directory.
 
 IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. Do NOT use it for file operations - use the specialized tools instead:
-- File search: Use glob_files (NOT find or ls)
+- Directory listing: Use list_directory (NOT ls)
+- Path discovery: Use find_paths or glob_files (NOT find)
 - Content search: Use grep_content (NOT grep or rg)
 - Read files: Use read_file (NOT cat/head/tail)
 - Edit files: Use edit_file (NOT sed/awk)

--- a/packages/tools-process/src/bash-exec-tool.ts
+++ b/packages/tools-process/src/bash-exec-tool.ts
@@ -64,11 +64,13 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. Do N
 - Edit files: Use edit_file (NOT sed/awk)
 - Write files: Use write_file (NOT echo/cat with heredoc)
 
+These are strong defaults because the specialized tools return structured, validated results and lead to higher success rates for repo exploration. Only use shell equivalents when shell behavior itself is required for the task.
+
 Before executing the command, follow these steps:
 
 1. Directory Verification:
-   - If the command will create new directories or files, first use ls to verify the parent directory exists and is the correct location
-   - For example, before running "mkdir foo/bar", first use ls foo to check that "foo" exists
+   - If the command will create new directories or files, first use list_directory to verify the parent directory exists and is the correct location
+   - For example, before running "mkdir foo/bar", first use list_directory on "foo" to check that "foo" exists
 
 2. Command Execution:
    - Always quote file paths that contain spaces with double quotes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tools to list directories and to find paths by query; find returns scored file/directory matches.

* **Enhancements**
  * Read-file responses now include pagination metadata (start line and next offset).
  * Content search defaults to literal matching with an optional regex mode.
  * Glob listing can optionally include per-file metadata.
  * Agents updated to begin discovery via directory listing/path-finding and granted those read permissions.

* **Tests**
  * Added tests for paginated reads, path discovery, and content search semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->