### PR TITLE
[codex] Type image host contexts generically

### DIFF
--- a/packages/agent-config/README.md
+++ b/packages/agent-config/README.md
@@ -39,6 +39,34 @@ const agent = new DextoAgent(toDextoAgentOptions({ config, services }));
 await agent.start();
 ```
 
+## Typed host contexts
+
+Hosted runtimes can thread a typed host context through image resolution without baking any
+platform-specific fields into upstream packages.
+
+```ts
+import type { DextoHostContext, DextoImage } from '@dexto/agent-config';
+
+type CloudHostContext = DextoHostContext<
+  {
+    dextoCloudflare: {
+      runtimeContext: {
+        sessionId: string;
+      };
+    };
+  },
+  {
+    workspace: boolean;
+  }
+>;
+
+declare const image: DextoImage<CloudHostContext>;
+declare const hostContext: CloudHostContext;
+
+const services = await resolveServicesFromConfig(config, image, hostContext);
+const options = toDextoAgentOptions({ config, services, image, hostContext });
+```
+
 ## Images (no registries)
 
 Images are typed modules (`DextoImage`) that export plain `Record<string, Factory>` maps.

--- a/packages/agent-config/src/image/types.ts
+++ b/packages/agent-config/src/image/types.ts
@@ -38,23 +38,27 @@ export interface ToolFactoryMetadata {
  * This stays generic on purpose: hosts may pass clients, capability flags, and runtime metadata
  * without changing the public agent YAML shape.
  */
-export interface DextoHostContext {
+export interface DextoHostContext<
+    TRuntime extends object = object,
+    TCapabilities extends object = object,
+    TClients extends object = object,
+> {
     mode?: 'local' | 'server' | 'hosted';
     sessionId?: string;
     workspaceId?: string;
     runId?: string;
     attemptId?: string;
-    clients?: Record<string, unknown>;
-    capabilities?: Record<string, unknown>;
-    runtime?: Record<string, unknown>;
+    clients?: TClients;
+    capabilities?: TCapabilities;
+    runtime?: TRuntime;
 }
 
 /**
  * Shared resolver context passed to image factories.
  */
-export interface ImageResolutionContext {
+export interface ImageResolutionContext<THostContext extends DextoHostContext = DextoHostContext> {
     agentId: string;
-    hostContext?: DextoHostContext | undefined;
+    hostContext?: THostContext | undefined;
 }
 
 /**
@@ -64,9 +68,11 @@ export interface ImageResolutionContext {
  */
 export type DextoImageRuntimeConfigOverrides = Partial<Omit<DextoAgentConfigInput, 'agentId'>>;
 
-export interface ResolveImageRuntimeConfigOptions {
+export interface ResolveImageRuntimeConfigOptions<
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     config: ValidatedAgentConfig;
-    context: ImageResolutionContext;
+    context: ImageResolutionContext<THostContext>;
 }
 
 /**
@@ -75,11 +81,14 @@ export interface ResolveImageRuntimeConfigOptions {
  * A single factory entry can produce multiple tools, which is useful for "tool packs" where a single
  * config block enables a related set of tools (e.g., filesystem tools: read/write/edit/glob/grep).
  */
-export interface ToolFactory<TConfig = unknown> {
+export interface ToolFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     /** Zod schema for validating factory-specific configuration. */
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
     /** Create one or more tool instances from validated config. */
-    create(config: TConfig, context?: ImageResolutionContext): Tool[];
+    create(config: TConfig, context?: ImageResolutionContext<THostContext>): Tool[];
     metadata?: ToolFactoryMetadata;
 }
 
@@ -88,32 +97,41 @@ export interface ToolFactory<TConfig = unknown> {
  *
  * Factories may return a Promise to support lazy optional dependencies (e.g., sqlite/pg/redis).
  */
-export interface BlobStoreFactory<TConfig = unknown> {
+export interface BlobStoreFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
     create(
         config: TConfig,
         logger: Logger,
-        context?: ImageResolutionContext
+        context?: ImageResolutionContext<THostContext>
     ): BlobStore | Promise<BlobStore>;
     metadata?: Record<string, unknown> | undefined;
 }
 
-export interface DatabaseFactory<TConfig = unknown> {
+export interface DatabaseFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
     create(
         config: TConfig,
         logger: Logger,
-        context?: ImageResolutionContext
+        context?: ImageResolutionContext<THostContext>
     ): Database | Promise<Database>;
     metadata?: Record<string, unknown> | undefined;
 }
 
-export interface CacheFactory<TConfig = unknown> {
+export interface CacheFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
     create(
         config: TConfig,
         logger: Logger,
-        context?: ImageResolutionContext
+        context?: ImageResolutionContext<THostContext>
     ): Cache | Promise<Cache>;
     metadata?: Record<string, unknown> | undefined;
 }
@@ -121,20 +139,26 @@ export interface CacheFactory<TConfig = unknown> {
 /**
  * Hook factories are keyed by `type` in the agent config (`hooks: [{ type: "..." }]`).
  */
-export interface HookFactory<TConfig = unknown> {
+export interface HookFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
-    create(config: TConfig, context?: ImageResolutionContext): Hook;
+    create(config: TConfig, context?: ImageResolutionContext<THostContext>): Hook;
     metadata?: Record<string, unknown> | undefined;
 }
 
 /**
  * Compaction factories are keyed by `type` in the agent config (`compaction.type`).
  */
-export interface CompactionFactory<TConfig = unknown> {
+export interface CompactionFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
     create(
         config: TConfig,
-        context?: ImageResolutionContext
+        context?: ImageResolutionContext<THostContext>
     ): CompactionStrategy | Promise<CompactionStrategy>;
     metadata?: Record<string, unknown> | undefined;
 }
@@ -144,9 +168,12 @@ export interface CompactionFactory<TConfig = unknown> {
  *
  * This remains a factory (vs a map) because an agent should have a single logger implementation.
  */
-export interface LoggerFactory<TConfig = unknown> {
+export interface LoggerFactory<
+    TConfig = unknown,
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
-    create(config: TConfig, context?: ImageResolutionContext): Logger;
+    create(config: TConfig, context?: ImageResolutionContext<THostContext>): Logger;
     metadata?: Record<string, unknown> | undefined;
 }
 
@@ -159,7 +186,7 @@ export interface LoggerFactory<TConfig = unknown> {
  * - Factories are plain exports; resolution is explicit and testable
  * - Hosts decide how to load images (static import, dynamic import via `loadImage()`, allowlists, etc.)
  */
-export interface DextoImage {
+export interface DextoImage<THostContext extends DextoHostContext = DextoHostContext> {
     /**
      * Metadata about the image package.
      *
@@ -178,19 +205,19 @@ export interface DextoImage {
      * Tool factories keyed by config `type`.
      * Example: `{ "filesystem-tools": fileSystemToolsFactory }`.
      */
-    tools: Record<string, ToolFactory>;
+    tools: Record<string, ToolFactory<unknown, THostContext>>;
     /**
      * Storage factories keyed by config `type`.
      */
     storage: {
-        blob: Record<string, BlobStoreFactory>;
-        database: Record<string, DatabaseFactory>;
-        cache: Record<string, CacheFactory>;
+        blob: Record<string, BlobStoreFactory<unknown, THostContext>>;
+        database: Record<string, DatabaseFactory<unknown, THostContext>>;
+        cache: Record<string, CacheFactory<unknown, THostContext>>;
     };
-    hooks: Record<string, HookFactory>;
-    compaction: Record<string, CompactionFactory>;
-    logger: LoggerFactory;
+    hooks: Record<string, HookFactory<unknown, THostContext>>;
+    compaction: Record<string, CompactionFactory<unknown, THostContext>>;
+    logger: LoggerFactory<unknown, THostContext>;
     resolveRuntimeConfig?(
-        options: ResolveImageRuntimeConfigOptions
+        options: ResolveImageRuntimeConfigOptions<THostContext>
     ): DextoImageRuntimeConfigOverrides | undefined;
 }

--- a/packages/agent-config/src/resolver/resolve-services-from-config.test.ts
+++ b/packages/agent-config/src/resolver/resolve-services-from-config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
 import type { CompactionStrategy, Hook } from '@dexto/core';
-import type { DextoImage } from '../image/types.js';
+import type { DextoHostContext, DextoImage, ImageResolutionContext } from '../image/types.js';
 import { AgentConfigSchema, type AgentConfig } from '../schemas/agent-config.js';
 import { resolveServicesFromConfig } from './resolve-services-from-config.js';
 import {
@@ -28,7 +28,9 @@ describe('resolveServicesFromConfig', () => {
         compaction: { type: 'noop', enabled: false },
     };
 
-    function createMockImage(overrides?: Partial<DextoImage>): DextoImage {
+    function createMockImage<THostContext extends DextoHostContext = DextoHostContext>(
+        overrides?: Partial<DextoImage<THostContext>>
+    ): DextoImage<THostContext> {
         const loggerFactory = {
             configSchema: z
                 .object({
@@ -39,7 +41,7 @@ describe('resolveServicesFromConfig', () => {
             create: (_cfg: { agentId: string }) => createMockLogger(),
         };
 
-        const image: DextoImage = {
+        const image: DextoImage<THostContext> = {
             metadata: { name: 'mock-image', version: '0.0.0', description: 'mock' },
             tools: {},
             storage: {
@@ -72,11 +74,26 @@ describe('resolveServicesFromConfig', () => {
     }
 
     it('passes host context through factory resolution when provided', async () => {
-        const hostContext = {
+        type HostedContext = DextoHostContext<
+            { session: { id: string } },
+            { workspace: boolean },
+            { gateway: { id: string } }
+        >;
+
+        const hostContext: HostedContext = {
             mode: 'hosted' as const,
             sessionId: 'session-1',
             workspaceId: 'workspace-1',
             runId: 'run-1',
+            runtime: {
+                session: { id: 'session-1' },
+            },
+            capabilities: {
+                workspace: true,
+            },
+            clients: {
+                gateway: { id: 'gateway-1' },
+            },
         };
 
         const logger = createMockLogger();
@@ -84,7 +101,12 @@ describe('resolveServicesFromConfig', () => {
         const blobCreate = vi.fn(() => createMockBlobStore('in-memory'));
         const databaseCreate = vi.fn(() => createMockDatabase('in-memory'));
         const cacheCreate = vi.fn(() => createMockCache('in-memory'));
-        const toolCreate = vi.fn(() => [createMockTool('foo')]);
+        const toolCreate = vi.fn((_config, context?: ImageResolutionContext<HostedContext>) => {
+            expect(context?.hostContext?.runtime?.session.id).toBe('session-1');
+            expect(context?.hostContext?.capabilities?.workspace).toBe(true);
+            expect(context?.hostContext?.clients?.gateway.id).toBe('gateway-1');
+            return [createMockTool('foo')];
+        });
         const hookCreate = vi.fn(() => ({
             beforeResponse: async () => ({ ok: true }),
         }));
@@ -92,7 +114,7 @@ describe('resolveServicesFromConfig', () => {
             () => ({ execute: vi.fn(async () => null) }) as unknown as CompactionStrategy
         );
 
-        const image = createMockImage({
+        const image = createMockImage<HostedContext>({
             logger: {
                 configSchema: z
                     .object({

--- a/packages/agent-config/src/resolver/resolve-services-from-config.ts
+++ b/packages/agent-config/src/resolver/resolve-services-from-config.ts
@@ -36,13 +36,15 @@ function resolveByType<TFactory>(options: {
     return factory;
 }
 
-export async function resolveServicesFromConfig(
+export async function resolveServicesFromConfig<
+    THostContext extends DextoHostContext = DextoHostContext,
+>(
     config: ValidatedAgentConfig,
-    image: DextoImage,
-    hostContext?: DextoHostContext
+    image: DextoImage<THostContext>,
+    hostContext?: THostContext
 ): Promise<ResolvedServices> {
     const imageName = image.metadata.name;
-    const resolutionContext: ImageResolutionContext = {
+    const resolutionContext: ImageResolutionContext<THostContext> = {
         agentId: config.agentId,
         ...(hostContext ? { hostContext } : {}),
     };
@@ -147,11 +149,13 @@ export async function resolveServicesFromConfig(
     return { logger, storage, tools, toolkitLoader, hooks, compaction };
 }
 
-export function resolveToolsFromEntries(options: {
+export function resolveToolsFromEntries<
+    THostContext extends DextoHostContext = DextoHostContext,
+>(options: {
     entries: ToolFactoryEntry[];
-    image: DextoImage;
+    image: DextoImage<THostContext>;
     logger: Logger;
-    resolutionContext?: ImageResolutionContext | undefined;
+    resolutionContext?: ImageResolutionContext<THostContext> | undefined;
 }): Tool[] {
     const { entries, image, logger, resolutionContext } = options;
     const imageName = image.metadata.name;

--- a/packages/agent-config/src/resolver/to-dexto-agent-options.test.ts
+++ b/packages/agent-config/src/resolver/to-dexto-agent-options.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import type {
     DextoImage,
     DextoHostContext,
@@ -7,7 +8,6 @@ import type {
 import { AgentConfigSchema } from '../schemas/agent-config.js';
 import type { ResolvedServices } from './types.js';
 import { toDextoAgentOptions } from './to-dexto-agent-options.js';
-import validImage from './__fixtures__/valid-image.js';
 import {
     createMockBlobStore,
     createMockCache,
@@ -17,6 +17,49 @@ import {
 } from './__fixtures__/test-mocks.js';
 
 describe('toDextoAgentOptions', () => {
+    function createMockImage<THostContext extends DextoHostContext = DextoHostContext>(
+        overrides?: Partial<DextoImage<THostContext>>
+    ): DextoImage<THostContext> {
+        const image: DextoImage<THostContext> = {
+            metadata: { name: 'mock-image', version: '0.0.0', description: 'mock' },
+            tools: {
+                'noop-tools': {
+                    configSchema: z.object({ type: z.literal('noop-tools') }).passthrough(),
+                    create: () => [],
+                },
+            },
+            storage: {
+                blob: {
+                    'in-memory': {
+                        configSchema: z.any(),
+                        create: () => createMockBlobStore('in-memory'),
+                    },
+                },
+                database: {
+                    'in-memory': {
+                        configSchema: z.any(),
+                        create: () => createMockDatabase('in-memory'),
+                    },
+                },
+                cache: {
+                    'in-memory': {
+                        configSchema: z.any(),
+                        create: () => createMockCache('in-memory'),
+                    },
+                },
+            },
+            hooks: {},
+            compaction: {},
+            logger: {
+                configSchema: z.object({}).passthrough(),
+                create: () => createMockLogger(),
+            },
+            ...(overrides ?? {}),
+        };
+
+        return image;
+    }
+
     it('combines validated config + resolved services into DextoAgentOptions', () => {
         const validated = AgentConfigSchema.parse({
             systemPrompt: 'You are a helpful assistant',
@@ -175,10 +218,9 @@ describe('toDextoAgentOptions', () => {
                 };
             }
         );
-        const image: DextoImage<HostedContext> = {
-            ...validImage,
+        const image = createMockImage<HostedContext>({
             resolveRuntimeConfig,
-        };
+        });
 
         const options = toDextoAgentOptions({
             config: validated,

--- a/packages/agent-config/src/resolver/to-dexto-agent-options.test.ts
+++ b/packages/agent-config/src/resolver/to-dexto-agent-options.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { DextoImage, DextoHostContext } from '../image/types.js';
+import type {
+    DextoImage,
+    DextoHostContext,
+    ResolveImageRuntimeConfigOptions,
+} from '../image/types.js';
 import { AgentConfigSchema } from '../schemas/agent-config.js';
 import type { ResolvedServices } from './types.js';
 import { toDextoAgentOptions } from './to-dexto-agent-options.js';
@@ -137,21 +141,44 @@ describe('toDextoAgentOptions', () => {
             compaction: null,
         };
 
-        const hostContext: DextoHostContext = {
+        type HostedContext = DextoHostContext<
+            { session: { id: string } },
+            { workspace: boolean },
+            { gateway: { id: string } }
+        >;
+
+        const hostContext: HostedContext = {
             mode: 'hosted',
             sessionId: 'session-1',
             workspaceId: 'workspace-1',
-        };
-        const resolveRuntimeConfig = vi.fn(() => ({
-            llm: {
-                ...validated.llm,
-                apiKey: 'resolved-api-key',
+            runtime: {
+                session: { id: 'session-1' },
             },
-        }));
-        const image = {
+            capabilities: {
+                workspace: true,
+            },
+            clients: {
+                gateway: { id: 'gateway-1' },
+            },
+        };
+        const resolveRuntimeConfig = vi.fn(
+            ({ context }: ResolveImageRuntimeConfigOptions<HostedContext>) => {
+                expect(context.hostContext?.runtime?.session.id).toBe('session-1');
+                expect(context.hostContext?.capabilities?.workspace).toBe(true);
+                expect(context.hostContext?.clients?.gateway.id).toBe('gateway-1');
+
+                return {
+                    llm: {
+                        ...validated.llm,
+                        apiKey: 'resolved-api-key',
+                    },
+                };
+            }
+        );
+        const image: DextoImage<HostedContext> = {
             ...validImage,
             resolveRuntimeConfig,
-        } as unknown as DextoImage;
+        };
 
         const options = toDextoAgentOptions({
             config: validated,

--- a/packages/agent-config/src/resolver/to-dexto-agent-options.ts
+++ b/packages/agent-config/src/resolver/to-dexto-agent-options.ts
@@ -3,16 +3,20 @@ import type { DextoHostContext, DextoImage } from '../image/types.js';
 import type { ValidatedAgentConfig } from '../schemas/agent-config.js';
 import type { ResolvedServices } from './types.js';
 
-export interface ToDextoAgentOptionsInput {
+export interface ToDextoAgentOptionsInput<
+    THostContext extends DextoHostContext = DextoHostContext,
+> {
     config: ValidatedAgentConfig;
     services: ResolvedServices;
-    image?: DextoImage | undefined;
-    hostContext?: DextoHostContext | undefined;
+    image?: DextoImage<THostContext> | undefined;
+    hostContext?: THostContext | undefined;
     overrides?: InitializeServicesOptions | undefined;
     runtimeOverrides?: Pick<DextoAgentOptions, 'usageScopeId'> | undefined;
 }
 
-export function toDextoAgentOptions(options: ToDextoAgentOptionsInput): DextoAgentOptions {
+export function toDextoAgentOptions<THostContext extends DextoHostContext = DextoHostContext>(
+    options: ToDextoAgentOptionsInput<THostContext>
+): DextoAgentOptions {
     const { config, services, image, hostContext, overrides, runtimeOverrides } = options;
     const imageRuntimeConfig = image?.resolveRuntimeConfig?.({
         config,


### PR DESCRIPTION
## What changed

- genericized `DextoHostContext` so hosts can supply typed `runtime`, `capabilities`, and `clients`
- threaded that host-context generic through `ImageResolutionContext`, `ResolveImageRuntimeConfigOptions`, image factories, and `DextoImage`
- updated resolver tests to prove typed host context reaches tool, storage, and runtime resolution
- added a README example showing how hosted runtimes can use typed host contexts without baking platform-specific fields into upstream

## Why

`DextoHostContext.runtime` was previously modeled as `Record<string, unknown>`, which forced image consumers to fall back to casts or runtime guards right at the host seam. That is the wrong tradeoff for hosted images.

This change keeps upstream generic, but makes the seam type-safe for consumers like `image-cloud` and any future hosted image implementation. The key detail is that the generic defaults now use `object`, not `Record<string, unknown>`, so explicit host interfaces do not need fake index signatures to satisfy the constraint.

## Impact

Hosts can now define a concrete host context type and get compile-time access to host-owned runtime state throughout image resolution.

## Validation

- `pnpm exec vitest run packages/agent-config/src/resolver/resolve-services-from-config.test.ts packages/agent-config/src/resolver/to-dexto-agent-options.test.ts`
- `pnpm --filter @dexto/agent-management build`
- downstream local-link verification in `dexto-cloudflare` with the linked upstream worktree:
  - `pnpm format:check`
  - `pnpm lint`
  - `pnpm typecheck`
  - `pnpm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Typed host contexts" section showing how to pass a strongly-typed host context (runtime, capabilities, clients) through image resolution and agent option construction.

* **Features**
  * Improved type safety for host-context propagation across image resolution and agent option creation, enabling stronger compile-time validation of runtime context shapes.

* **Tests**
  * Updated tests and fixtures to cover typed host-context behavior and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->