### PR TITLE
[codex] fix(filesystem-tools): expand home shorthand paths

### DIFF
--- a/packages/tools-filesystem/src/directory-approval.ts
+++ b/packages/tools-filesystem/src/directory-approval.ts
@@ -4,6 +4,7 @@ import { ApprovalStatus, ApprovalType, ToolError } from '@dexto/core';
 import type { ApprovalRequestDetails, ApprovalResponse, ToolExecutionContext } from '@dexto/core';
 import type { FileSystemService } from './filesystem-service.js';
 import type { FileSystemServiceGetter } from './file-tool-types.js';
+import { resolveUserPath } from './path-utils.js';
 
 type DirectoryApprovalOperation = 'read' | 'write' | 'edit';
 
@@ -16,9 +17,7 @@ export function resolveFilePath(
     workingDirectory: string,
     filePath: string
 ): DirectoryApprovalPaths {
-    const resolvedPath = path.isAbsolute(filePath)
-        ? path.resolve(filePath)
-        : path.resolve(workingDirectory, filePath);
+    const resolvedPath = resolveUserPath(workingDirectory, filePath);
     return { path: resolvedPath, parentDir: path.dirname(resolvedPath) };
 }
 

--- a/packages/tools-filesystem/src/filesystem-service.ts
+++ b/packages/tools-filesystem/src/filesystem-service.ts
@@ -38,6 +38,7 @@ import {
 import { PathValidator } from './path-validator.js';
 import { FileSystemError } from './errors.js';
 import { detectMimeType, getMediaFileKind, isLikelyBinary, isTextMimeType } from './mime-utils.js';
+import { resolveUserPath } from './path-utils.js';
 
 const DEFAULT_ENCODING: BufferEncoding = 'utf-8';
 const DEFAULT_MAX_RESULTS = 1000;
@@ -83,7 +84,9 @@ export class FileSystemService {
      */
     private getBackupDir(): string {
         // Use custom path if provided (absolute), otherwise use context-aware default
-        return this.config.backupPath || getDextoPath('backups');
+        return this.config.backupPath
+            ? resolveUserPath(this.getWorkingDirectory(), this.config.backupPath)
+            : getDextoPath('backups');
     }
 
     /**
@@ -382,7 +385,10 @@ export class FileSystemService {
     async globFiles(pattern: string, options: GlobOptions = {}): Promise<GlobResult> {
         await this.ensureInitialized();
 
-        const cwd: string = options.cwd || this.config.workingDirectory || process.cwd();
+        const cwd = resolveUserPath(
+            this.config.workingDirectory || process.cwd(),
+            options.cwd || this.config.workingDirectory || process.cwd()
+        );
         const maxResults = options.maxResults || DEFAULT_MAX_RESULTS;
 
         try {

--- a/packages/tools-filesystem/src/glob-files-tool.test.ts
+++ b/packages/tools-filesystem/src/glob-files-tool.test.ts
@@ -85,13 +85,11 @@ describe('glob_files tool', () => {
             await fs.writeFile(filePath, 'hello');
 
             const tool = createGlobFilesTool(async () => fileSystemServiceForHome);
-            const result = (await tool.execute(
-                {
-                    pattern: '**/*.txt',
-                    path: `~/${path.basename(homeTempDir)}`,
-                },
-                createToolContext(mockLogger)
-            )) as {
+            const parsedInput = tool.inputSchema.parse({
+                pattern: '**/*.txt',
+                path: `~/${path.basename(homeTempDir)}`,
+            });
+            const result = (await tool.execute(parsedInput, createToolContext(mockLogger))) as {
                 files: Array<{ path: string }>;
                 total_found: number;
             };

--- a/packages/tools-filesystem/src/glob-files-tool.test.ts
+++ b/packages/tools-filesystem/src/glob-files-tool.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import type { Logger, ToolExecutionContext } from '@dexto/core';
+import { FileSystemService } from './filesystem-service.js';
+import { createGlobFilesTool } from './glob-files-tool.js';
+
+const createMockLogger = (): Logger => {
+    const logger: Logger = {
+        debug: vi.fn(),
+        silly: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        createChild: vi.fn(() => logger),
+        createFileOnlyChild: vi.fn(() => logger),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'debug' as const),
+        getLogFilePath: vi.fn(() => null),
+        destroy: vi.fn(async () => undefined),
+    };
+    return logger;
+};
+
+function createToolContext(logger: Logger): ToolExecutionContext {
+    return { logger };
+}
+
+describe('glob_files tool', () => {
+    let mockLogger: Logger;
+    let tempDir: string;
+    let fileSystemService: FileSystemService;
+
+    beforeEach(async () => {
+        mockLogger = createMockLogger();
+
+        const rawTempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dexto-glob-test-'));
+        tempDir = await fs.realpath(rawTempDir);
+
+        fileSystemService = new FileSystemService(
+            {
+                allowedPaths: [tempDir],
+                blockedPaths: [],
+                blockedExtensions: [],
+                maxFileSize: 10 * 1024 * 1024,
+                workingDirectory: tempDir,
+                enableBackups: false,
+                backupRetentionDays: 7,
+            },
+            mockLogger
+        );
+        await fileSystemService.initialize();
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+
+        try {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // ignore cleanup failures
+        }
+    });
+
+    it('expands home-directory shorthand for glob base paths', async () => {
+        const homeTempDir = await fs.mkdtemp(path.join(os.homedir(), '.dexto-glob-home-test-'));
+        const fileSystemServiceForHome = new FileSystemService(
+            {
+                allowedPaths: [homeTempDir],
+                blockedPaths: [],
+                blockedExtensions: [],
+                maxFileSize: 10 * 1024 * 1024,
+                workingDirectory: tempDir,
+                enableBackups: false,
+                backupRetentionDays: 7,
+            },
+            mockLogger
+        );
+        await fileSystemServiceForHome.initialize();
+
+        try {
+            const filePath = path.join(homeTempDir, 'notes.txt');
+            await fs.writeFile(filePath, 'hello');
+
+            const tool = createGlobFilesTool(async () => fileSystemServiceForHome);
+            const result = (await tool.execute(
+                {
+                    pattern: '**/*.txt',
+                    path: `~/${path.basename(homeTempDir)}`,
+                },
+                createToolContext(mockLogger)
+            )) as {
+                files: Array<{ path: string }>;
+                total_found: number;
+            };
+
+            expect(result.total_found).toBe(1);
+            expect(result.files).toEqual([
+                {
+                    path: filePath,
+                    size: 5,
+                    modified: expect.any(String),
+                },
+            ]);
+        } finally {
+            await fs.rm(homeTempDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/tools-filesystem/src/glob-files-tool.ts
+++ b/packages/tools-filesystem/src/glob-files-tool.ts
@@ -4,13 +4,13 @@
  * Internal tool for finding files using glob patterns
  */
 
-import * as path from 'node:path';
 import { z } from 'zod';
 import { createLocalToolCallHeader, defineTool, truncateForHeader } from '@dexto/core';
 import type { SearchDisplayData } from '@dexto/core';
 import type { Tool, ToolExecutionContext } from '@dexto/core';
 import type { FileSystemServiceGetter } from './file-tool-types.js';
 import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
+import { resolveUserPath } from './path-utils.js';
 
 const GlobFilesInputSchema = z
     .object({
@@ -64,7 +64,7 @@ export function createGlobFilesTool(
             getFileSystemService,
             resolvePaths: (input, fileSystemService) => {
                 const baseDir = fileSystemService.getWorkingDirectory();
-                const searchDir = path.resolve(baseDir, input.path || '.');
+                const searchDir = resolveUserPath(baseDir, input.path || '.');
                 return { path: searchDir, parentDir: searchDir };
             },
         }),
@@ -77,7 +77,7 @@ export function createGlobFilesTool(
 
             // Resolve the search directory consistently with directory-approval path handling
             const baseDir = resolvedFileSystemService.getWorkingDirectory();
-            const resolvedSearchPath = path.resolve(baseDir, searchPath || '.');
+            const resolvedSearchPath = resolveUserPath(baseDir, searchPath || '.');
 
             // Search for files using FileSystemService
             const result = await resolvedFileSystemService.globFiles(pattern, {

--- a/packages/tools-filesystem/src/grep-content-tool.test.ts
+++ b/packages/tools-filesystem/src/grep-content-tool.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as path from 'node:path';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import type { Logger, ToolExecutionContext } from '@dexto/core';
+import { FileSystemService } from './filesystem-service.js';
+import { createGrepContentTool } from './grep-content-tool.js';
+
+const createMockLogger = (): Logger => {
+    const logger: Logger = {
+        debug: vi.fn(),
+        silly: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        createChild: vi.fn(() => logger),
+        createFileOnlyChild: vi.fn(() => logger),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'debug' as const),
+        getLogFilePath: vi.fn(() => null),
+        destroy: vi.fn(async () => undefined),
+    };
+    return logger;
+};
+
+function createToolContext(logger: Logger): ToolExecutionContext {
+    return { logger };
+}
+
+describe('grep_content tool', () => {
+    let mockLogger: Logger;
+    let tempDir: string;
+    let fileSystemService: FileSystemService;
+
+    beforeEach(async () => {
+        mockLogger = createMockLogger();
+
+        const rawTempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dexto-grep-test-'));
+        tempDir = await fs.realpath(rawTempDir);
+
+        fileSystemService = new FileSystemService(
+            {
+                allowedPaths: [tempDir],
+                blockedPaths: [],
+                blockedExtensions: [],
+                maxFileSize: 10 * 1024 * 1024,
+                workingDirectory: tempDir,
+                enableBackups: false,
+                backupRetentionDays: 7,
+            },
+            mockLogger
+        );
+        await fileSystemService.initialize();
+    });
+
+    afterEach(async () => {
+        vi.restoreAllMocks();
+
+        try {
+            await fs.rm(tempDir, { recursive: true, force: true });
+        } catch {
+            // ignore cleanup failures
+        }
+    });
+
+    it('expands home-directory shorthand for search paths', async () => {
+        const homeTempDir = await fs.mkdtemp(path.join(os.homedir(), '.dexto-grep-home-test-'));
+        const fileSystemServiceForHome = new FileSystemService(
+            {
+                allowedPaths: [homeTempDir],
+                blockedPaths: [],
+                blockedExtensions: [],
+                maxFileSize: 10 * 1024 * 1024,
+                workingDirectory: tempDir,
+                enableBackups: false,
+                backupRetentionDays: 7,
+            },
+            mockLogger
+        );
+        await fileSystemServiceForHome.initialize();
+
+        try {
+            const filePath = path.join(homeTempDir, 'notes.txt');
+            await fs.writeFile(filePath, 'alpha\nneedle\nomega\n');
+
+            const tool = createGrepContentTool(async () => fileSystemServiceForHome);
+            const result = (await tool.execute(
+                {
+                    pattern: 'needle',
+                    path: `~/${path.basename(homeTempDir)}`,
+                },
+                createToolContext(mockLogger)
+            )) as {
+                matches: Array<{ file: string; line_number: number; line: string }>;
+                files_searched: number;
+            };
+
+            expect(result.files_searched).toBe(1);
+            expect(result.matches).toEqual([
+                {
+                    file: filePath,
+                    line_number: 2,
+                    line: 'needle',
+                },
+            ]);
+        } finally {
+            await fs.rm(homeTempDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/tools-filesystem/src/grep-content-tool.test.ts
+++ b/packages/tools-filesystem/src/grep-content-tool.test.ts
@@ -85,13 +85,11 @@ describe('grep_content tool', () => {
             await fs.writeFile(filePath, 'alpha\nneedle\nomega\n');
 
             const tool = createGrepContentTool(async () => fileSystemServiceForHome);
-            const result = (await tool.execute(
-                {
-                    pattern: 'needle',
-                    path: `~/${path.basename(homeTempDir)}`,
-                },
-                createToolContext(mockLogger)
-            )) as {
+            const parsedInput = tool.inputSchema.parse({
+                pattern: 'needle',
+                path: `~/${path.basename(homeTempDir)}`,
+            });
+            const result = (await tool.execute(parsedInput, createToolContext(mockLogger))) as {
                 matches: Array<{ file: string; line_number: number; line: string }>;
                 files_searched: number;
             };

--- a/packages/tools-filesystem/src/grep-content-tool.ts
+++ b/packages/tools-filesystem/src/grep-content-tool.ts
@@ -4,13 +4,13 @@
  * Internal tool for searching file contents using regex patterns
  */
 
-import * as path from 'node:path';
 import { z } from 'zod';
 import { createLocalToolCallHeader, defineTool, truncateForHeader } from '@dexto/core';
 import type { SearchDisplayData } from '@dexto/core';
 import type { Tool, ToolExecutionContext } from '@dexto/core';
 import type { FileSystemServiceGetter } from './file-tool-types.js';
 import { createDirectoryAccessApprovalHandlers } from './directory-approval.js';
+import { resolveUserPath } from './path-utils.js';
 
 const GrepContentInputSchema = z
     .object({
@@ -81,7 +81,7 @@ export function createGrepContentTool(
             getFileSystemService,
             resolvePaths: (input, fileSystemService) => {
                 const baseDir = fileSystemService.getWorkingDirectory();
-                const searchDir = path.resolve(baseDir, input.path || '.');
+                const searchDir = resolveUserPath(baseDir, input.path || '.');
                 return { path: searchDir, parentDir: searchDir };
             },
         }),
@@ -99,7 +99,7 @@ export function createGrepContentTool(
                 max_results,
             } = input;
             const baseDir = resolvedFileSystemService.getWorkingDirectory();
-            const resolvedSearchPath = path.resolve(baseDir, searchPath || '.');
+            const resolvedSearchPath = resolveUserPath(baseDir, searchPath || '.');
 
             // Search for content using FileSystemService
             const result = await resolvedFileSystemService.searchContent(pattern, {

--- a/packages/tools-filesystem/src/path-utils.test.ts
+++ b/packages/tools-filesystem/src/path-utils.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { expandHomeShorthand, resolveUserPath } from './path-utils.js';
+
+describe('path-utils', () => {
+    it('expands bare home shorthand', () => {
+        expect(expandHomeShorthand('~')).toBe(os.homedir());
+    });
+
+    it('expands home shorthand with nested path segments', () => {
+        expect(expandHomeShorthand('~/Projects/test.md')).toBe(
+            path.join(os.homedir(), 'Projects', 'test.md')
+        );
+        expect(expandHomeShorthand('~\\Projects\\test.md')).toBe(
+            path.join(os.homedir(), 'Projects\\test.md')
+        );
+    });
+
+    it('does not expand unsupported user-home syntax', () => {
+        expect(expandHomeShorthand('~other-user/file.txt')).toBe('~other-user/file.txt');
+    });
+
+    it('resolves home shorthand before relative resolution', () => {
+        expect(resolveUserPath('/workspace', '~/Projects/test.md')).toBe(
+            path.join(os.homedir(), 'Projects', 'test.md')
+        );
+        expect(resolveUserPath('/workspace', 'notes/today.md')).toBe('/workspace/notes/today.md');
+        expect(resolveUserPath('~', 'notes/today.md')).toBe(
+            path.join(os.homedir(), 'notes/today.md')
+        );
+    });
+});

--- a/packages/tools-filesystem/src/path-utils.ts
+++ b/packages/tools-filesystem/src/path-utils.ts
@@ -1,0 +1,30 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+/**
+ * Expand a leading home-directory shorthand (`~`) into an absolute path.
+ * Leaves other path shapes untouched, including `~user/...`.
+ */
+export function expandHomeShorthand(inputPath: string): string {
+    if (!/^~(?=$|[\\/])/.test(inputPath)) {
+        return inputPath;
+    }
+
+    if (inputPath === '~') {
+        return os.homedir();
+    }
+
+    return path.join(os.homedir(), inputPath.slice(2));
+}
+
+/**
+ * Resolve a user-supplied path against a working directory after expanding
+ * supported home-directory shorthand.
+ */
+export function resolveUserPath(workingDirectory: string, inputPath: string): string {
+    const resolvedWorkingDirectory = path.resolve(expandHomeShorthand(workingDirectory));
+    const expandedPath = expandHomeShorthand(inputPath);
+    return path.isAbsolute(expandedPath)
+        ? path.resolve(expandedPath)
+        : path.resolve(resolvedWorkingDirectory, expandedPath);
+}

--- a/packages/tools-filesystem/src/path-validator.test.ts
+++ b/packages/tools-filesystem/src/path-validator.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { PathValidator, DirectoryApprovalChecker } from './path-validator.js';
 
 // Create mock logger
@@ -101,6 +103,25 @@ describe('PathValidator', () => {
 
                 const result = await validator.validatePath('src/file.ts');
                 expect(result.isValid).toBe(true);
+            });
+
+            it('should expand home-directory shorthand before validation', async () => {
+                const validator = new PathValidator(
+                    {
+                        allowedPaths: ['~'],
+                        blockedPaths: [],
+                        blockedExtensions: [],
+                        maxFileSize: 10 * 1024 * 1024,
+                        enableBackups: false,
+                        backupRetentionDays: 7,
+                        workingDirectory: '/workspace/project',
+                    },
+                    mockLogger as any
+                );
+
+                const result = await validator.validatePath('~/notes/file.ts');
+                expect(result.isValid).toBe(true);
+                expect(result.normalizedPath).toBe(path.join(os.homedir(), 'notes', 'file.ts'));
             });
 
             it('should reject paths outside allowed directories', async () => {

--- a/packages/tools-filesystem/src/path-validator.ts
+++ b/packages/tools-filesystem/src/path-validator.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
 import { FileSystemConfig, PathValidation } from './types.js';
 import type { Logger } from '@dexto/core';
+import { expandHomeShorthand, resolveUserPath } from './path-utils.js';
 
 /**
  * Callback type for checking if a path is in an approved directory.
@@ -41,11 +42,15 @@ export class PathValidator {
         this.logger = logger;
 
         // Normalize allowed paths to absolute paths
-        const workingDir = config.workingDirectory || process.cwd();
-        this.normalizedAllowedPaths = config.allowedPaths.map((p) => path.resolve(workingDir, p));
+        const workingDir = resolveUserPath(process.cwd(), config.workingDirectory || process.cwd());
+        this.normalizedAllowedPaths = config.allowedPaths.map((p) =>
+            resolveUserPath(workingDir, p)
+        );
 
         // Normalize blocked paths
-        this.normalizedBlockedPaths = config.blockedPaths.map((p) => path.normalize(p));
+        this.normalizedBlockedPaths = config.blockedPaths.map((p) =>
+            path.normalize(expandHomeShorthand(p))
+        );
 
         // Normalize blocked extensions: ensure leading dot and lowercase
         this.normalizedBlockedExtensions = (config.blockedExtensions || []).map((ext) => {
@@ -105,15 +110,16 @@ export class PathValidator {
         }
 
         // 2. Normalize the path to absolute
-        const workingDir = this.config.workingDirectory || process.cwd();
+        const workingDir = resolveUserPath(
+            process.cwd(),
+            this.config.workingDirectory || process.cwd()
+        );
         let resolvedPath: string;
         let normalizedPath: string;
 
         try {
             // Handle both absolute and relative paths
-            resolvedPath = path.isAbsolute(filePath)
-                ? path.resolve(filePath)
-                : path.resolve(workingDir, filePath);
+            resolvedPath = resolveUserPath(workingDir, filePath);
             normalizedPath = resolvedPath;
 
             // Canonicalize to handle symlinks and resolve real paths (async, non-blocking)
@@ -188,7 +194,10 @@ export class PathValidator {
         // Check for ../ patterns in original path
         if (originalPath.includes('../') || originalPath.includes('..\\')) {
             // Verify the normalized path still escapes allowed boundaries
-            const workingDir = this.config.workingDirectory || process.cwd();
+            const workingDir = resolveUserPath(
+                process.cwd(),
+                this.config.workingDirectory || process.cwd()
+            );
             const relative = path.relative(workingDir, normalizedPath);
             if (relative.startsWith('..')) {
                 return true;
@@ -213,7 +222,7 @@ export class PathValidator {
         const roots =
             this.normalizedAllowedPaths.length > 0
                 ? this.normalizedAllowedPaths
-                : [this.config.workingDirectory || process.cwd()];
+                : [resolveUserPath(process.cwd(), this.config.workingDirectory || process.cwd())];
 
         for (const blocked of this.normalizedBlockedPaths) {
             for (const root of roots) {
@@ -287,13 +296,14 @@ export class PathValidator {
         }
 
         // Normalize the path to absolute
-        const workingDir = this.config.workingDirectory || process.cwd();
+        const workingDir = resolveUserPath(
+            process.cwd(),
+            this.config.workingDirectory || process.cwd()
+        );
         let normalizedPath: string;
 
         try {
-            normalizedPath = path.isAbsolute(filePath)
-                ? path.resolve(filePath)
-                : path.resolve(workingDir, filePath);
+            normalizedPath = resolveUserPath(workingDir, filePath);
 
             // Try to resolve symlinks for existing files (async, non-blocking)
             try {

--- a/packages/tools-filesystem/src/write-file-tool.test.ts
+++ b/packages/tools-filesystem/src/write-file-tool.test.ts
@@ -229,6 +229,46 @@ describe('write_file tool', () => {
     });
 
     describe('File Modification Detection - New Files', () => {
+        it('should expand home-directory shorthand when creating a file', async () => {
+            const homeTempDir = await fs.mkdtemp(
+                path.join(os.homedir(), '.dexto-write-home-test-')
+            );
+            const homeRelativeDir = `~/${path.basename(homeTempDir)}`;
+            const fileSystemServiceForHome = new FileSystemService(
+                {
+                    allowedPaths: [homeTempDir],
+                    blockedPaths: [],
+                    blockedExtensions: [],
+                    maxFileSize: 10 * 1024 * 1024,
+                    workingDirectory: tempDir,
+                    enableBackups: false,
+                    backupRetentionDays: 7,
+                },
+                mockLogger
+            );
+            await fileSystemServiceForHome.initialize();
+            const tool = createWriteFileTool(async () => fileSystemServiceForHome);
+
+            try {
+                const parsedInput = tool.inputSchema.parse({
+                    file_path: `${homeRelativeDir}/nested/new-file.txt`,
+                    content: 'brand new content',
+                    create_dirs: true,
+                });
+
+                const result = (await tool.execute(parsedInput, createToolContext(mockLogger))) as {
+                    success: boolean;
+                    path: string;
+                };
+
+                expect(result.success).toBe(true);
+                expect(result.path).toBe(path.join(homeTempDir, 'nested', 'new-file.txt'));
+                expect(await fs.readFile(result.path, 'utf-8')).toBe('brand new content');
+            } finally {
+                await fs.rm(homeTempDir, { recursive: true, force: true });
+            }
+        });
+
         it('should succeed when creating new file that still does not exist', async () => {
             const tool = createWriteFileTool(async () => fileSystemService);
             const testFile = path.join(tempDir, 'new-file.txt');


### PR DESCRIPTION
## What changed

This fixes filesystem tool path handling so home-directory shorthand like `~`, `~/...`, and `~\\...` is expanded consistently before path validation or resolution.

The change adds a shared path helper and routes all affected filesystem entry points through it, including directory approval, path validation, glob base paths, grep search paths, and backup-path resolution.

It also adds regression coverage for the shared resolver plus representative filesystem tools.

## Why this changed

`Write(~/Projects/test.md)` and similar filesystem tool calls were treating `~` as a literal path segment instead of the user home directory.

## Root cause

The filesystem tools were passing raw user input into Node path resolution APIs like `path.resolve(...)`. Those APIs do not expand shell shorthand, so `~/file.txt` was being resolved relative to the workspace root as a literal `~` directory.

## Impact

Users can now use home-directory shorthand across the filesystem tool surface without path approval, preview, and execution disagreeing about the resolved target.

This covers the filesystem path handling used by:

- `read_file`
- `read_media_file`
- `write_file`
- `edit_file`
- `glob_files`
- `grep_content`

## Validation

- Targeted Vitest coverage for the shared resolver and path validator
- Targeted filesystem-tool Vitest suites covering write/edit/read-media, glob/grep, directory approval, and filesystem service behavior
- Full `/quality-checks` sweep not run in this pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for home-directory shorthand (~) and unified user-path resolution across filesystem tools, improving how relative and absolute paths are interpreted.

* **Bug Fixes / Improvements**
  * Consistent expansion and resolution for configured paths (e.g., backups, glob/grep/search bases), reducing mismatches between tools.

* **Tests**
  * Added extensive tests validating ~ expansion and path-resolution behavior for file search, grep, glob, validation, and write operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->