### PR TITLE
feat(tools): Support generic __meta tool metadata transport

### DIFF
--- a/.changeset/sweet-trees-drop.md
+++ b/.changeset/sweet-trees-drop.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Support extensible `__meta` on tool calls and forward that metadata through tool lifecycle events without passing it to tool execution.

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -20,6 +20,7 @@ import type { ConversationHistoryProvider } from '../session/history/types.js';
 import { ContextError } from './errors.js';
 import { ValidatedLLMConfig } from '../llm/schemas.js';
 import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
+import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 import { getResourceKind } from './media-helpers.js';
 
 /**
@@ -911,6 +912,7 @@ export class ContextManager<TMessage = unknown> {
             requireApproval?: boolean;
             approvalStatus?: 'approved' | 'rejected';
             presentationSnapshot?: ToolPresentationSnapshotV1;
+            meta?: ToolCallMetadata;
         }
     ): Promise<void> {
         if (!toolCallId || !name) {
@@ -947,6 +949,9 @@ export class ContextManager<TMessage = unknown> {
             name,
             ...(metadata?.presentationSnapshot !== undefined && {
                 presentationSnapshot: metadata.presentationSnapshot,
+            }),
+            ...(metadata?.meta !== undefined && {
+                meta: metadata.meta,
             }),
             // Success status comes from sanitizedResult.meta (single source of truth)
             success: sanitizedResult.meta.success,

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -1,6 +1,7 @@
 import type { LLMProvider, LLMPricingStatus, TokenUsage } from '../llm/types.js';
 import type { ToolDisplayData } from '../tools/display-types.js';
 import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
+import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 
 // =============================================================================
 // Content Part Types
@@ -309,6 +310,8 @@ export interface ToolMessage extends MessageBase {
 
     /** Optional UI-agnostic presentation snapshot for this tool call/result */
     presentationSnapshot?: ToolPresentationSnapshotV1;
+    /** Optional non-execution metadata from the reserved __meta wrapper */
+    meta?: ToolCallMetadata;
 
     /** Whether the tool execution was successful */
     success?: boolean;

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -6,6 +6,7 @@ import type { SanitizedToolResult } from '../context/types.js';
 import type { CodexRateLimitSnapshot } from '../llm/providers/codex-app-server.js';
 import type { WorkspaceContext } from '../workspace/types.js';
 import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
+import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 
 /**
  * LLM finish reason - why the LLM stopped generating
@@ -394,6 +395,8 @@ export interface AgentEventMap {
         /** Optional UI-agnostic presentation snapshot (clients MUST fall back when absent) */
         presentationSnapshot?: ToolPresentationSnapshotV1;
         args: Record<string, any>;
+        /** Optional non-execution metadata from the reserved __meta wrapper */
+        meta?: ToolCallMetadata;
         /** Optional user-facing description from tool call metadata (e.g., __meta.callDescription) */
         callDescription?: string;
         callId?: string;
@@ -416,6 +419,8 @@ export interface AgentEventMap {
         toolName: string;
         /** Optional UI-agnostic presentation snapshot (clients MUST fall back when absent) */
         presentationSnapshot?: ToolPresentationSnapshotV1;
+        /** Optional non-execution metadata from the reserved __meta wrapper */
+        meta?: ToolCallMetadata;
         callId?: string;
         success: boolean;
         /** Sanitized result - present when success=true */
@@ -670,6 +675,8 @@ export interface SessionEventMap {
         /** Optional UI-agnostic presentation snapshot (clients MUST fall back when absent) */
         presentationSnapshot?: ToolPresentationSnapshotV1;
         args: Record<string, any>;
+        /** Optional non-execution metadata from the reserved __meta wrapper */
+        meta?: ToolCallMetadata;
         /** Optional user-facing description from tool call metadata (e.g., __meta.callDescription) */
         callDescription?: string;
         callId?: string;
@@ -690,6 +697,8 @@ export interface SessionEventMap {
         toolName: string;
         /** Optional UI-agnostic presentation snapshot (clients MUST fall back when absent) */
         presentationSnapshot?: ToolPresentationSnapshotV1;
+        /** Optional non-execution metadata from the reserved __meta wrapper */
+        meta?: ToolCallMetadata;
         callId?: string;
         success: boolean;
         /** Sanitized result - present when success=true */

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -99,6 +99,7 @@ export type {
 
 // Event types (used by client-sdk package)
 export type { AgentEventMap, SessionEventMap } from './events/index.js';
+export type { ToolCallMetadata } from './tools/tool-call-metadata.js';
 
 // LLM registry types (used by client-sdk package)
 export type { ModelInfo, ProviderInfo } from './llm/registry/index.js';

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -5,6 +5,8 @@ import type { ContextManager } from '../../context/manager.js';
 import type { SessionEventBus } from '../../events/index.js';
 import type { ResourceManager } from '../../resources/index.js';
 import type { Logger } from '../../logger/v2/types.js';
+import type { ToolPresentationSnapshotV1 } from '../../tools/types.js';
+import type { ToolCallMetadata } from '../../tools/tool-call-metadata.js';
 
 /**
  * Creates a mock async generator that yields events
@@ -772,6 +774,84 @@ describe('StreamProcessor', () => {
                 })
             );
         });
+
+        test('propagates stored tool metadata for tool errors', async () => {
+            const mocks = createMocks();
+            const presentationSnapshot: ToolPresentationSnapshotV1 = {
+                version: 1,
+                header: { title: 'Command' },
+            };
+            const meta: ToolCallMetadata = {
+                reactiveUi: { type: 'open', surface: 'browser' },
+            };
+            const toolCallMetadata = new Map([
+                [
+                    'call-error',
+                    {
+                        presentationSnapshot,
+                        meta,
+                        requireApproval: true,
+                        approvalStatus: 'approved' as const,
+                    },
+                ],
+            ]);
+
+            const processor = new StreamProcessor(
+                mocks.contextManager,
+                mocks.eventBus,
+                mocks.resourceManager,
+                mocks.abortController.signal,
+                mocks.config,
+                mocks.logger,
+                true,
+                toolCallMetadata
+            );
+
+            const events = [
+                {
+                    type: 'tool-error',
+                    toolCallId: 'call-error',
+                    toolName: 'bash',
+                    error: new Error('boom'),
+                },
+                {
+                    type: 'finish',
+                    finishReason: 'stop',
+                    totalUsage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                },
+            ];
+
+            await processor.process(() => createMockStream(events) as never);
+
+            expect(mocks.contextManager.addToolResult).toHaveBeenCalledWith(
+                'call-error',
+                'bash',
+                expect.objectContaining({
+                    meta: expect.objectContaining({
+                        success: false,
+                    }),
+                }),
+                expect.objectContaining({
+                    presentationSnapshot,
+                    meta,
+                    requireApproval: true,
+                    approvalStatus: 'approved',
+                })
+            );
+
+            const toolResultEvent = mocks.emittedEvents.find((e) => e.name === 'llm:tool-result');
+            expect(toolResultEvent?.payload).toMatchObject({
+                toolName: 'bash',
+                callId: 'call-error',
+                success: false,
+                error: 'boom',
+                meta,
+                presentationSnapshot,
+                requireApproval: true,
+                approvalStatus: 'approved',
+            });
+            expect(toolCallMetadata.size).toBe(0);
+        });
     });
 
     describe('Finish Event Handling', () => {
@@ -1315,6 +1395,81 @@ describe('StreamProcessor', () => {
             expect(
                 (responseEvent?.payload as { estimatedCost?: number } | undefined)?.estimatedCost
             ).toBeGreaterThan(0);
+        });
+
+        test('propagates stored tool metadata for cancelled pending tool calls', async () => {
+            const mocks = createMocks();
+            const presentationSnapshot: ToolPresentationSnapshotV1 = {
+                version: 1,
+                header: { title: 'Preview App' },
+            };
+            const meta: ToolCallMetadata = {
+                reactiveUi: {
+                    type: 'open',
+                    surface: 'workspace',
+                    target: { kind: 'app', appId: 'smoke-app' },
+                },
+            };
+            const toolCallMetadata = new Map([
+                [
+                    'call-cancelled',
+                    {
+                        presentationSnapshot,
+                        meta,
+                    },
+                ],
+            ]);
+
+            const abortingStream = {
+                fullStream: (async function* () {
+                    yield {
+                        type: 'tool-call',
+                        toolCallId: 'call-cancelled',
+                        toolName: 'bash',
+                        input: { command: 'echo hi' },
+                    };
+                    yield { type: 'abort' };
+                })(),
+            };
+
+            const processor = new StreamProcessor(
+                mocks.contextManager,
+                mocks.eventBus,
+                mocks.resourceManager,
+                mocks.abortController.signal,
+                mocks.config,
+                mocks.logger,
+                true,
+                toolCallMetadata
+            );
+
+            await processor.process(() => abortingStream as never);
+
+            expect(mocks.contextManager.addToolResult).toHaveBeenCalledWith(
+                'call-cancelled',
+                'bash',
+                expect.objectContaining({
+                    content: [{ type: 'text', text: 'Cancelled by user' }],
+                    meta: expect.objectContaining({
+                        success: false,
+                    }),
+                }),
+                expect.objectContaining({
+                    presentationSnapshot,
+                    meta,
+                })
+            );
+
+            const toolResultEvent = mocks.emittedEvents.find((e) => e.name === 'llm:tool-result');
+            expect(toolResultEvent?.payload).toMatchObject({
+                toolName: 'bash',
+                callId: 'call-cancelled',
+                success: false,
+                error: 'Cancelled by user',
+                meta,
+                presentationSnapshot,
+            });
+            expect(toolCallMetadata.size).toBe(0);
         });
     });
 

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -481,6 +481,7 @@ export class StreamProcessor {
                             event.error instanceof Error
                                 ? event.error.message
                                 : String(event.error);
+                        const metadata = this.toolCallMetadata?.get(event.toolCallId);
 
                         // CRITICAL: Must persist error result to history to maintain tool_use/tool_result pairing
                         // Without this, the conversation history has tool_use without tool_result,
@@ -498,14 +499,26 @@ export class StreamProcessor {
                             event.toolCallId,
                             event.toolName,
                             errorResult,
-                            undefined // No approval metadata for errors
+                            metadata
                         );
 
                         this.eventBus.emit('llm:tool-result', {
                             toolName: event.toolName,
+                            ...(metadata?.presentationSnapshot !== undefined && {
+                                presentationSnapshot: metadata.presentationSnapshot,
+                            }),
+                            ...(metadata?.meta !== undefined && {
+                                meta: metadata.meta,
+                            }),
                             callId: event.toolCallId,
                             success: false,
                             error: errorMessage,
+                            ...(metadata?.requireApproval !== undefined && {
+                                requireApproval: metadata.requireApproval,
+                            }),
+                            ...(metadata?.approvalStatus !== undefined && {
+                                approvalStatus: metadata.approvalStatus,
+                            }),
                         });
 
                         this.eventBus.emit('llm:error', {
@@ -517,6 +530,7 @@ export class StreamProcessor {
                             toolCallId: event.toolCallId,
                             recoverable: true, // Tool errors are typically recoverable
                         });
+                        this.toolCallMetadata?.delete(event.toolCallId);
                         // Remove from pending (tool failed but result was persisted)
                         this.pendingToolCalls.delete(event.toolCallId);
                         this.partialToolCalls.delete(event.toolCallId);
@@ -832,6 +846,7 @@ export class StreamProcessor {
         );
 
         for (const [toolCallId, { toolName }] of this.pendingToolCalls) {
+            const metadata = this.toolCallMetadata?.get(toolCallId);
             const cancelledResult: SanitizedToolResult = {
                 content: [{ type: 'text', text: 'Cancelled by user' }],
                 meta: {
@@ -845,16 +860,29 @@ export class StreamProcessor {
                 toolCallId,
                 toolName,
                 cancelledResult,
-                undefined // No approval metadata for cancelled tools
+                metadata
             );
 
             // Emit tool-result event so CLI/WebUI can update UI
             this.eventBus.emit('llm:tool-result', {
                 toolName,
+                ...(metadata?.presentationSnapshot !== undefined && {
+                    presentationSnapshot: metadata.presentationSnapshot,
+                }),
+                ...(metadata?.meta !== undefined && {
+                    meta: metadata.meta,
+                }),
                 callId: toolCallId,
                 success: false,
                 error: 'Cancelled by user',
+                ...(metadata?.requireApproval !== undefined && {
+                    requireApproval: metadata.requireApproval,
+                }),
+                ...(metadata?.approvalStatus !== undefined && {
+                    approvalStatus: metadata.approvalStatus,
+                }),
             });
+            this.toolCallMetadata?.delete(toolCallId);
         }
 
         this.pendingToolCalls.clear();

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -9,6 +9,7 @@ import type { SanitizedToolResult } from '../../context/types.js';
 import type { Logger } from '../../logger/v2/types.js';
 import { DextoLogComponent } from '../../logger/v2/types.js';
 import type { ToolPresentationSnapshotV1 } from '../../tools/types.js';
+import type { ToolCallMetadata } from '../../tools/tool-call-metadata.js';
 import { getUsagePricingMetadata } from '../usage-metadata.js';
 import type { LLMProvider, LLMPricingStatus, ReasoningVariant, TokenUsage } from '../types.js';
 
@@ -105,6 +106,7 @@ export class StreamProcessor {
             string,
             {
                 presentationSnapshot?: ToolPresentationSnapshotV1;
+                meta?: ToolCallMetadata;
                 requireApproval?: boolean;
                 approvalStatus?: 'approved' | 'rejected';
             }
@@ -315,6 +317,9 @@ export class StreamProcessor {
                             toolName: event.toolName,
                             ...(metadata?.presentationSnapshot !== undefined && {
                                 presentationSnapshot: metadata.presentationSnapshot,
+                            }),
+                            ...(metadata?.meta !== undefined && {
+                                meta: metadata.meta,
                             }),
                             callId: event.toolCallId,
                             success: true,

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -20,6 +20,7 @@ import type {
 import { ToolManager } from '../../tools/tool-manager.js';
 import { ToolSet } from '../../tools/types.js';
 import type { ToolPresentationSnapshotV1 } from '../../tools/types.js';
+import type { ToolCallMetadata } from '../../tools/tool-call-metadata.js';
 import { StreamProcessor } from './stream-processor.js';
 import { ExecutorResult } from './types.js';
 import { buildProviderOptions, getEffectiveReasoningBudgetTokens } from './provider-options.js';
@@ -88,6 +89,7 @@ export class TurnExecutor {
         string,
         {
             presentationSnapshot?: ToolPresentationSnapshotV1;
+            meta?: ToolCallMetadata;
             requireApproval?: boolean;
             approvalStatus?: 'approved' | 'rejected';
         }
@@ -703,12 +705,14 @@ export class TurnExecutor {
                                     const metadata:
                                         | {
                                               presentationSnapshot?: ToolPresentationSnapshotV1;
+                                              meta?: ToolCallMetadata;
                                               requireApproval?: boolean;
                                               approvalStatus?: 'approved' | 'rejected';
                                           }
                                         | undefined = (() => {
                                         const meta: {
                                             presentationSnapshot?: ToolPresentationSnapshotV1;
+                                            meta?: ToolCallMetadata;
                                             requireApproval?: boolean;
                                             approvalStatus?: 'approved' | 'rejected';
                                         } = {};
@@ -716,6 +720,9 @@ export class TurnExecutor {
                                         if (executionResult.presentationSnapshot !== undefined) {
                                             meta.presentationSnapshot =
                                                 executionResult.presentationSnapshot;
+                                        }
+                                        if (executionResult.meta !== undefined) {
+                                            meta.meta = executionResult.meta;
                                         }
 
                                         // Store approval metadata for later retrieval by StreamProcessor

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -19,6 +19,7 @@ export * from './schemas.js';
 
 // Presentation helpers
 export * from './presentation.js';
+export type { ToolCallMetadata, ToolCallMetaWrapper } from './tool-call-metadata.js';
 
 // Tool errors and error codes
 export { ToolError } from './errors.js';

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -1,6 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
 
-export type ToolCallMetadata = {
+export type ToolCallMetadata = Record<string, unknown> & {
     runInBackground?: boolean;
     timeoutMs?: number;
     notifyOnComplete?: boolean;
@@ -31,7 +31,7 @@ const META_SCHEMA: JSONSchema7 = {
             description: 'Optional description shown to the user when requesting approval.',
         },
     },
-    additionalProperties: false,
+    additionalProperties: true,
 };
 
 const META_KEY = '__meta';

--- a/packages/core/src/tools/tool-manager.integration.test.ts
+++ b/packages/core/src/tools/tool-manager.integration.test.ts
@@ -273,6 +273,13 @@ describe('ToolManager Integration Tests', () => {
                 properties?: Record<string, unknown>;
             };
             expect(mcpParams.properties?.__meta).toBeDefined();
+            expect(
+                (
+                    mcpParams.properties?.__meta as {
+                        additionalProperties?: boolean;
+                    }
+                ).additionalProperties
+            ).toBe(true);
 
             // Execute both types
             const mcpResult = await toolManager.executeTool(

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -448,6 +448,78 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             );
         });
 
+        it('should emit __meta as generic tool-call metadata while stripping it from args', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
+
+            const tool = defineTool({
+                id: 'typed',
+                description: 'Typed tool',
+                inputSchema: z
+                    .object({
+                        count: z.number().int(),
+                    })
+                    .strict(),
+                execute: vi.fn().mockResolvedValue('ok'),
+            });
+
+            const toolManager = new ToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'auto-approve',
+                mockAgentEventBus,
+                { alwaysAllow: [], alwaysDeny: [] },
+                [tool],
+                mockLogger
+            );
+            toolManager.setToolExecutionContextFactory((baseContext) => baseContext);
+
+            const result = await toolManager.executeTool(
+                'typed',
+                {
+                    count: 5,
+                    __meta: {
+                        callDescription: 'Read test file',
+                        reactiveUi: {
+                            type: 'open',
+                            surface: 'browser',
+                        },
+                    },
+                },
+                'call-1',
+                'session-1'
+            );
+
+            expect(mockAgentEventBus.emit).toHaveBeenCalledWith(
+                'llm:tool-call',
+                expect.objectContaining({
+                    toolName: 'typed',
+                    args: { count: 5 },
+                    meta: {
+                        callDescription: 'Read test file',
+                        reactiveUi: {
+                            type: 'open',
+                            surface: 'browser',
+                        },
+                    },
+                    callDescription: 'Read test file',
+                    callId: 'call-1',
+                    sessionId: 'session-1',
+                })
+            );
+            expect(result).toEqual(
+                expect.objectContaining({
+                    meta: {
+                        callDescription: 'Read test file',
+                        reactiveUi: {
+                            type: 'open',
+                            surface: 'browser',
+                        },
+                    },
+                })
+            );
+        });
+
         it('should emit callDescription on llm:tool-call events when args.description is provided', async () => {
             mockMcpManager.executeTool = vi.fn().mockResolvedValue('result');
 

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -31,7 +31,11 @@ import type { BeforeToolCallPayload, AfterToolResultPayload } from '../hooks/typ
 import type { WorkspaceManager } from '../workspace/manager.js';
 import type { WorkspaceContext } from '../workspace/types.js';
 import { InstrumentClass } from '../telemetry/decorators.js';
-import { extractToolCallMeta, wrapToolParametersSchema } from './tool-call-metadata.js';
+import {
+    extractToolCallMeta,
+    wrapToolParametersSchema,
+    type ToolCallMetadata,
+} from './tool-call-metadata.js';
 import { isBackgroundTasksEnabled } from '../utils/env.js';
 import type {
     DynamicContributorContext,
@@ -1346,6 +1350,8 @@ export class ToolManager {
         abortSignal?: AbortSignal
     ): Promise<import('./types.js').ToolExecutionResult> {
         const { toolArgs: rawToolArgs, meta } = extractToolCallMeta(args);
+        const eventMeta: ToolCallMetadata | undefined =
+            Object.keys(meta).length > 0 ? meta : undefined;
         let toolArgs = rawToolArgs;
         const callDescription =
             typeof meta.callDescription === 'string'
@@ -1378,6 +1384,7 @@ export class ToolManager {
                 toolName,
                 presentationSnapshot,
                 args: toolArgs,
+                ...(eventMeta !== undefined ? { meta: eventMeta } : {}),
                 ...(callDescription !== undefined && { callDescription }),
                 callId: toolCallId,
                 sessionId,
@@ -1597,6 +1604,7 @@ export class ToolManager {
             return {
                 result,
                 ...(presentationSnapshot !== undefined && { presentationSnapshot }),
+                ...(eventMeta !== undefined ? { meta: eventMeta } : {}),
                 ...(requireApproval && { requireApproval, approvalStatus }),
             };
         } catch (error) {

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -108,6 +108,8 @@ export interface ToolExecutionResult {
     result: unknown;
     /** Optional UI-agnostic presentation snapshot for this call/result */
     presentationSnapshot?: ToolPresentationSnapshotV1;
+    /** Optional non-execution metadata carried through the tool lifecycle */
+    meta?: import('./tool-call-metadata.js').ToolCallMetadata;
     /** Whether this tool required user approval before execution */
     requireApproval?: boolean;
     /** The approval status (only present if requireApproval is true) */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool calls can include optional, extensible custom metadata that is carried with tool-call events and appears on tool results (including errors and cancellations), enabling richer context and configuration surfaced in event payloads.

* **Tests**
  * Added tests ensuring this metadata is preserved and propagated across tool-call events, results, cancellations, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->