### PR TITLE
[codex] Drop queued follow-ups on agent restart

### DIFF
--- a/.changeset/stale-queue-restart.md
+++ b/.changeset/stale-queue-restart.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Drop persisted queued follow-up state on startup and best-effort shutdown so stale interrupted messages do not survive an agent restart.

--- a/packages/core/src/session/session-manager.integration.test.ts
+++ b/packages/core/src/session/session-manager.integration.test.ts
@@ -396,7 +396,7 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
         agents = [];
     });
 
-    test('restores queued messages, session overrides, approvals, and tool preferences after agent restart', async () => {
+    test('drops queued messages during shutdown cleanup but restores other interaction state on next startup', async () => {
         const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
         process.env.OPENAI_API_KEY = 'test-key-123';
 
@@ -408,6 +408,7 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
             };
             const sessionId = 'persisted-interaction-session';
             const approvedDirectory = path.join(os.tmpdir(), 'dexto-persisted-approval');
+            const queueKey = `session-message-queue:${sessionId}`;
 
             const agent1 = await createAgentWithSharedStorage(
                 'interaction-state-agent-1',
@@ -440,9 +441,7 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
 
             const persistedQueue = await agent1.services.storageManager
                 .getDatabase()
-                .get<
-                    Array<{ content: Array<{ type: string; text?: string }> }>
-                >(`session-message-queue:${sessionId}`);
+                .get<Array<{ content: Array<{ type: string; text?: string }> }>>(queueKey);
             expect(persistedQueue).toHaveLength(1);
             expect(persistedQueue?.[0]?.content).toEqual([
                 { type: 'text', text: 'resume with plan B' },
@@ -472,6 +471,12 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
                 )
             ).toBe(true);
 
+            await agent1.sessionManager.cleanup();
+
+            expect(await sharedStorage.database.get(`session:${sessionId}`)).toBeDefined();
+            expect(await sharedStorage.database.get(queueKey)).toBeUndefined();
+            expect(await sharedStorage.cache.get(queueKey)).toBeUndefined();
+
             const agent2 = await createAgentWithSharedStorage(
                 'interaction-state-agent-2',
                 sharedStorage
@@ -484,10 +489,7 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
             expect(agent2.services.stateManager.getLLMConfig(sessionId).model).toBe('gpt-5');
 
             const queuedMessages = await agent2.getQueuedMessages(sessionId);
-            expect(queuedMessages).toHaveLength(1);
-            expect(queuedMessages[0]?.content).toEqual([
-                { type: 'text', text: 'resume with plan B' },
-            ]);
+            expect(queuedMessages).toEqual([]);
 
             expect(await agent2.getSessionAutoApproveTools(sessionId)).toEqual(['allowed_tool']);
 
@@ -515,6 +517,47 @@ describe('Session Integration: Core-owned Interaction State Persistence', () => 
                 process.env.OPENAI_API_KEY = originalOpenAiApiKey;
             }
         }
+    });
+
+    test('purges persisted queued messages on startup after an unclean shutdown', async () => {
+        const sharedStorage = {
+            blob: createInMemoryBlobStore(),
+            cache: createInMemoryCache(),
+            database: createInMemoryDatabase(),
+        };
+        const sessionId = 'stale-queued-session';
+        const queueKey = `session-message-queue:${sessionId}`;
+        const queuedMessages = [
+            {
+                content: [{ type: 'text' as const, text: 'stale queued follow-up' }],
+                metadata: { source: 'unclean-shutdown' },
+            },
+        ];
+
+        await sharedStorage.database.set<SessionData>(`session:${sessionId}`, {
+            id: sessionId,
+            createdAt: Date.now(),
+            lastActivity: Date.now(),
+            messageCount: 0,
+        });
+        await sharedStorage.database.set(queueKey, queuedMessages);
+        await sharedStorage.cache.set(queueKey, queuedMessages, 60);
+
+        expect(await sharedStorage.database.get(queueKey)).toEqual(queuedMessages);
+        expect(await sharedStorage.cache.get(queueKey)).toEqual(queuedMessages);
+
+        const restoredAgent = await createAgentWithSharedStorage(
+            'stale-queue-agent',
+            sharedStorage
+        );
+
+        expect(await sharedStorage.database.get(`session:${sessionId}`)).toBeDefined();
+        expect(await sharedStorage.database.get(queueKey)).toBeUndefined();
+        expect(await sharedStorage.cache.get(queueKey)).toBeUndefined();
+
+        const restoredSession = await restoredAgent.getSession(sessionId);
+        expect(restoredSession).toBeDefined();
+        expect(await restoredAgent.getQueuedMessages(sessionId)).toEqual([]);
     });
 
     test('drops persisted interaction state when startup cleanup purges an expired session', async () => {

--- a/packages/core/src/session/session-manager.test.ts
+++ b/packages/core/src/session/session-manager.test.ts
@@ -41,6 +41,21 @@ describe('SessionManager', () => {
         messageCount: 5,
     };
 
+    const mockDatabaseLists = (options: { sessionKeys?: string[]; queueKeys?: string[] } = {}) => {
+        const { sessionKeys = [], queueKeys = [] } = options;
+        mockStorageManager.database.list.mockImplementation(async (prefix: string) => {
+            if (prefix === 'session:') {
+                return sessionKeys;
+            }
+
+            if (prefix === 'session-message-queue:') {
+                return queueKeys;
+            }
+
+            return [];
+        });
+    };
+
     beforeEach(() => {
         vi.resetAllMocks();
 
@@ -61,7 +76,7 @@ describe('SessionManager', () => {
             get: vi.fn().mockResolvedValue(null),
             set: vi.fn().mockResolvedValue(undefined),
             delete: vi.fn().mockResolvedValue(true),
-            list: vi.fn().mockResolvedValue([]),
+            list: vi.fn(),
             clear: vi.fn().mockResolvedValue(undefined),
             append: vi.fn().mockResolvedValue(undefined),
             getRange: vi.fn().mockResolvedValue([]),
@@ -97,6 +112,7 @@ describe('SessionManager', () => {
             database: mockDatabase,
             blobStore: mockBlobStore,
         };
+        mockDatabaseLists();
 
         // Mock services - use mockImplementation to defer evaluation until called
         // This ensures we get the current value of mockLLMConfig, not a stale reference
@@ -245,16 +261,29 @@ describe('SessionManager', () => {
         test('should initialize storage layer on first use', async () => {
             await sessionManager.init();
 
-            // Verify database.list is called to find existing sessions
-            expect(mockStorageManager.database.list).toHaveBeenCalledWith('session:');
+            expect(mockStorageManager.database.list).toHaveBeenNthCalledWith(
+                1,
+                'session-message-queue:'
+            );
+            expect(mockStorageManager.database.list).toHaveBeenNthCalledWith(2, 'session:');
         });
 
         test('should prevent duplicate initialization', async () => {
             await sessionManager.init();
             await sessionManager.init(); // Second call
 
-            // Should only call database.list once since it's already initialized
-            expect(mockStorageManager.database.list).toHaveBeenCalledTimes(1);
+            expect(mockStorageManager.database.list).toHaveBeenCalledTimes(2);
+        });
+
+        test('clears persisted queued messages on startup', async () => {
+            mockDatabaseLists({
+                queueKeys: ['session-message-queue:session-1', 'session-message-queue:session-2'],
+            });
+
+            await sessionManager.init();
+
+            expect(mockServices.messageQueueStore.delete).toHaveBeenCalledWith('session-1');
+            expect(mockServices.messageQueueStore.delete).toHaveBeenCalledWith('session-2');
         });
 
         test('should restore valid sessions from persistent storage on startup', async () => {
@@ -265,7 +294,7 @@ describe('SessionManager', () => {
                 lastActivity: new Date().getTime(), // Recent activity
             };
 
-            mockStorageManager.database.list.mockResolvedValue(existingSessionKeys);
+            mockDatabaseLists({ sessionKeys: existingSessionKeys });
             mockStorageManager.database.get.mockResolvedValue(validMetadata);
 
             await sessionManager.init();
@@ -283,7 +312,7 @@ describe('SessionManager', () => {
                 lastActivity: new Date(Date.now() - 7200000).getTime(), // 2 hours ago
             };
 
-            mockStorageManager.database.list.mockResolvedValue(existingSessionKeys);
+            mockDatabaseLists({ sessionKeys: existingSessionKeys });
             mockStorageManager.database.get.mockResolvedValue(expiredMetadata);
 
             await sessionManager.init();
@@ -1157,6 +1186,19 @@ describe('SessionManager', () => {
             for (const session of sessions) {
                 expect(session.cleanup).toHaveBeenCalled();
             }
+        });
+
+        test('clears persisted queued messages during shutdown', async () => {
+            mockDatabaseLists({
+                queueKeys: ['session-message-queue:session-1'],
+            });
+
+            await sessionManager.init();
+            mockServices.messageQueueStore.delete.mockClear();
+
+            await sessionManager.cleanup();
+
+            expect(mockServices.messageQueueStore.delete).toHaveBeenCalledWith('session-1');
         });
 
         test('should handle cleanup errors gracefully', async () => {

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -120,6 +120,7 @@ export class SessionManager {
     private sessions: Map<string, ChatSession> = new Map();
     private readonly maxSessions: number;
     private readonly sessionTTL: number;
+    private static readonly MESSAGE_QUEUE_KEY_PREFIX = 'session-message-queue:';
     private initialized = false;
     private cleanupInterval?: NodeJS.Timeout;
     private initializationPromise!: Promise<void>;
@@ -179,6 +180,8 @@ export class SessionManager {
         if (this.initialized) {
             return;
         }
+
+        await this.clearPersistedQueuedMessages('startup');
 
         // Restore any existing sessions from storage
         await this.restoreSessionsFromStorage();
@@ -241,6 +244,39 @@ export class SessionManager {
                 `Failed to restore sessions from storage: ${error instanceof Error ? error.message : String(error)}`
             );
             // Continue without restored sessions
+        }
+    }
+
+    private async clearPersistedQueuedMessages(reason: 'startup' | 'shutdown'): Promise<void> {
+        try {
+            const queueKeys = await this.services.storageManager
+                .getDatabase()
+                .list(SessionManager.MESSAGE_QUEUE_KEY_PREFIX);
+            if (queueKeys.length === 0) {
+                return;
+            }
+
+            await Promise.all(
+                queueKeys.map((key) =>
+                    this.services.messageQueueStore.delete(
+                        key.slice(SessionManager.MESSAGE_QUEUE_KEY_PREFIX.length)
+                    )
+                )
+            );
+
+            const message = `${reason === 'startup' ? 'Cleared stale queued follow-up state from previous agent run' : 'Cleared queued follow-up state during agent shutdown'} (${queueKeys.length} session bucket(s))`;
+            if (reason === 'startup') {
+                // TODO(issue-743): Replace startup purge with explicit resume semantics for interrupted queued follow-ups.
+                this.logger.info(message);
+            } else {
+                this.logger.debug(message);
+            }
+        } catch (error) {
+            this.logger.warn(
+                `Failed to clear persisted queued follow-up state during ${reason}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
         }
     }
 
@@ -1413,6 +1449,8 @@ export class SessionManager {
             delete this.cleanupInterval;
             this.logger.debug('Periodic session cleanup stopped');
         }
+
+        await this.clearPersistedQueuedMessages('shutdown');
 
         // End all in-memory sessions (preserve conversation history)
         const sessionIds = Array.from(this.sessions.keys());


### PR DESCRIPTION
## What changed
- clear persisted queued follow-up buckets during `SessionManager.cleanup()` as a best-effort shutdown cleanup
- purge any leftover queued follow-up buckets at `SessionManager.init()` before restoring sessions
- keep the change scoped to `SessionManager` by reusing the existing `messageQueueStore.delete(sessionId)` path
- update unit and integration coverage to reflect the new runtime-only queue semantics

## Why
Issue #743 came from queued follow-up messages surviving interruption without any explicit resume path. After an agent restart, those stale queued messages could be injected into the next unrelated user turn.

This PR takes the simpler policy for now: queued follow-ups are runtime-only. A graceful shutdown clears them best-effort, and startup purges anything left behind after an unclean exit.

## Impact
- queued follow-up messages no longer survive agent shutdown or crash
- session history, LLM overrides, tool preferences, and approval state still restore normally
- a TODO is left in core for future explicit resume semantics

## Validation
- `bash scripts/quality-checks.sh`
- `pnpm exec vitest run packages/core/src/session/session-manager.test.ts packages/core/src/session/session-manager.integration.test.ts`
- `pnpm run typecheck:core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Queued follow-up messages are now purged during session cleanup and on agent startup, preventing stale messages from persisting across restarts while preserving session settings.

* **Tests**
  * Added integration and unit tests covering explicit shutdown cleanup and unclean startup scenarios to verify queued-message purge behavior.

* **Chore**
  * Release note entry added to reflect the behavioral patch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->