### PR TITLE
[codex] Add cost fields to LLM usage analytics

### DIFF
--- a/.changeset/few-apes-judge.md
+++ b/.changeset/few-apes-judge.md
@@ -1,0 +1,16 @@
+---
+'dexto': patch
+'@dexto/analytics': patch
+'@dexto/core': patch
+'@dexto/server': patch
+'@dexto/tui': patch
+'@dexto/webui': patch
+---
+
+Publish LLM usage analytics cost metrics.
+
+- `dexto` / `@dexto/tui`: include estimated USD cost and per-bucket cost fields in CLI LLM usage analytics.
+- `@dexto/webui`: include estimated USD cost and per-bucket cost fields in WebUI LLM usage analytics.
+- `@dexto/analytics`: extend the shared `dexto_llm_tokens_consumed` event payload with cost fields.
+- `@dexto/core`: emit `costBreakdown` alongside `estimatedCost` from shared LLM pricing metadata.
+- `@dexto/server`: forward the emitted cost breakdown through usage delivery and A2A SSE events.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.6.21",
+    "version": "1.6.22",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/analytics/src/events.ts
+++ b/packages/analytics/src/events.ts
@@ -24,6 +24,18 @@ export interface LLMTokensConsumedEvent {
     totalTokens?: number | undefined;
     cacheReadTokens?: number | undefined;
     cacheWriteTokens?: number | undefined;
+    /** Total estimated cost in USD for the response, when pricing is available. */
+    estimatedCostUsd?: number | undefined;
+    /** Estimated input-token cost in USD for the response, when pricing is available. */
+    inputCostUsd?: number | undefined;
+    /** Estimated output-token cost in USD for the response, when pricing is available. */
+    outputCostUsd?: number | undefined;
+    /** Estimated reasoning-token cost in USD for the response, when pricing is available. */
+    reasoningCostUsd?: number | undefined;
+    /** Estimated cache-read cost in USD for the response, when pricing is available. */
+    cacheReadCostUsd?: number | undefined;
+    /** Estimated cache-write cost in USD for the response, when pricing is available. */
+    cacheWriteCostUsd?: number | undefined;
     /** Estimated input tokens (before LLM call, using length/4 heuristic) */
     estimatedInputTokens?: number | undefined;
     /** Accuracy of estimate vs actual: (estimated - actual) / actual * 100 */

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events';
 import type { LLMProvider, LLMPricingStatus, ReasoningVariant, TokenUsage } from '../llm/types.js';
+import type { TokenUsageCostBreakdown } from '../llm/registry/index.js';
 import type { AgentRuntimeSettings } from '../agent/runtime-config.js';
 import type { ApprovalRequest, ApprovalResponse } from '../approval/types.js';
 import type { SanitizedToolResult } from '../context/types.js';
@@ -371,6 +372,8 @@ export interface AgentEventMap {
         usageScopeId?: string;
         /** Estimated cost in USD for this response, when pricing is available. */
         estimatedCost?: number;
+        /** Estimated token-cost breakdown in USD for this response, when pricing is available. */
+        costBreakdown?: TokenUsageCostBreakdown;
         /** Whether pricing was resolved for this response. */
         pricingStatus?: LLMPricingStatus;
         /** Estimated input tokens before LLM call (for analytics/calibration) */
@@ -649,6 +652,8 @@ export interface SessionEventMap {
         usageScopeId?: string;
         /** Estimated cost in USD for this response, when pricing is available. */
         estimatedCost?: number;
+        /** Estimated token-cost breakdown in USD for this response, when pricing is available. */
+        costBreakdown?: TokenUsageCostBreakdown;
         /** Whether pricing was resolved for this response. */
         pricingStatus?: LLMPricingStatus;
         /** Estimated input tokens before LLM call (for analytics/calibration) */

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -1105,6 +1105,11 @@ describe('StreamProcessor', () => {
                 messageId: 'msg-1',
                 provider: 'openai',
                 model: 'gpt-4',
+                costBreakdown: {
+                    inputUsd: expect.any(Number),
+                    outputUsd: expect.any(Number),
+                    totalUsd: expect.any(Number),
+                },
                 pricingStatus: 'estimated',
                 tokenUsage: {
                     inputTokens: 100,
@@ -1303,6 +1308,11 @@ describe('StreamProcessor', () => {
             const responseEvent = mocks.emittedEvents.find((e) => e.name === 'llm:response');
             expect(responseEvent?.payload).toMatchObject({
                 finishReason: 'cancelled',
+                costBreakdown: {
+                    inputUsd: expect.any(Number),
+                    outputUsd: expect.any(Number),
+                    totalUsd: expect.any(Number),
+                },
                 pricingStatus: 'estimated',
                 tokenUsage: {
                     inputTokens: 12,

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -10,6 +10,7 @@ import type { Logger } from '../../logger/v2/types.js';
 import { DextoLogComponent } from '../../logger/v2/types.js';
 import type { ToolPresentationSnapshotV1 } from '../../tools/types.js';
 import { getUsagePricingMetadata } from '../usage-metadata.js';
+import type { TokenUsageCostBreakdown } from '../registry/index.js';
 import type { LLMProvider, LLMPricingStatus, ReasoningVariant, TokenUsage } from '../types.js';
 
 type UsageLike = {
@@ -714,6 +715,7 @@ export class StreamProcessor {
         tokenUsage: TokenUsage;
         finishReason: LLMFinishReason;
         estimatedCost?: number;
+        costBreakdown?: TokenUsageCostBreakdown;
         pricingStatus?: LLMPricingStatus;
     }): void {
         this.eventBus.emit('llm:response', {
@@ -727,6 +729,9 @@ export class StreamProcessor {
             ...(this.usageScopeId && { usageScopeId: this.usageScopeId }),
             ...(config.estimatedCost !== undefined && {
                 estimatedCost: config.estimatedCost,
+            }),
+            ...(config.costBreakdown && {
+                costBreakdown: config.costBreakdown,
             }),
             ...(config.pricingStatus && { pricingStatus: config.pricingStatus }),
             ...(this.config.estimatedInputTokens !== undefined && {

--- a/packages/core/src/llm/usage-metadata.ts
+++ b/packages/core/src/llm/usage-metadata.ts
@@ -1,9 +1,14 @@
-import { calculateCost, getModelPricing } from './registry/index.js';
+import {
+    calculateCostBreakdown,
+    getModelPricing,
+    type TokenUsageCostBreakdown,
+} from './registry/index.js';
 import type { LLMProvider, LLMPricingStatus, TokenUsage } from './types.js';
 
 export interface LLMUsagePricingMetadata {
     estimatedCost?: number;
     pricingStatus?: LLMPricingStatus;
+    costBreakdown?: TokenUsageCostBreakdown;
 }
 
 export function hasMeaningfulTokenUsage(tokenUsage: TokenUsage | undefined): boolean {
@@ -38,10 +43,12 @@ export function getUsagePricingMetadata(config: {
     }
 
     // TODO(llm-pricing): Handle totalTokens-only usage without reporting a false zero-cost
-    // estimate. calculateCost() prices detailed token buckets only, so this path should
+    // estimate. calculateCostBreakdown() prices detailed token buckets only, so this path should
     // eventually distinguish "insufficient token detail" from a real zero-cost estimate.
+    const costBreakdown = calculateCostBreakdown(tokenUsage, pricing);
     return {
-        estimatedCost: calculateCost(tokenUsage, pricing),
+        estimatedCost: costBreakdown.totalUsd,
         pricingStatus: 'estimated',
+        costBreakdown,
     };
 }

--- a/packages/server/src/events/a2a-sse-subscriber.ts
+++ b/packages/server/src/events/a2a-sse-subscriber.ts
@@ -149,6 +149,9 @@ export class A2ASseEventSubscriber {
                     ...(payload.estimatedCost !== undefined && {
                         estimatedCost: payload.estimatedCost,
                     }),
+                    ...(payload.costBreakdown && {
+                        costBreakdown: payload.costBreakdown,
+                    }),
                     ...(payload.pricingStatus && { pricingStatus: payload.pricingStatus }),
                 });
             },

--- a/packages/server/src/events/usage-event-subscriber.ts
+++ b/packages/server/src/events/usage-event-subscriber.ts
@@ -154,7 +154,8 @@ export class UsageEventSubscriber implements EventSubscriber {
         }
 
         const resolvedCostBreakdown =
-            payload.provider && payload.model
+            payload.costBreakdown ??
+            (payload.provider && payload.model
                 ? (() => {
                       const pricing = getModelPricing(payload.provider, payload.model);
                       if (!pricing) {
@@ -163,7 +164,7 @@ export class UsageEventSubscriber implements EventSubscriber {
 
                       return calculateCostBreakdown(payload.tokenUsage, pricing);
                   })()
-                : undefined;
+                : undefined);
         const resolvedEstimatedCost = payload.estimatedCost ?? resolvedCostBreakdown?.totalUsd;
 
         return {

--- a/packages/tui/src/services/processStream.test.ts
+++ b/packages/tui/src/services/processStream.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type React from 'react';
 import type { QueuedMessage, StreamingEvent } from '@dexto/core';
 import type { Message, UIState, SessionState } from '../state/types.js';
 import { processStream } from './processStream.js';
 import type { ApprovalRequest } from '../components/ApprovalPrompt.js';
+
+const { captureAnalyticsMock } = vi.hoisted(() => ({
+    captureAnalyticsMock: vi.fn(),
+}));
+
+vi.mock('../host/index.js', () => ({
+    captureAnalytics: captureAnalyticsMock,
+}));
 
 type SetStateAction<T> = React.SetStateAction<T>;
 type Dispatch<T> = React.Dispatch<SetStateAction<T>>;
@@ -93,6 +101,10 @@ function createSetters() {
 }
 
 describe('processStream (reasoning)', () => {
+    beforeEach(() => {
+        captureAnalyticsMock.mockClear();
+    });
+
     it('attaches streamed reasoning chunks to the assistant message', async () => {
         const { getMessages, getPendingMessages, setters } = createSetters();
 
@@ -294,5 +306,62 @@ describe('processStream (reasoning)', () => {
 
         expect(assistantMessages[1]?.content).toBe('Final');
         expect(assistantMessages[1]?.reasoning).toBeUndefined();
+    });
+
+    it('captures analytics cost fields for priced llm responses', async () => {
+        const { setters } = createSetters();
+
+        const events: StreamingEvent[] = [
+            { name: 'llm:thinking', sessionId: 'test-session' },
+            {
+                name: 'llm:response',
+                sessionId: 'test-session',
+                content: 'Priced response',
+                provider: 'openai',
+                model: 'gpt-4',
+                estimatedCost: 0.0015,
+                costBreakdown: {
+                    inputUsd: 0.001,
+                    outputUsd: 0.0005,
+                    reasoningUsd: 0,
+                    cacheReadUsd: 0,
+                    cacheWriteUsd: 0,
+                    totalUsd: 0.0015,
+                },
+                tokenUsage: {
+                    inputTokens: 10,
+                    outputTokens: 20,
+                    totalTokens: 30,
+                },
+            },
+            {
+                name: 'run:complete',
+                sessionId: 'test-session',
+                finishReason: 'stop',
+                stepCount: 1,
+                durationMs: 1,
+            },
+        ];
+
+        await processStream(eventStream(events), setters, {
+            useStreaming: false,
+            autoApproveEditsRef: { current: false },
+            bypassPermissionsRef: { current: false },
+            eventBus: { emit: vi.fn() },
+        });
+
+        expect(captureAnalyticsMock).toHaveBeenCalledWith(
+            'dexto_llm_tokens_consumed',
+            expect.objectContaining({
+                source: 'cli',
+                sessionId: 'test-session',
+                estimatedCostUsd: 0.0015,
+                inputCostUsd: 0.001,
+                outputCostUsd: 0.0005,
+                reasoningCostUsd: 0,
+                cacheReadCostUsd: 0,
+                cacheWriteCostUsd: 0,
+            })
+        );
     });
 });

--- a/packages/tui/src/services/processStream.ts
+++ b/packages/tui/src/services/processStream.ts
@@ -116,6 +116,28 @@ interface StreamState {
     nonStreamingAccumulatedReasoning: string;
 }
 
+function hasMeaningfulTokenUsageForAnalytics(
+    tokenUsage: Extract<StreamingEvent, { name: 'llm:response' }>['tokenUsage'],
+    estimatedCost?: number
+): boolean {
+    if (estimatedCost !== undefined) {
+        return true;
+    }
+
+    if (!tokenUsage) {
+        return false;
+    }
+
+    return (
+        (tokenUsage.inputTokens ?? 0) > 0 ||
+        (tokenUsage.outputTokens ?? 0) > 0 ||
+        (tokenUsage.reasoningTokens ?? 0) > 0 ||
+        (tokenUsage.cacheReadTokens ?? 0) > 0 ||
+        (tokenUsage.cacheWriteTokens ?? 0) > 0 ||
+        (tokenUsage.totalTokens ?? 0) > 0
+    );
+}
+
 /**
  * Processes the async iterator from agent.stream() and updates UI state.
  *
@@ -546,19 +568,14 @@ export async function processStream(
 
                     // Track token usage analytics
                     if (
-                        event.tokenUsage &&
-                        (event.tokenUsage.inputTokens || event.tokenUsage.outputTokens)
+                        hasMeaningfulTokenUsageForAnalytics(event.tokenUsage, event.estimatedCost)
                     ) {
                         // Calculate estimate accuracy if both estimate and actual are available
                         let estimateAccuracyPercent: number | undefined;
-                        if (
-                            event.estimatedInputTokens !== undefined &&
-                            event.tokenUsage.inputTokens
-                        ) {
-                            const diff = event.estimatedInputTokens - event.tokenUsage.inputTokens;
-                            estimateAccuracyPercent = Math.round(
-                                (diff / event.tokenUsage.inputTokens) * 100
-                            );
+                        const actualInputTokens = event.tokenUsage?.inputTokens;
+                        if (event.estimatedInputTokens !== undefined && actualInputTokens) {
+                            const diff = event.estimatedInputTokens - actualInputTokens;
+                            estimateAccuracyPercent = Math.round((diff / actualInputTokens) * 100);
                         }
 
                         captureAnalytics('dexto_llm_tokens_consumed', {
@@ -568,12 +585,18 @@ export async function processStream(
                             model: event.model,
                             reasoningVariant: event.reasoningVariant ?? undefined,
                             reasoningBudgetTokens: event.reasoningBudgetTokens ?? undefined,
-                            inputTokens: event.tokenUsage.inputTokens,
-                            outputTokens: event.tokenUsage.outputTokens,
-                            reasoningTokens: event.tokenUsage.reasoningTokens,
-                            totalTokens: event.tokenUsage.totalTokens,
-                            cacheReadTokens: event.tokenUsage.cacheReadTokens,
-                            cacheWriteTokens: event.tokenUsage.cacheWriteTokens,
+                            inputTokens: event.tokenUsage?.inputTokens,
+                            outputTokens: event.tokenUsage?.outputTokens,
+                            reasoningTokens: event.tokenUsage?.reasoningTokens,
+                            totalTokens: event.tokenUsage?.totalTokens,
+                            cacheReadTokens: event.tokenUsage?.cacheReadTokens,
+                            cacheWriteTokens: event.tokenUsage?.cacheWriteTokens,
+                            estimatedCostUsd: event.estimatedCost,
+                            inputCostUsd: event.costBreakdown?.inputUsd,
+                            outputCostUsd: event.costBreakdown?.outputUsd,
+                            reasoningCostUsd: event.costBreakdown?.reasoningUsd,
+                            cacheReadCostUsd: event.costBreakdown?.cacheReadUsd,
+                            cacheWriteCostUsd: event.costBreakdown?.cacheWriteUsd,
                             estimatedInputTokens: event.estimatedInputTokens,
                             estimateAccuracyPercent,
                         });

--- a/packages/webui/lib/events/handlers.test.ts
+++ b/packages/webui/lib/events/handlers.test.ts
@@ -27,6 +27,14 @@ import {
 import { useChatStore } from '../stores/chatStore.js';
 import { useAgentStore } from '../stores/agentStore.js';
 
+const { captureTokenUsageMock } = vi.hoisted(() => ({
+    captureTokenUsageMock: vi.fn(),
+}));
+
+vi.mock('../analytics/capture.js', () => ({
+    captureTokenUsage: captureTokenUsageMock,
+}));
+
 // Mock generateMessageId to return predictable IDs
 vi.mock('../stores/chatStore.js', async () => {
     const actual = await vi.importActual('../stores/chatStore.js');
@@ -189,6 +197,51 @@ describe('Event Handler Registry', () => {
             expect(chatState.messages[0].tokenUsage).toEqual(event.tokenUsage);
             expect(chatState.messages[0].model).toBe('gpt-4');
             expect(chatState.messages[0].provider).toBe('openai');
+        });
+
+        it('should capture analytics cost fields for priced responses', () => {
+            useChatStore.getState().setStreamingMessage(TEST_SESSION_ID, {
+                id: 'msg-1',
+                role: 'assistant',
+                content: 'Response content',
+                createdAt: Date.now(),
+            });
+
+            const event: Extract<StreamingEvent, { name: 'llm:response' }> = {
+                name: 'llm:response',
+                sessionId: TEST_SESSION_ID,
+                content: 'Response content',
+                provider: 'openai',
+                model: 'gpt-4',
+                estimatedCost: 0.0015,
+                costBreakdown: {
+                    inputUsd: 0.001,
+                    outputUsd: 0.0005,
+                    reasoningUsd: 0,
+                    cacheReadUsd: 0,
+                    cacheWriteUsd: 0,
+                    totalUsd: 0.0015,
+                },
+                tokenUsage: {
+                    inputTokens: 10,
+                    outputTokens: 20,
+                    totalTokens: 30,
+                },
+            };
+
+            handleLLMResponse(event);
+
+            expect(captureTokenUsageMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    sessionId: TEST_SESSION_ID,
+                    estimatedCostUsd: 0.0015,
+                    inputCostUsd: 0.001,
+                    outputCostUsd: 0.0005,
+                    reasoningCostUsd: 0,
+                    cacheReadCostUsd: 0,
+                    cacheWriteCostUsd: 0,
+                })
+            );
         });
     });
 

--- a/packages/webui/lib/events/handlers.ts
+++ b/packages/webui/lib/events/handlers.ts
@@ -121,6 +121,28 @@ function getApprovalRequestToolContext(event: EventByName<'approval:request'>): 
     };
 }
 
+function hasMeaningfulTokenUsageForAnalytics(
+    tokenUsage: EventByName<'llm:response'>['tokenUsage'],
+    estimatedCost?: number
+): boolean {
+    if (estimatedCost !== undefined) {
+        return true;
+    }
+
+    if (!tokenUsage) {
+        return false;
+    }
+
+    return (
+        (tokenUsage.inputTokens ?? 0) > 0 ||
+        (tokenUsage.outputTokens ?? 0) > 0 ||
+        (tokenUsage.reasoningTokens ?? 0) > 0 ||
+        (tokenUsage.cacheReadTokens ?? 0) > 0 ||
+        (tokenUsage.cacheWriteTokens ?? 0) > 0 ||
+        (tokenUsage.totalTokens ?? 0) > 0
+    );
+}
+
 // =============================================================================
 // Handler Implementations
 // =============================================================================
@@ -195,6 +217,8 @@ function handleLLMResponse(event: EventByName<'llm:response'>): void {
         tokenUsage,
         model,
         provider,
+        estimatedCost,
+        costBreakdown,
         estimatedInputTokens,
         reasoningVariant,
         reasoningBudgetTokens,
@@ -215,12 +239,13 @@ function handleLLMResponse(event: EventByName<'llm:response'>): void {
         });
 
         // Track token usage analytics before returning
-        if (tokenUsage && (tokenUsage.inputTokens || tokenUsage.outputTokens)) {
+        if (hasMeaningfulTokenUsageForAnalytics(tokenUsage, estimatedCost)) {
             // Calculate estimate accuracy if both estimate and actual are available
             let estimateAccuracyPercent: number | undefined;
-            if (estimatedInputTokens !== undefined && tokenUsage.inputTokens) {
-                const diff = estimatedInputTokens - tokenUsage.inputTokens;
-                estimateAccuracyPercent = Math.round((diff / tokenUsage.inputTokens) * 100);
+            const actualInputTokens = tokenUsage?.inputTokens;
+            if (estimatedInputTokens !== undefined && actualInputTokens) {
+                const diff = estimatedInputTokens - actualInputTokens;
+                estimateAccuracyPercent = Math.round((diff / actualInputTokens) * 100);
             }
 
             captureTokenUsage({
@@ -229,12 +254,18 @@ function handleLLMResponse(event: EventByName<'llm:response'>): void {
                 model,
                 reasoningVariant,
                 reasoningBudgetTokens,
-                inputTokens: tokenUsage.inputTokens,
-                outputTokens: tokenUsage.outputTokens,
-                reasoningTokens: tokenUsage.reasoningTokens,
-                totalTokens: tokenUsage.totalTokens,
-                cacheReadTokens: tokenUsage.cacheReadTokens,
-                cacheWriteTokens: tokenUsage.cacheWriteTokens,
+                inputTokens: tokenUsage?.inputTokens,
+                outputTokens: tokenUsage?.outputTokens,
+                reasoningTokens: tokenUsage?.reasoningTokens,
+                totalTokens: tokenUsage?.totalTokens,
+                cacheReadTokens: tokenUsage?.cacheReadTokens,
+                cacheWriteTokens: tokenUsage?.cacheWriteTokens,
+                estimatedCostUsd: estimatedCost,
+                inputCostUsd: costBreakdown?.inputUsd,
+                outputCostUsd: costBreakdown?.outputUsd,
+                reasoningCostUsd: costBreakdown?.reasoningUsd,
+                cacheReadCostUsd: costBreakdown?.cacheReadUsd,
+                cacheWriteCostUsd: costBreakdown?.cacheWriteUsd,
                 estimatedInputTokens,
                 estimateAccuracyPercent,
             });
@@ -286,12 +317,13 @@ function handleLLMResponse(event: EventByName<'llm:response'>): void {
     }
 
     // Track token usage analytics (at end, after all processing)
-    if (tokenUsage && (tokenUsage.inputTokens || tokenUsage.outputTokens)) {
+    if (hasMeaningfulTokenUsageForAnalytics(tokenUsage, estimatedCost)) {
         // Calculate estimate accuracy if both estimate and actual are available
         let estimateAccuracyPercent: number | undefined;
-        if (estimatedInputTokens !== undefined && tokenUsage.inputTokens) {
-            const diff = estimatedInputTokens - tokenUsage.inputTokens;
-            estimateAccuracyPercent = Math.round((diff / tokenUsage.inputTokens) * 100);
+        const actualInputTokens = tokenUsage?.inputTokens;
+        if (estimatedInputTokens !== undefined && actualInputTokens) {
+            const diff = estimatedInputTokens - actualInputTokens;
+            estimateAccuracyPercent = Math.round((diff / actualInputTokens) * 100);
         }
 
         captureTokenUsage({
@@ -300,12 +332,18 @@ function handleLLMResponse(event: EventByName<'llm:response'>): void {
             model,
             reasoningVariant,
             reasoningBudgetTokens,
-            inputTokens: tokenUsage.inputTokens,
-            outputTokens: tokenUsage.outputTokens,
-            reasoningTokens: tokenUsage.reasoningTokens,
-            totalTokens: tokenUsage.totalTokens,
-            cacheReadTokens: tokenUsage.cacheReadTokens,
-            cacheWriteTokens: tokenUsage.cacheWriteTokens,
+            inputTokens: tokenUsage?.inputTokens,
+            outputTokens: tokenUsage?.outputTokens,
+            reasoningTokens: tokenUsage?.reasoningTokens,
+            totalTokens: tokenUsage?.totalTokens,
+            cacheReadTokens: tokenUsage?.cacheReadTokens,
+            cacheWriteTokens: tokenUsage?.cacheWriteTokens,
+            estimatedCostUsd: estimatedCost,
+            inputCostUsd: costBreakdown?.inputUsd,
+            outputCostUsd: costBreakdown?.outputUsd,
+            reasoningCostUsd: costBreakdown?.reasoningUsd,
+            cacheReadCostUsd: costBreakdown?.cacheReadUsd,
+            cacheWriteCostUsd: costBreakdown?.cacheWriteUsd,
             estimatedInputTokens,
             estimateAccuracyPercent,
         });


### PR DESCRIPTION
## Summary

- add estimated USD cost fields and flattened cost-breakdown fields to the shared `dexto_llm_tokens_consumed` analytics payload
- propagate `costBreakdown` through core `llm:response` pricing metadata so TUI/WebUI analytics can forward cost data without duplicating pricing logic
- preserve downstream usage delivery by teaching the server subscribers to forward or reuse the emitted cost breakdown
- add focused regression coverage for core, TUI, and WebUI analytics emission paths

## Why

Core already computes per-response LLM pricing, but the cross-platform usage analytics event only carried token counts. That left PostHog-style usage metrics blind to cost even though the information already existed in the runtime.

## Impact

- LLM usage analytics now include total estimated USD cost plus per-bucket input/output/reasoning/cache cost fields when pricing is available
- priced responses with non-input/output token buckets are no longer dropped from analytics just because `inputTokens`/`outputTokens` are zero
- the generated OpenAPI document is synced so repo checks no longer fail on stale version metadata

## Validation

- `pnpm exec vitest run packages/core/src/llm/executor/stream-processor.test.ts packages/webui/lib/events/handlers.test.ts packages/tui/src/services/processStream.test.ts`
- `bash scripts/quality-checks.sh lint`
- `bash scripts/quality-checks.sh typecheck`
- `bash scripts/quality-checks.sh hono-inference`
- `./scripts/quality-checks.sh` reaches build and OpenAPI successfully, but the full test step is currently blocked by unrelated CLI test instability/timeouts in `packages/cli/src/cli/utils/config-validation.test.ts` and `packages/cli/src/cli/modes/cli.test.ts`
- `pnpm exec vitest run packages/cli/src/cli/modes/cli.test.ts packages/cli/src/cli/utils/config-validation.test.ts` passed when rerun in isolation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM usage analytics now display estimated USD costs
  * Cost breakdown by category: input tokens, output tokens, reasoning operations, and cache read/write operations
  * Cost metrics available across CLI and WebUI interfaces

<!-- end of auto-generated comment: release notes by coderabbit.ai -->