### PR TITLE
Allow dexto-nova gateway URL overrides

### DIFF
--- a/.changeset/neat-laws-exist.md
+++ b/.changeset/neat-laws-exist.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Allow `dexto-nova` to target non-production gateways via `llm.baseURL` or `DEXTO_API_URL`.

--- a/packages/core/src/llm/registry/index.test.ts
+++ b/packages/core/src/llm/registry/index.test.ts
@@ -660,6 +660,17 @@ describe('Provider-Specific Tests', () => {
         });
     });
 
+    describe('Dexto Nova provider', () => {
+        it('allows optional baseURL overrides for non-production gateways', () => {
+            expect(getSupportedProviders()).toContain('dexto-nova');
+            expect(getSupportedModels('dexto-nova').length).toBeGreaterThan(0);
+            expect(getDefaultModelForProvider('dexto-nova')).not.toBeNull();
+            expect(supportsBaseURL('dexto-nova')).toBe(true);
+            expect(requiresBaseURL('dexto-nova')).toBe(false);
+            expect(acceptsAnyModel('dexto-nova')).toBe(false);
+        });
+    });
+
     describe('LiteLLM provider', () => {
         it('has correct capabilities for proxy routing', () => {
             expect(getSupportedProviders()).toContain('litellm');

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -505,7 +505,7 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
                 },
             },
         ],
-        baseURLSupport: 'none',
+        baseURLSupport: 'optional',
         supportedFileTypes: GENERIC_UPLOAD_FILE_TYPES,
         supportsCustomModels: true,
         supportsAllRegistryModels: true,

--- a/packages/core/src/llm/services/factory.test.ts
+++ b/packages/core/src/llm/services/factory.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LLMConfigSchema } from '../schemas.js';
+import { createVercelModel } from './factory.js';
+
+const { createOpenRouterMock } = vi.hoisted(() => {
+    return {
+        createOpenRouterMock: vi.fn(),
+    };
+});
+
+vi.mock('@openrouter/ai-sdk-provider', () => ({
+    createOpenRouter: createOpenRouterMock,
+}));
+
+function createLanguageModelStub(modelId: string) {
+    return {
+        modelId,
+        doGenerate: vi.fn(),
+    };
+}
+
+function buildDextoConfig(overrides: Record<string, unknown> = {}) {
+    return LLMConfigSchema.parse({
+        provider: 'dexto-nova',
+        model: 'openai/gpt-5.4',
+        apiKey: 'dxt_test_key',
+        ...overrides,
+    });
+}
+
+function getLastOpenRouterBaseUrl(): string {
+    const lastCall = createOpenRouterMock.mock.calls.at(-1)?.[0];
+    if (!lastCall || typeof lastCall !== 'object' || !('baseURL' in lastCall)) {
+        throw new Error('createOpenRouter call did not capture baseURL');
+    }
+
+    const { baseURL } = lastCall;
+    if (typeof baseURL !== 'string') {
+        throw new Error('Expected createOpenRouter baseURL to be a string');
+    }
+
+    return baseURL;
+}
+
+describe('createVercelModel dexto-nova base URL resolution', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        delete process.env.DEXTO_API_URL;
+
+        createOpenRouterMock.mockImplementation(({ baseURL }) => ({
+            chat: (model: string) => createLanguageModelStub(`${baseURL}:${model}`),
+        }));
+    });
+
+    afterEach(() => {
+        delete process.env.DEXTO_API_URL;
+    });
+
+    it('uses the production gateway by default', () => {
+        createVercelModel(buildDextoConfig());
+
+        expect(getLastOpenRouterBaseUrl()).toBe('https://api.dexto.ai/v1');
+    });
+
+    it('uses llm.baseURL when explicitly provided', () => {
+        createVercelModel(
+            buildDextoConfig({
+                baseURL: 'http://localhost:3001/v1/',
+            })
+        );
+
+        expect(getLastOpenRouterBaseUrl()).toBe('http://localhost:3001/v1');
+    });
+
+    it('uses DEXTO_API_URL when no explicit baseURL is set', () => {
+        process.env.DEXTO_API_URL = 'http://localhost:3001';
+
+        createVercelModel(buildDextoConfig());
+
+        expect(getLastOpenRouterBaseUrl()).toBe('http://localhost:3001/v1');
+    });
+
+    it('preserves DEXTO_API_URL when it already includes /v1', () => {
+        process.env.DEXTO_API_URL = 'https://api.preview.dexto.ai/v1/';
+
+        createVercelModel(buildDextoConfig());
+
+        expect(getLastOpenRouterBaseUrl()).toBe('https://api.preview.dexto.ai/v1');
+    });
+
+    it('prefers explicit baseURL over DEXTO_API_URL', () => {
+        process.env.DEXTO_API_URL = 'https://api.preview.dexto.ai';
+
+        createVercelModel(
+            buildDextoConfig({
+                baseURL: 'http://localhost:3001/v1',
+            })
+        );
+
+        expect(getLastOpenRouterBaseUrl()).toBe('http://localhost:3001/v1');
+    });
+});

--- a/packages/core/src/llm/services/factory.ts
+++ b/packages/core/src/llm/services/factory.ts
@@ -44,6 +44,30 @@ function isLanguageModel(value: unknown): value is LanguageModel {
     );
 }
 
+const DEFAULT_DEXTO_GATEWAY_BASE_URL = 'https://api.dexto.ai/v1';
+
+function trimTrailingSlash(value: string): string {
+    return value.trim().replace(/\/$/, '');
+}
+
+function resolveDextoGatewayBaseURL(baseURL?: string): string {
+    if (baseURL?.trim()) {
+        return trimTrailingSlash(baseURL);
+    }
+
+    const envBaseURL = process.env.DEXTO_API_URL?.trim();
+    if (!envBaseURL) {
+        return DEFAULT_DEXTO_GATEWAY_BASE_URL;
+    }
+
+    const normalizedEnvBaseURL = trimTrailingSlash(envBaseURL);
+    if (normalizedEnvBaseURL.endsWith('/v1')) {
+        return normalizedEnvBaseURL;
+    }
+
+    return `${normalizedEnvBaseURL}/v1`;
+}
+
 // Dexto Gateway headers for usage tracking
 const DEXTO_GATEWAY_HEADERS = {
     SESSION_ID: 'X-Dexto-Session-ID',
@@ -187,7 +211,7 @@ export function createVercelModel(
             // Users explicitly choose `provider: dexto-nova` in their config
             //
             // Note: 402 "insufficient credits" errors are handled in turn-executor.ts mapProviderError()
-            const dextoBaseURL = 'https://api.dexto.ai/v1';
+            const dextoBaseURL = resolveDextoGatewayBaseURL(baseURL);
 
             // Build headers for usage tracking
             const headers: Record<string, string> = {


### PR DESCRIPTION
## Summary
`dexto-nova` currently hardcodes `https://api.dexto.ai/v1` in core. That works for production, but it breaks local/preview and any first-party service-side callers that need to route `dexto-nova` traffic to a non-production gateway.

This PR makes `dexto-nova` resolve its gateway URL with the same precedence we want for hosted cloud usage:
- explicit `llm.baseURL`
- `DEXTO_API_URL`
- production default (`https://api.dexto.ai/v1`)

## What is in scope here
- allow `dexto-nova` configs to set `baseURL`
- make the `dexto-nova` factory respect explicit `baseURL`
- make `dexto-nova` fall back to `DEXTO_API_URL` when no explicit `baseURL` is set
- normalize `DEXTO_API_URL` roots to `/v1`
- add focused tests for the new precedence/normalization behavior

## What stays out of scope
- any `dexto-cloud` materialization changes
- gateway auth changes for internal service-to-service calls
- BYOK or cloud LLM configuration work

Those will land in follow-up cloud PRs once this core behavior exists.

## Why this matters
`dexto-cloud` is moving hosted sandboxes onto `dexto-nova` by default. Without this core override path, local/preview hosted runs and server-side fallback agents still risk routing to production unintentionally.

Related cloud work:
- truffle-ai/dexto-cloud#255
- truffle-ai/dexto-cloud#266

## Tests
- `pnpm --filter @dexto/core exec vitest run src/llm/services/factory.test.ts`
- `pnpm --filter @dexto/core exec vitest run src/llm/registry/index.test.ts`
- `pnpm --filter @dexto/core exec vitest run src/llm/schemas.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dexto Nova now supports optional base URL configuration. You can set a custom endpoint via configuration or the DEXTO_API_URL environment variable; explicit config takes precedence. Default endpoint remains https://api.dexto.ai/v1.

* **Tests**
  * Added tests verifying provider metadata and base URL resolution behavior across env/config combinations.

* **Chores**
  * Added a changeset documenting the patch release for this behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->