### PR TITLE
Tighten session requirements across core chat flows

### DIFF
--- a/.changeset/curvy-swans-train.md
+++ b/.changeset/curvy-swans-train.md
@@ -1,0 +1,10 @@
+---
+'dexto': patch
+'@dexto/core': patch
+'@dexto/server': patch
+'@dexto/client-sdk': patch
+'@dexto/tools-filesystem': patch
+'@dexto/tools-todo': patch
+---
+
+Tighten session handling across chat and approval flows by removing implicit session creation, dropping global approval fallbacks, requiring real session IDs for session-scoped tool and directory state, and updating session-facing docs to match the current API behavior.

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Dexto is an **agent harness**—the orchestration layer that turns LLMs into rel
 
 Think of it like an operating system for AI agents:
 
-| Component | Analogy | Role |
-|-----------|---------|------|
-| **LLM** | CPU | Raw processing power |
-| **Context Window** | RAM | Working memory |
-| **Dexto** | Operating System | Orchestration, state, tools, recovery |
-| **Your Agent** | Application | Domain-specific logic and clients |
+| Component          | Analogy          | Role                                  |
+| ------------------ | ---------------- | ------------------------------------- |
+| **LLM**            | CPU              | Raw processing power                  |
+| **Context Window** | RAM              | Working memory                        |
+| **Dexto**          | Operating System | Orchestration, state, tools, recovery |
+| **Your Agent**     | Application      | Domain-specific logic and clients     |
 
 ### Why Dexto?
 
@@ -78,6 +78,7 @@ dexto --agent coding-agent
 ```
 
 **What it can do:**
+
 - Build new apps from scratch
 - Read, write, and refactor code across your entire codebase
 - Execute shell commands and run tests
@@ -86,6 +87,7 @@ dexto --agent coding-agent
 - Work with any of 50+ LLMs (swap models mid-conversation)
 
 **Ready-to-use interfaces:**
+
 - **Web UI** – Chat interface with file uploads, syntax highlighting, and MCP tool browser
 - **CLI** – Terminal-native with `/commands`, streaming output, and session management
 
@@ -110,6 +112,7 @@ cd dexto && pnpm install && pnpm install-cli
 ```
 
 Upgrade/uninstall and migration troubleshooting live in docs:
+
 - Installation guide: https://docs.dexto.ai/docs/getting-started/installation
 - CLI command reference: https://docs.dexto.ai/docs/guides/cli/overview
 
@@ -149,15 +152,15 @@ Logs are stored in `~/.dexto/logs/`. Use `DEXTO_LOG_LEVEL=debug` for verbose out
 
 Switch models mid-conversation—no code changes, no restarts.
 
-| Provider | Models |
-|----------|--------|
-| **OpenAI** | gpt-5.2, gpt-5.2-pro, gpt-5.2-codex, o4-mini |
-| **Anthropic** | Claude Sonnet, Opus, Haiku (with extended thinking) |
-| **Google** | Gemini 3 Pro, 2.5 Pro/Flash |
-| **Groq** | Llama 4, Qwen, DeepSeek |
-| **xAI** | Grok 4, Grok 3 |
-| **Local** | Ollama, GGUF via node-llama-cpp (Llama, Qwen, Mistral, etc.) |
-| **+ Gateways** | OpenRouter, AWS Bedrock, Vertex AI, LiteLLM |
+| Provider       | Models                                                       |
+| -------------- | ------------------------------------------------------------ |
+| **OpenAI**     | gpt-5.2, gpt-5.2-pro, gpt-5.2-codex, o4-mini                 |
+| **Anthropic**  | Claude Sonnet, Opus, Haiku (with extended thinking)          |
+| **Google**     | Gemini 3 Pro, 2.5 Pro/Flash                                  |
+| **Groq**       | Llama 4, Qwen, DeepSeek                                      |
+| **xAI**        | Grok 4, Grok 3                                               |
+| **Local**      | Ollama, GGUF via node-llama-cpp (Llama, Qwen, Mistral, etc.) |
+| **+ Gateways** | OpenRouter, AWS Bedrock, Vertex AI, LiteLLM                  |
 
 **Run locally for privacy**: Local models keep data on your machine with automatic GPU detection (Metal, CUDA, Vulkan).
 
@@ -168,14 +171,14 @@ Connect to Model Context Protocol servers—Puppeteer, Linear, ElevenLabs, Firec
 ```yaml
 # agents/my-agent.yml
 mcpServers:
-  filesystem:
-    type: stdio
-    command: npx
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
-  browser:
-    type: stdio
-    command: npx
-    args: ['-y', '@anthropics/mcp-server-puppeteer']
+    filesystem:
+        type: stdio
+        command: npx
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    browser:
+        type: stdio
+        command: npx
+        args: ['-y', '@anthropics/mcp-server-puppeteer']
 ```
 
 Browse and add servers from the MCP Store in the Web UI or via `/mcp` commands in the CLI.
@@ -186,14 +189,14 @@ Fine-grained control over what your agent can do:
 
 ```yaml
 permissions:
-  mode: manual           # Require approval for each tool
-  # mode: auto-approve   # Trust mode for local development
-  toolPolicies:
-    alwaysAllow:
-      - mcp--filesystem--read_file
-      - mcp--filesystem--list_directory
-    alwaysDeny:
-      - mcp--filesystem--delete_file
+    mode: manual # Require approval for each tool
+    # mode: auto-approve   # Trust mode for local development
+    toolPolicies:
+        alwaysAllow:
+            - mcp--filesystem--read_file
+            - mcp--filesystem--list_directory
+        alwaysDeny:
+            - mcp--filesystem--delete_file
 ```
 
 Agents remember which tools you've approved per session.
@@ -220,13 +223,14 @@ Agents can spawn specialized sub-agents to handle complex subtasks. The coding a
 ```yaml
 # In your agent config
 tools:
-  - type: agent-spawner
-    allowedAgents: ["explore-agent"]
-    maxConcurrentAgents: 5
-    defaultTimeout: 300000  # 5 minutes
+    - type: agent-spawner
+      allowedAgents: ['explore-agent']
+      maxConcurrentAgents: 5
+      defaultTimeout: 300000 # 5 minutes
 ```
 
 **Built-in sub-agents:**
+
 - **explore-agent** – Fast, read-only codebase exploration
 
 Any agent in the [Agent Registry](#agent-registry) can be spawned as a sub-agent—including custom agents you create and register.
@@ -237,12 +241,12 @@ Sub-agents run ephemerally, auto-cleanup after completion, and forward tool appr
 
 ## Run Modes
 
-| Mode | Command | Use Case |
-|------|---------|----------|
-| **Web UI** | `dexto` | Chat interface with file uploads (default) |
-| **CLI** | `dexto --mode cli` | Terminal interaction |
-| **Web Server** | `dexto --mode server` | REST & SSE APIs |
-| **MCP Server** | `dexto --mode mcp` | Expose agent as an MCP server over stdio |
+| Mode           | Command               | Use Case                                   |
+| -------------- | --------------------- | ------------------------------------------ |
+| **Web UI**     | `dexto`               | Chat interface with file uploads (default) |
+| **CLI**        | `dexto --mode cli`    | Terminal interaction                       |
+| **Web Server** | `dexto --mode server` | REST & SSE APIs                            |
+| **MCP Server** | `dexto --mode mcp`    | Expose agent as an MCP server over stdio   |
 
 Platform integrations: [Discord](examples/discord-bot/), [Telegram](examples/telegram-bot/)
 
@@ -263,8 +267,17 @@ Example MCP config for Claude Code or Cursor:
 
 ```json
 {
-  "command": "npx",
-  "args": ["-y", "dexto", "--mode", "mcp", "--agent", "coding-agent", "--auto-approve", "--no-elicitation"]
+    "command": "npx",
+    "args": [
+        "-y",
+        "dexto",
+        "--mode",
+        "mcp",
+        "--agent",
+        "coding-agent",
+        "--auto-approve",
+        "--no-elicitation"
+    ]
 }
 ```
 
@@ -295,7 +308,7 @@ npm install @dexto/core
 import { DextoAgent } from '@dexto/core';
 
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-5.2', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-5.2', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -305,14 +318,17 @@ console.log(response.content);
 
 // Streaming
 for await (const event of await agent.stream('Write a story', session.id)) {
-  if (event.name === 'llm:chunk') process.stdout.write(event.content);
+    if (event.name === 'llm:chunk') process.stdout.write(event.content);
 }
 
 // Multimodal
-await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64Data, mimeType: 'image/png' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64Data, mimeType: 'image/png' },
+    ],
+    session.id
+);
 
 // Switch models mid-conversation
 await agent.switchLLM({ model: 'claude-sonnet-4-5-20250929' });
@@ -346,13 +362,13 @@ const agent = new DextoAgent(config);
 await agent.start();
 
 // Create and manage sessions
-const session = await agent.createSession('user-123');
+const session = await agent.createSession();
 await agent.generate('Hello, how can you help me?', session.id);
 
 // List and manage sessions
 const sessions = await agent.listSessions();
-const history = await agent.getSessionHistory('user-123');
-await agent.deleteSession('user-123');
+const history = await agent.getSessionHistory(session.id);
+await agent.deleteSession(session.id);
 
 // Search across conversations
 const results = await agent.searchMessages('bug fix', { limit: 10 });
@@ -389,9 +405,9 @@ const manager = new MCPManager();
 
 // Connect to MCP servers
 await manager.connectServer('filesystem', {
-  type: 'stdio',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
 });
 
 // Access tools, prompts, and resources
@@ -412,19 +428,20 @@ Configure storage backends for production.
 ```yaml
 # agents/production-agent.yml
 storage:
-  cache:
-    type: redis
-    url: $REDIS_URL
-  database:
-    type: postgres
-    connectionString: $POSTGRES_CONNECTION_STRING
+    cache:
+        type: redis
+        url: $REDIS_URL
+    database:
+        type: postgres
+        connectionString: $POSTGRES_CONNECTION_STRING
 
 sessions:
-  maxSessions: 1000
-  sessionTTL: 86400000  # 24 hours
+    maxSessions: 1000
+    sessionTTL: 86400000 # 24 hours
 ```
 
 **Supported Backends:**
+
 - **Cache**: Redis, In-Memory
 - **Database**: PostgreSQL, SQLite, In-Memory
 
@@ -460,29 +477,29 @@ Dexto treats each configuration as a unique agent allowing you to define and sav
 ```yaml
 # agents/production-agent.yml
 llm:
-  provider: anthropic
-  model: claude-sonnet-4-5-20250929
-  apiKey: $ANTHROPIC_API_KEY
+    provider: anthropic
+    model: claude-sonnet-4-5-20250929
+    apiKey: $ANTHROPIC_API_KEY
 
 mcpServers:
-  filesystem:
-    type: stdio
-    command: npx
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    filesystem:
+        type: stdio
+        command: npx
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
 
 systemPrompt: |
-  You are a helpful assistant with filesystem access.
+    You are a helpful assistant with filesystem access.
 
 storage:
-  cache:
-    type: redis
-    url: $REDIS_URL
-  database:
-    type: postgres
-    connectionString: $POSTGRES_CONNECTION_STRING
+    cache:
+        type: redis
+        url: $REDIS_URL
+    database:
+        type: postgres
+        connectionString: $POSTGRES_CONNECTION_STRING
 
 permissions:
-  mode: manual
+    mode: manual
 ```
 
 ### LLM Providers
@@ -491,36 +508,36 @@ Switch between providers instantly—no code changes required.
 
 #### Built-in Providers
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **OpenAI** | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `o4-mini` | API key |
+| Provider      | Models                                                                      | Setup   |
+| ------------- | --------------------------------------------------------------------------- | ------- |
+| **OpenAI**    | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `o4-mini`                        | API key |
 | **Anthropic** | `claude-sonnet-4-5-20250929`, `claude-opus-4-5-20250929`, extended thinking | API key |
-| **Google** | `gemini-3-pro`, `gemini-2.5-pro`, `gemini-2.5-flash` | API key |
-| **Groq** | `llama-4-scout`, `qwen-qwq`, `deepseek-r1-distill` | API key |
-| **xAI** | `grok-4`, `grok-3`, `grok-3-fast` | API key |
-| **Cohere** | `command-r-plus`, `command-r` | API key |
+| **Google**    | `gemini-3-pro`, `gemini-2.5-pro`, `gemini-2.5-flash`                        | API key |
+| **Groq**      | `llama-4-scout`, `qwen-qwq`, `deepseek-r1-distill`                          | API key |
+| **xAI**       | `grok-4`, `grok-3`, `grok-3-fast`                                           | API key |
+| **Cohere**    | `command-r-plus`, `command-r`                                               | API key |
 
 #### Local Models (Privacy-First)
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **Ollama** | Llama, Qwen, Mistral, DeepSeek, etc. | Local install |
-| **node-llama-cpp** | Any GGUF model | Bundled (auto GPU detection: Metal, CUDA, Vulkan) |
+| Provider           | Models                               | Setup                                             |
+| ------------------ | ------------------------------------ | ------------------------------------------------- |
+| **Ollama**         | Llama, Qwen, Mistral, DeepSeek, etc. | Local install                                     |
+| **node-llama-cpp** | Any GGUF model                       | Bundled (auto GPU detection: Metal, CUDA, Vulkan) |
 
 #### Cloud Platforms
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **AWS Bedrock** | Claude, Llama, Mistral | AWS credentials |
-| **Google Vertex AI** | Gemini, Claude | GCP credentials |
+| Provider             | Models                 | Setup           |
+| -------------------- | ---------------------- | --------------- |
+| **AWS Bedrock**      | Claude, Llama, Mistral | AWS credentials |
+| **Google Vertex AI** | Gemini, Claude         | GCP credentials |
 
 #### Gateway Providers
 
-| Provider | Access | Setup |
-|----------|--------|-------|
-| **OpenRouter** | 100+ models from multiple providers | API key |
-| **LiteLLM** | Unified API for any provider | Self-hosted or API key |
-| **Glama** | Multi-provider gateway | API key |
+| Provider       | Access                              | Setup                  |
+| -------------- | ----------------------------------- | ---------------------- |
+| **OpenRouter** | 100+ models from multiple providers | API key                |
+| **LiteLLM**    | Unified API for any provider        | Self-hosted or API key |
+| **Glama**      | Multi-provider gateway              | API key                |
 
 ```bash
 # Switch models via CLI
@@ -537,50 +554,63 @@ See the [Configuration Guide](https://docs.dexto.ai/docs/category/agent-configur
 
 ## Demos & Examples
 
-| Image Editor | MCP Store | Portable Agents |
-|:---:|:---:|:---:|
+|                                   Image Editor                                   |                                 MCP Store                                  |                                    Portable Agents                                    |
+| :------------------------------------------------------------------------------: | :------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------: |
 | <img src=".github/assets/image_editor_demo.gif" alt="Image Editor" width="280"/> | <img src=".github/assets/mcp_store_demo.gif" alt="MCP Store" width="280"/> | <img src=".github/assets/portable_agent_demo.gif" alt="Portable Agents" width="280"/> |
-| Face detection & annotation using OpenCV | Browse and add MCPs | Use agents in Cursor, Claude Code via MCP|
+|                     Face detection & annotation using OpenCV                     |                            Browse and add MCPs                             |                       Use agents in Cursor, Claude Code via MCP                       |
 
 <details>
 <summary><strong>More Examples</strong></summary>
 
 ### Coding Agent
+
 Build applications from natural language:
+
 ```bash
 dexto --agent coding-agent
 # "Create a snake game and open it in the browser"
 ```
+
 <img src=".github/assets/coding_agent_demo.gif" alt="Coding Agent Demo" width="600"/>
 
 ### Podcast Agent
+
 Generate multi-speaker audio content:
+
 ```bash
 dexto --agent podcast-agent
 ```
+
 <img src="https://github.com/user-attachments/assets/cfd59751-3daa-4ccd-97b2-1b2862c96af1" alt="Podcast Agent Demo" width="600"/>
 
 ### Multi-Agent Triage
+
 Coordinate specialized agents:
+
 ```bash
 dexto --agent triage-agent
 ```
+
 <img src=".github/assets/triage_agent_demo.gif" alt="Triage Agent Demo" width="600">
 
 ### Memory System
+
 Persistent context that shapes behavior:
 <img src=".github/assets/memory_demo.gif" alt="Memory Demo" width="600">
 
 ### Dynamic Forms
+
 Agents generate forms for structured input:
 <img src=".github/assets/user_form_demo.gif" alt="User Form Demo" width="600">
 
 ### Browser Automation
+
 <a href="https://youtu.be/C-Z0aVbl4Ik">
   <img src="https://github.com/user-attachments/assets/3f5be5e2-7a55-4093-a071-8c52f1a83ba3" alt="Amazon Shopping Demo" width="600"/>
 </a>
 
 ### MCP Playground
+
 Test tools before deploying:
 <img src=".github/assets/playground_demo.gif" alt="Playground Demo" width="600">
 

--- a/docs/api/sdk/dexto-agent.md
+++ b/docs/api/sdk/dexto-agent.md
@@ -16,9 +16,9 @@ Creates a new Dexto agent instance with the provided configuration.
 constructor(config: AgentConfig)
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `config` | `AgentConfig` | Agent configuration object |
+| Parameter | Type          | Description                |
+| :-------- | :------------ | :------------------------- |
+| `config`  | `AgentConfig` | Agent configuration object |
 
 ### `start`
 
@@ -31,6 +31,7 @@ async start(): Promise<void>
 **Parameters:** None
 
 **Example:**
+
 ```typescript
 const agent = new DextoAgent(config);
 await agent.start();
@@ -45,6 +46,7 @@ async stop(): Promise<void>
 ```
 
 **Example:**
+
 ```typescript
 await agent.stop();
 ```
@@ -54,6 +56,7 @@ await agent.stop();
 ## Core Methods
 
 The Dexto Agent SDK provides three methods for processing messages:
+
 - **`generate()`** - Recommended for most use cases. Returns a complete response.
 - **`stream()`** - For real-time streaming UIs. Yields events as they arrive.
 - **`run()`** - Lower-level method for direct control.
@@ -70,13 +73,14 @@ async generate(
 ): Promise<GenerateResponse>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `content` | `string \| ContentPart[]` | User message (string) or multimodal content (array) |
-| `sessionId` | `string` | **Required.** Session ID for the conversation |
-| `options.signal` | `AbortSignal` | (Optional) For cancellation |
+| Parameter        | Type                      | Description                                         |
+| :--------------- | :------------------------ | :-------------------------------------------------- |
+| `content`        | `string \| ContentPart[]` | User message (string) or multimodal content (array) |
+| `sessionId`      | `string`                  | **Required.** Session ID for the conversation       |
+| `options.signal` | `AbortSignal`             | (Optional) For cancellation                         |
 
 **Content Types:**
+
 ```typescript
 // Simple string content
 type ContentInput = string | ContentPart[];
@@ -84,24 +88,38 @@ type ContentInput = string | ContentPart[];
 // For multimodal content, use ContentPart array:
 type ContentPart = TextPart | ImagePart | FilePart;
 
-interface TextPart { type: 'text'; text: string; }
-interface ImagePart { type: 'image'; image: string; mimeType?: string; }
-interface FilePart { type: 'file'; data: string; mimeType: string; filename?: string; }
+interface TextPart {
+    type: 'text';
+    text: string;
+}
+interface ImagePart {
+    type: 'image';
+    image: string;
+    mimeType?: string;
+}
+interface FilePart {
+    type: 'file';
+    data: string;
+    mimeType: string;
+    filename?: string;
+}
 ```
 
 **Returns:** `Promise<GenerateResponse>`
+
 ```typescript
 interface GenerateResponse {
-  content: string;           // The AI's text response
-  reasoning?: string;        // Extended thinking (o1/o3 models)
-  usage: TokenUsage;         // Token usage statistics
-  toolCalls: AgentToolCall[]; // Tools that were called
-  sessionId: string;
-  messageId: string;
+    content: string; // The AI's text response
+    reasoning?: string; // Extended thinking (o1/o3 models)
+    usage: TokenUsage; // Token usage statistics
+    toolCalls: AgentToolCall[]; // Tools that were called
+    sessionId: string;
+    messageId: string;
 }
 ```
 
 **Example:**
+
 ```typescript
 const agent = new DextoAgent(config);
 await agent.start();
@@ -114,28 +132,40 @@ console.log(response.content); // "4"
 console.log(response.usage.totalTokens); // Token count
 
 // With image URL (auto-detected)
-const response = await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: 'https://example.com/photo.jpg' }
-], session.id);
+const response = await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: 'https://example.com/photo.jpg' },
+    ],
+    session.id
+);
 
 // With image base64
-const response = await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64Image, mimeType: 'image/png' }
-], session.id);
+const response = await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64Image, mimeType: 'image/png' },
+    ],
+    session.id
+);
 
 // With file URL
-const response = await agent.generate([
-  { type: 'text', text: 'Summarize this document' },
-  { type: 'file', data: 'https://example.com/doc.pdf', mimeType: 'application/pdf' }
-], session.id);
+const response = await agent.generate(
+    [
+        { type: 'text', text: 'Summarize this document' },
+        { type: 'file', data: 'https://example.com/doc.pdf', mimeType: 'application/pdf' },
+    ],
+    session.id
+);
 
 // With file base64
-const response = await agent.generate([
-  { type: 'text', text: 'Summarize this document' },
-  { type: 'file', data: base64Pdf, mimeType: 'application/pdf', filename: 'doc.pdf' }
-], session.id);
+const response = await agent.generate(
+    [
+        { type: 'text', text: 'Summarize this document' },
+        { type: 'file', data: base64Pdf, mimeType: 'application/pdf', filename: 'doc.pdf' },
+    ],
+    session.id
+);
 
 // With cancellation support
 const controller = new AbortController();
@@ -156,36 +186,40 @@ async stream(
 ): Promise<AsyncIterableIterator<StreamingEvent>>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `content` | `string \| ContentPart[]` | User message (string) or multimodal content (array) |
-| `sessionId` | `string` | **Required.** Session ID |
-| `options.signal` | `AbortSignal` | (Optional) For cancellation |
+| Parameter        | Type                      | Description                                         |
+| :--------------- | :------------------------ | :-------------------------------------------------- |
+| `content`        | `string \| ContentPart[]` | User message (string) or multimodal content (array) |
+| `sessionId`      | `string`                  | **Required.** Session ID                            |
+| `options.signal` | `AbortSignal`             | (Optional) For cancellation                         |
 
 **Returns:** `Promise<AsyncIterableIterator<StreamingEvent>>`
 
 **Example:**
+
 ```typescript
 const session = await agent.createSession();
 
 // Simple text streaming
 for await (const event of await agent.stream('Write a poem', session.id)) {
-  if (event.name === 'llm:chunk') {
-    process.stdout.write(event.content);
-  }
-  if (event.name === 'llm:tool-call') {
-    console.log(`\n[Using ${event.toolName}]\n`);
-  }
+    if (event.name === 'llm:chunk') {
+        process.stdout.write(event.content);
+    }
+    if (event.name === 'llm:tool-call') {
+        console.log(`\n[Using ${event.toolName}]\n`);
+    }
 }
 
 // Streaming with image
-for await (const event of await agent.stream([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64Image, mimeType: 'image/png' }
-], session.id)) {
-  if (event.name === 'llm:chunk') {
-    process.stdout.write(event.content);
-  }
+for await (const event of await agent.stream(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64Image, mimeType: 'image/png' },
+    ],
+    session.id
+)) {
+    if (event.name === 'llm:chunk') {
+        process.stdout.write(event.content);
+    }
 }
 ```
 
@@ -203,17 +237,18 @@ async run(
 ): Promise<string>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `textInput` | `string` | User message or query |
-| `imageDataInput` | `{ image: string; mimeType: string } \| undefined` | Image data or undefined |
-| `fileDataInput` | `{ data: string; mimeType: string; filename?: string } \| undefined` | File data or undefined |
-| `sessionId` | `string` | **Required.** Session ID |
-| `stream` | `boolean` | (Optional) Enable streaming (default: false) |
+| Parameter        | Type                                                                 | Description                                  |
+| :--------------- | :------------------------------------------------------------------- | :------------------------------------------- |
+| `textInput`      | `string`                                                             | User message or query                        |
+| `imageDataInput` | `{ image: string; mimeType: string } \| undefined`                   | Image data or undefined                      |
+| `fileDataInput`  | `{ data: string; mimeType: string; filename?: string } \| undefined` | File data or undefined                       |
+| `sessionId`      | `string`                                                             | **Required.** Session ID                     |
+| `stream`         | `boolean`                                                            | (Optional) Enable streaming (default: false) |
 
 **Returns:** `Promise<string>` - AI response text
 
 **Example:**
+
 ```typescript
 const agent = new DextoAgent(config);
 await agent.start();
@@ -221,18 +256,15 @@ await agent.start();
 const session = await agent.createSession();
 
 // Recommended: Use generate() for most use cases
-const response = await agent.generate(
-  "Explain quantum computing",
-  session.id
-);
+const response = await agent.generate('Explain quantum computing', session.id);
 console.log(response.content);
 
 // Lower-level run() method (returns just the text)
 const responseText = await agent.run(
-  "Explain quantum computing",
-  undefined,  // no image
-  undefined,  // no file
-  session.id
+    'Explain quantum computing',
+    undefined, // no image
+    undefined, // no file
+    session.id
 );
 
 await agent.stop();
@@ -246,8 +278,8 @@ Cancels the currently running turn for a session.
 async cancel(sessionId: string): Promise<boolean>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter   | Type     | Description                        |
+| :---------- | :------- | :--------------------------------- |
 | `sessionId` | `string` | **Required.** Session ID to cancel |
 
 **Returns:** `Promise<boolean>` - true if a run was in progress and cancelled
@@ -262,29 +294,28 @@ DextoAgent's core is **stateless** and does not track a "current" or "default" s
 
 ### `createSession`
 
-Creates a new conversation session with optional custom ID.
+Creates a new conversation session. Standard callers should omit `sessionId` and use the
+generated ID that comes back.
 
 ```typescript
 async createSession(sessionId?: string): Promise<ChatSession>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `sessionId` | `string` | (Optional) Custom session ID |
+| Parameter   | Type     | Description                                                         |
+| :---------- | :------- | :------------------------------------------------------------------ |
+| `sessionId` | `string` | (Optional) Integration override. Standard callers should omit this. |
 
 **Returns:** `Promise<ChatSession>`
 
 **Example:**
+
 ```typescript
 // Create a new session (auto-generated ID)
 const session = await agent.createSession();
 console.log(`Created session: ${session.id}`);
 
-// Create a session with custom ID
-const userSession = await agent.createSession('user-123');
-
 // Use the session for conversations
-await agent.generate("Hello!", session.id);
+await agent.generate('Hello!', session.id);
 ```
 
 ### `getSession`
@@ -295,8 +326,8 @@ Retrieves an existing session by its ID.
 async getSession(sessionId: string): Promise<ChatSession | undefined>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter   | Type     | Description            |
+| :---------- | :------- | :--------------------- |
 | `sessionId` | `string` | Session ID to retrieve |
 
 **Returns:** `Promise<ChatSession | undefined>`
@@ -319,8 +350,8 @@ Permanently deletes a session and all its conversation history. This action cann
 async deleteSession(sessionId: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter   | Type     | Description          |
+| :---------- | :------- | :------------------- |
 | `sessionId` | `string` | Session ID to delete |
 
 **Note:** This completely removes the session and all associated conversation data from storage.
@@ -333,8 +364,8 @@ Clears the conversation history of a session while keeping the session active.
 async resetConversation(sessionId: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter   | Type     | Description         |
+| :---------- | :------- | :------------------ |
 | `sessionId` | `string` | Session ID to reset |
 
 ### `getSessionMetadata`
@@ -345,9 +376,9 @@ Retrieves metadata for a session including creation time and message count.
 async getSessionMetadata(sessionId: string): Promise<SessionMetadata | undefined>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `sessionId` | `string` | Session ID |
+| Parameter   | Type     | Description |
+| :---------- | :------- | :---------- |
+| `sessionId` | `string` | Session ID  |
 
 **Returns:** `Promise<SessionMetadata | undefined>`
 
@@ -359,9 +390,9 @@ Gets the complete conversation history for a session.
 async getSessionHistory(sessionId: string): Promise<ConversationHistory>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `sessionId` | `string` | Session ID |
+| Parameter   | Type     | Description |
+| :---------- | :------- | :---------- |
+| `sessionId` | `string` | Session ID  |
 
 **Returns:** `Promise<ConversationHistory>`
 
@@ -380,17 +411,17 @@ async switchLLM(
 ): Promise<ValidatedLLMConfig>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter    | Type         | Description                                               |
+| :----------- | :----------- | :-------------------------------------------------------- |
 | `llmUpdates` | `LLMUpdates` | LLM configuration updates (model, provider, apiKey, etc.) |
-| `sessionId` | `string` | (Optional) Target session ID |
+| `sessionId`  | `string`     | (Optional) Target session ID                              |
 
 **Returns:** `Promise<ValidatedLLMConfig>` – the fully validated, effective LLM configuration.
 
 ```typescript
-const config = await agent.switchLLM({ 
-  provider: 'anthropic', 
-  model: 'claude-sonnet-4-5-20250929' 
+const config = await agent.switchLLM({
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5-20250929',
 });
 console.log(config.model);
 ```
@@ -413,8 +444,8 @@ Gets the complete effective configuration for a session or the default configura
 getEffectiveConfig(sessionId?: string): Readonly<AgentConfig>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
+| Parameter   | Type     | Description           |
+| :---------- | :------- | :-------------------- |
 | `sessionId` | `string` | (Optional) Session ID |
 
 **Returns:** `Readonly<AgentConfig>`
@@ -431,10 +462,10 @@ Adds and connects to a new MCP server, making its tools available to the agent.
 async addMcpServer(name: string, config: McpServerConfig): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `name` | `string` | Server name |
-| `config` | `McpServerConfig` | Server configuration |
+| Parameter | Type              | Description          |
+| :-------- | :---------------- | :------------------- |
+| `name`    | `string`          | Server name          |
+| `config`  | `McpServerConfig` | Server configuration |
 
 ### `removeMcpServer`
 
@@ -444,9 +475,9 @@ Disconnects from an MCP server and removes it completely from the agent.
 async removeMcpServer(name: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `name` | `string` | Server name to remove |
+| Parameter | Type     | Description           |
+| :-------- | :------- | :-------------------- |
+| `name`    | `string` | Server name to remove |
 
 ### `enableMcpServer`
 
@@ -456,9 +487,9 @@ Enables a disabled MCP server and connects it.
 async enableMcpServer(name: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `name` | `string` | Server name to enable |
+| Parameter | Type     | Description           |
+| :-------- | :------- | :-------------------- |
+| `name`    | `string` | Server name to enable |
 
 ### `disableMcpServer`
 
@@ -468,9 +499,9 @@ Disables an MCP server and disconnects it. The server remains registered but ina
 async disableMcpServer(name: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `name` | `string` | Server name to disable |
+| Parameter | Type     | Description            |
+| :-------- | :------- | :--------------------- |
+| `name`    | `string` | Server name to disable |
 
 ### `restartMcpServer`
 
@@ -480,9 +511,9 @@ Restarts an MCP server by disconnecting and reconnecting with its original confi
 async restartMcpServer(name: string): Promise<void>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `name` | `string` | Server name to restart |
+| Parameter | Type     | Description            |
+| :-------- | :------- | :--------------------- |
+| `name`    | `string` | Server name to restart |
 
 ### `executeTool`
 
@@ -492,10 +523,10 @@ Executes a tool from any source (MCP servers, custom tools, or internal tools). 
 async executeTool(toolName: string, args: any): Promise<any>
 ```
 
-| Parameter | Type | Description |
-| :--- | :--- | :--- |
-| `toolName` | `string` | Tool name |
-| `args` | `any` | Tool arguments |
+| Parameter  | Type     | Description    |
+| :--------- | :------- | :------------- |
+| `toolName` | `string` | Tool name      |
+| `args`     | `any`    | Tool arguments |
 
 **Returns:** `Promise<any>` - Tool execution result
 
@@ -537,7 +568,7 @@ Returns a record of failed MCP server connections and their error messages.
 getMcpFailedConnections(): Record<string, string>
 ```
 
-**Returns:** `Record<string, string>` - Failed connection names to error messages 
+**Returns:** `Record<string, string>` - Failed connection names to error messages
 
 ---
 

--- a/docs/docs/architecture/services.md
+++ b/docs/docs/architecture/services.md
@@ -6,15 +6,15 @@ Dexto's architecture is built around core services that handle different aspects
 
 ## Service Overview
 
-| Service | Purpose | Key Responsibilities |
-|---------|---------|---------------------|
-| **DextoAgent** | Main orchestrator | Coordinates all services, handles user interactions |
-| **MCPManager** | Tool coordination | Connects to MCP servers, manages tools and resources |
-| **ToolManager** | Tool execution | Executes tools, handles confirmations, manages internal tools |
-| **SessionManager** | Conversation state | Manages chat sessions, conversation history |
-| **StorageManager** | Data persistence | Handles cache and database storage |
-| **SystemPromptManager** | System prompts | Manages system prompt assembly and dynamic content |
-| **AgentEventBus** | Event coordination | Handles inter-service communication |
+| Service                 | Purpose            | Key Responsibilities                                          |
+| ----------------------- | ------------------ | ------------------------------------------------------------- |
+| **DextoAgent**          | Main orchestrator  | Coordinates all services, handles user interactions           |
+| **MCPManager**          | Tool coordination  | Connects to MCP servers, manages tools and resources          |
+| **ToolManager**         | Tool execution     | Executes tools, handles confirmations, manages internal tools |
+| **SessionManager**      | Conversation state | Manages chat sessions, conversation history                   |
+| **StorageManager**      | Data persistence   | Handles cache and database storage                            |
+| **SystemPromptManager** | System prompts     | Manages system prompt assembly and dynamic content            |
+| **AgentEventBus**       | Event coordination | Handles inter-service communication                           |
 
 ## Service Relationships
 
@@ -45,7 +45,8 @@ graph TB
 
     STM --> Cache
     STM --> DB
-```
+
+````
 </ExpandableMermaid>
 
 ## DextoAgent
@@ -57,7 +58,7 @@ graph TB
 - `generate(message, options)` - Execute user prompt (recommended)
 - `run(prompt, imageData?, fileData?, sessionId)` - Lower-level execution
 - `switchLLM(updates)` - Change LLM model/provider
-- `createSession(sessionId?)` - Create new chat session
+- `createSession(sessionId?)` - Create new chat session (standard callers omit `sessionId`)
 - `stop()` - Shutdown all services
 
 ### Usage Example
@@ -76,30 +77,33 @@ console.log(response.content);
 await agent.switchLLM({ model: "claude-sonnet-4-5-20250929" });
 
 await agent.stop();
-```
+````
 
 ## MCPManager
 
 **Tool coordination** service that connects to Model Context Protocol servers.
 
 ### Key Methods
+
 - `connectServer(name, config)` - Connect to MCP server
 - `disconnectServer(name)` - Disconnect server
 - `getAllTools()` - Get all available tools
 - `executeTool(name, params)` - Execute specific tool
 
 ### Server Types
+
 - **stdio** - Command-line programs
-- **http** - HTTP REST endpoints  
+- **http** - HTTP REST endpoints
 - **sse** - Server-sent events
 
 ### Usage Example
+
 ```typescript
 // Connect filesystem tools
 await agent.mcpManager.connectServer('filesystem', {
-  type: 'stdio',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
 });
 
 // Get available tools
@@ -111,17 +115,21 @@ const tools = await agent.mcpManager.getAllTools();
 **Tool execution** service that handles tool calls and confirmations.
 
 ### Key Methods
+
 - `getToolStats()` - Get tool counts (MCP + internal)
 - `getAllTools()` - Get all available tools
 - `executeTool(call)` - Execute tool with confirmation
 
 ### Tool Confirmation
+
 Controls when users are prompted to approve tool execution:
+
 - **auto** - Smart approval based on tool risk
-- **always** - Always ask for confirmation  
+- **always** - Always ask for confirmation
 - **never** - Never ask (auto-approve)
 
 ### Usage Example
+
 ```typescript
 // Get tool statistics
 const stats = await agent.toolManager.getToolStats();
@@ -133,7 +141,8 @@ console.log(`${stats.total} tools: ${stats.mcp} MCP, ${stats.internal} internal`
 **Conversation state** management for persistent chat sessions.
 
 ### Key Methods
-- `createSession(sessionId?)` - Create new session
+
+- `createSession(sessionId?)` - Create new session (standard callers omit `sessionId`)
 - `getSession(sessionId)` - Retrieve existing session
 - `listSessions()` - List all sessions
 - `deleteSession(sessionId)` - Delete session
@@ -141,24 +150,26 @@ console.log(`${stats.total} tools: ${stats.mcp} MCP, ${stats.internal} internal`
 - `resetConversation(sessionId)` - Clear session history while keeping session active
 
 ### Session Features
+
 - Persistent conversation history
 - Session metadata (creation time, last activity)
 - Cross-session search capabilities
 - Export/import functionality
 
 ### Usage Example
+
 ```typescript
 // Create new session
-const session = await agent.createSession('work-session');
+const session = await agent.createSession();
 
 // List all sessions
 const sessions = await agent.listSessions();
 
 // Get conversation history
-const history = await agent.getSessionHistory('work-session');
+const history = await agent.getSessionHistory(session.id);
 
 // Use session in conversations
-const response = await agent.generate("Hello", session.id);
+const response = await agent.generate('Hello', session.id);
 console.log(response.content);
 ```
 
@@ -167,26 +178,29 @@ console.log(response.content);
 **Data persistence** using two-tier architecture.
 
 ### Storage Tiers
+
 - **Cache** - Fast, ephemeral (Redis or in-memory)
 - **Database** - Persistent, reliable (PostgreSQL, SQLite)
 
 ### Backends
-| Backend | Use Case | Configuration |
-|---------|----------|---------------|
-| **in-memory** | Development, testing | No config needed |
-| **sqlite** | Single instance, persistence | `path: ./data/dexto.db` |
-| **postgres** | Production, scaling | `connectionString: $POSTGRES_URL` |
-| **redis** | Fast caching | `url: $REDIS_URL` |
+
+| Backend       | Use Case                     | Configuration                     |
+| ------------- | ---------------------------- | --------------------------------- |
+| **in-memory** | Development, testing         | No config needed                  |
+| **sqlite**    | Single instance, persistence | `path: ./data/dexto.db`           |
+| **postgres**  | Production, scaling          | `connectionString: $POSTGRES_URL` |
+| **redis**     | Fast caching                 | `url: $REDIS_URL`                 |
 
 ### Usage Pattern
+
 ```yaml
 storage:
-  cache:
-    type: redis                    # Fast access
-    url: $REDIS_URL
-  database:
-    type: postgres                 # Persistent storage
-    connectionString: $POSTGRES_CONNECTION_STRING
+    cache:
+        type: redis # Fast access
+        url: $REDIS_URL
+    database:
+        type: postgres # Persistent storage
+        connectionString: $POSTGRES_CONNECTION_STRING
 ```
 
 ## SystemPromptManager
@@ -194,29 +208,32 @@ storage:
 **System prompt** assembly from multiple contributors.
 
 ### Contributor Types
+
 - **static** - Fixed text content
-- **dynamic** - Generated content (e.g., current date/time)  
+- **dynamic** - Generated content (e.g., current date/time)
 - **file** - Content from files (.md, .txt)
 
 ### Priority System
+
 Lower numbers execute first (0 = highest priority).
 
 ### Usage Example
+
 ```yaml
 systemPrompt:
-  contributors:
-    - id: primary
-      type: static
-      priority: 0
-      content: "You are a helpful AI assistant..."
-    - id: date
-      type: dynamic
-      priority: 10
-      source: date
-    - id: context
-      type: file
-      priority: 5
-      files: ["./docs/context.md"]
+    contributors:
+        - id: primary
+          type: static
+          priority: 0
+          content: 'You are a helpful AI assistant...'
+        - id: date
+          type: dynamic
+          priority: 10
+          source: date
+        - id: context
+          type: file
+          priority: 5
+          files: ['./docs/context.md']
 ```
 
 ## AgentEventBus
@@ -224,6 +241,7 @@ systemPrompt:
 **Event coordination** for inter-service communication.
 
 ### Event Types
+
 - **llm:thinking** - AI is processing
 - **llm:chunk** - Streaming response chunk
 - **llm:tool-call** - Tool execution starting
@@ -231,13 +249,14 @@ systemPrompt:
 - **llm:response** - Final response ready
 
 ### Usage Example
+
 ```typescript
 agent.on('llm:tool-call', (event) => {
-  console.log(`Executing tool: ${event.toolName}`);
+    console.log(`Executing tool: ${event.toolName}`);
 });
 
 agent.on('llm:response', (event) => {
-  console.log(`Response: ${event.content}`);
+    console.log(`Response: ${event.content}`);
 });
 ```
 
@@ -255,6 +274,7 @@ Services are initialized automatically when `DextoAgent.start()` is called:
 ## Debugging Services
 
 ### Log Levels
+
 ```bash
 # Enable debug logging
 DEXTO_LOG_LEVEL=debug dexto
@@ -264,6 +284,7 @@ DEXTO_LOG_LEVEL=silly dexto  # Most verbose
 ```
 
 ### Service Health Checks
+
 ```typescript
 // Check MCP connections
 const connectedServers = agent.mcpManager.getClients();
@@ -277,6 +298,7 @@ const storageHealth = agent.storageManager.getStatus();
 ```
 
 ### Common Issues
+
 - **MCP connection failures** - Check command paths, network access
 - **Storage errors** - Verify database/Redis connections
 - **Tool execution timeouts** - Increase timeout in server config
@@ -289,27 +311,27 @@ Each service can be configured through the agent config:
 ```yaml
 # MCP server connections
 mcpServers:
-  filesystem:
-    type: stdio
-    command: npx
-    timeout: 30000
+    filesystem:
+        type: stdio
+        command: npx
+        timeout: 30000
 
 # Storage backends
 storage:
-  cache:
-    type: redis
-  database:
-    type: postgres
+    cache:
+        type: redis
+    database:
+        type: postgres
 
 # Session limits
 sessions:
-  maxSessions: 100
-  sessionTTL: 3600000
+    maxSessions: 100
+    sessionTTL: 3600000
 
 # Permissions
 permissions:
-  mode: auto
-  timeout: 30000
+    mode: auto
+    timeout: 30000
 ```
 
 See [Configuration Guide](../guides/configuring-dexto/overview.md) for complete config options.

--- a/docs/docs/architecture/services.md
+++ b/docs/docs/architecture/services.md
@@ -124,9 +124,9 @@ const tools = await agent.mcpManager.getAllTools();
 
 Controls when users are prompted to approve tool execution:
 
-- **auto** - Smart approval based on tool risk
-- **always** - Always ask for confirmation
-- **never** - Never ask (auto-approve)
+- **manual** - Always ask for confirmation
+- **auto-approve** - Never ask and allow execution
+- **auto-deny** - Never ask and deny execution
 
 ### Usage Example
 

--- a/docs/docs/guides/dexto-sdk.md
+++ b/docs/docs/guides/dexto-sdk.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-title: "Dexto Agent SDK Guide"
+title: 'Dexto Agent SDK Guide'
 ---
 
 import ExpandableMermaid from '@site/src/components/ExpandableMermaid';
@@ -32,11 +32,11 @@ Here's a quick example of how to create a simple agent that uses the OpenAI API:
 import { DextoAgent } from '@dexto/core';
 
 const agent = new DextoAgent({
-  llm: {
-    provider: 'openai',
-    model: 'gpt-5',
-    apiKey: process.env.OPENAI_API_KEY,
-  }
+    llm: {
+        provider: 'openai',
+        model: 'gpt-5',
+        apiKey: process.env.OPENAI_API_KEY,
+    },
 });
 
 await agent.start();
@@ -60,6 +60,7 @@ The Dexto SDK provides a complete TypeScript library for building AI agents with
 ### When to Use the SDK vs REST API
 
 **Use the Dexto SDK when:**
+
 - Building TypeScript applications
 - Need real-time event handling
 - Want type safety and IDE support
@@ -67,6 +68,7 @@ The Dexto SDK provides a complete TypeScript library for building AI agents with
 - Building long-running applications
 
 **Use the REST API when:**
+
 - Working in other languages
 - Building simple integrations
 - Prefer stateless interactions
@@ -87,11 +89,11 @@ import { DextoAgent } from '@dexto/core';
 
 // Create agent with minimal configuration
 const agent = new DextoAgent({
-  llm: {
-    provider: 'openai',
-    model: 'gpt-5',
-    apiKey: process.env.OPENAI_API_KEY
-  }
+    llm: {
+        provider: 'openai',
+        model: 'gpt-5',
+        apiKey: process.env.OPENAI_API_KEY,
+    },
 });
 await agent.start();
 
@@ -105,32 +107,32 @@ console.log(response.content);
 
 ```typescript
 const agent = new DextoAgent({
-  llm: {
-    provider: 'openai',
-    model: 'gpt-5',
-    apiKey: process.env.OPENAI_API_KEY
-  },
-  permissions: { mode: 'auto-approve' },
-  mcpServers: {
-    filesystem: {
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    llm: {
+        provider: 'openai',
+        model: 'gpt-5',
+        apiKey: process.env.OPENAI_API_KEY,
     },
-    web: {
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-brave-search']
-    }
-  }
+    permissions: { mode: 'auto-approve' },
+    mcpServers: {
+        filesystem: {
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
+        },
+        web: {
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-brave-search'],
+        },
+    },
 });
 await agent.start();
 
 // Create session and use the agent with filesystem and web search tools
 const session = await agent.createSession();
 const response = await agent.generate(
-  'List the files in this directory and search for recent AI news',
-  session.id
+    'List the files in this directory and search for recent AI news',
+    session.id
 );
 console.log(response.content);
 ```
@@ -148,8 +150,8 @@ const agent = new DextoAgent(config);
 await agent.start();
 
 // Create multiple sessions for different conversations
-const userSession = await agent.createSession('user-123');
-const adminSession = await agent.createSession('admin-456');
+const userSession = await agent.createSession();
+const adminSession = await agent.createSession();
 
 // Each session maintains separate conversation history
 await agent.generate('Help me with my account', userSession.id);
@@ -169,35 +171,50 @@ const session = await agent.createSession();
 await agent.generate('What is TypeScript?', session.id);
 
 // Image from URL (auto-detected)
-await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: 'https://example.com/photo.jpg' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: 'https://example.com/photo.jpg' },
+    ],
+    session.id
+);
 
 // Image from base64
-await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64ImageData, mimeType: 'image/png' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64ImageData, mimeType: 'image/png' },
+    ],
+    session.id
+);
 
 // File from URL
-await agent.generate([
-  { type: 'text', text: 'Summarize this document' },
-  { type: 'file', data: 'https://example.com/report.pdf', mimeType: 'application/pdf' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Summarize this document' },
+        { type: 'file', data: 'https://example.com/report.pdf', mimeType: 'application/pdf' },
+    ],
+    session.id
+);
 
 // File from base64
-await agent.generate([
-  { type: 'text', text: 'Summarize this document' },
-  { type: 'file', data: base64PdfData, mimeType: 'application/pdf', filename: 'report.pdf' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Summarize this document' },
+        { type: 'file', data: base64PdfData, mimeType: 'application/pdf', filename: 'report.pdf' },
+    ],
+    session.id
+);
 
 // Multiple attachments
-await agent.generate([
-  { type: 'text', text: 'Compare these two images' },
-  { type: 'image', image: 'https://example.com/image1.png' },
-  { type: 'image', image: 'https://example.com/image2.jpg' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Compare these two images' },
+        { type: 'image', image: 'https://example.com/image1.png' },
+        { type: 'image', image: 'https://example.com/image2.jpg' },
+    ],
+    session.id
+);
 ```
 
 ### Streaming Responses
@@ -208,30 +225,33 @@ Use `stream()` for real-time UIs that display text as it arrives:
 const session = await agent.createSession();
 
 for await (const event of await agent.stream('Write a short story', session.id)) {
-  switch (event.name) {
-    case 'llm:thinking':
-      console.log('Thinking...');
-      break;
-    case 'llm:chunk':
-      process.stdout.write(event.content); // Stream text in real-time
-      break;
-    case 'llm:tool-call':
-      console.log(`\n[Using tool: ${event.toolName}]`);
-      break;
-    case 'llm:response':
-      console.log(`\n\nTotal tokens: ${event.tokenUsage?.totalTokens}`);
-      break;
-  }
+    switch (event.name) {
+        case 'llm:thinking':
+            console.log('Thinking...');
+            break;
+        case 'llm:chunk':
+            process.stdout.write(event.content); // Stream text in real-time
+            break;
+        case 'llm:tool-call':
+            console.log(`\n[Using tool: ${event.toolName}]`);
+            break;
+        case 'llm:response':
+            console.log(`\n\nTotal tokens: ${event.tokenUsage?.totalTokens}`);
+            break;
+    }
 }
 
 // Streaming with multimodal content
-for await (const event of await agent.stream([
-  { type: 'text', text: 'Describe this image in detail' },
-  { type: 'image', image: base64Image, mimeType: 'image/png' }
-], session.id)) {
-  if (event.name === 'llm:chunk') {
-    process.stdout.write(event.content);
-  }
+for await (const event of await agent.stream(
+    [
+        { type: 'text', text: 'Describe this image in detail' },
+        { type: 'image', image: base64Image, mimeType: 'image/png' },
+    ],
+    session.id
+)) {
+    if (event.name === 'llm:chunk') {
+        process.stdout.write(event.content);
+    }
 }
 ```
 
@@ -242,16 +262,16 @@ The SDK provides real-time events for monitoring and integration:
 ```typescript
 // Listen to agent-wide events
 agent.on('mcp:server-connected', (data) => {
-  console.log(`✅ Connected to ${data.name}`);
+    console.log(`✅ Connected to ${data.name}`);
 });
 
 // Listen to conversation events
 agent.on('llm:thinking', (data) => {
-  console.log(`🤔 Agent thinking... (session: ${data.sessionId})`);
+    console.log(`🤔 Agent thinking... (session: ${data.sessionId})`);
 });
 
 agent.on('llm:tool-call', (data) => {
-  console.log(`🔧 Using tool: ${data.toolName}`);
+    console.log(`🔧 Using tool: ${data.toolName}`);
 });
 ```
 
@@ -273,7 +293,8 @@ sequenceDiagram
     Agent->>Agent: Process message
     Agent-->>ChatApp: Response
     ChatApp-->>User1: broadcastToUser
-```
+
+````
 </ExpandableMermaid>
 
 ```typescript
@@ -301,7 +322,7 @@ class ChatApplication {
     // Get or create session for user
     let sessionId = this.userSessions.get(userId);
     if (!sessionId) {
-      const session = await this.agent.createSession(`user-${userId}`);
+      const session = await this.agent.createSession();
       sessionId = session.id;
       this.userSessions.set(userId, sessionId);
     }
@@ -315,37 +336,37 @@ class ChatApplication {
     // Find user and send response via SSE, etc.
   }
 }
-```
+````
 
 ### Dynamic Tool Management
 
 ```typescript
 class AdaptiveAgent {
-  private agent: DextoAgent;
+    private agent: DextoAgent;
 
-  async initialize() {
-    this.agent = new DextoAgent(baseConfig);
-    await this.agent.start();
-  }
-
-  async addCapability(name: string, serverConfig: McpServerConfig) {
-    try {
-      await this.agent.addMcpServer(name, serverConfig);
-      console.log(`✅ Added ${name} capability`);
-    } catch (error) {
-      console.error(`❌ Failed to add ${name}:`, error);
+    async initialize() {
+        this.agent = new DextoAgent(baseConfig);
+        await this.agent.start();
     }
-  }
 
-  async removeCapability(name: string) {
-    await this.agent.removeMcpServer(name);
-    console.log(`🗑️ Removed ${name} capability`);
-  }
+    async addCapability(name: string, serverConfig: McpServerConfig) {
+        try {
+            await this.agent.addMcpServer(name, serverConfig);
+            console.log(`✅ Added ${name} capability`);
+        } catch (error) {
+            console.error(`❌ Failed to add ${name}:`, error);
+        }
+    }
 
-  async listCapabilities() {
-    const tools = await this.agent.getAllMcpTools();
-    return Object.keys(tools);
-  }
+    async removeCapability(name: string) {
+        await this.agent.removeMcpServer(name);
+        console.log(`🗑️ Removed ${name} capability`);
+    }
+
+    async listCapabilities() {
+        const tools = await this.agent.getAllMcpTools();
+        return Object.keys(tools);
+    }
 }
 ```
 
@@ -364,41 +385,42 @@ flowchart TD
 
 ```typescript
 class PersistentChatBot {
-  private agent: DextoAgent;
+    private agent: DextoAgent;
 
-  async initialize() {
-    this.agent = new DextoAgent({
-      llm: { /* config */ },
-      storage: {
-        cache: { type: 'redis', url: 'redis://localhost:6379' },
-        database: { type: 'postgresql', url: process.env.DATABASE_URL }
-      }
-    });
-    await this.agent.start();
-  }
-
-  async resumeConversation(userId: string) {
-    const sessionId = `user-${userId}`;
-
-    // Check if session exists
-    const sessions = await this.agent.listSessions();
-    if (sessions.includes(sessionId)) {
-      // Retrieve existing session history
-      const history = await this.agent.getSessionHistory(sessionId);
-      return { sessionId, history };
-    } else {
-      // Create new session
-      const session = await this.agent.createSession(sessionId);
-      return { sessionId: session.id, history: null };
+    async initialize() {
+        this.agent = new DextoAgent({
+            llm: {
+                /* config */
+            },
+            storage: {
+                cache: { type: 'redis', url: 'redis://localhost:6379' },
+                database: { type: 'postgresql', url: process.env.DATABASE_URL },
+            },
+        });
+        await this.agent.start();
     }
-  }
 
-  async chat(userId: string, message: string) {
-    const sessionId = `user-${userId}`;
-    // Always pass session ID explicitly
-    const response = await this.agent.generate(message, sessionId);
-    return response.content;
-  }
+    async resumeConversation(userId: string) {
+        let sessionId = this.userSessions.get(userId);
+
+        if (sessionId) {
+            // Retrieve existing session history
+            const history = await this.agent.getSessionHistory(sessionId);
+            return { sessionId, history };
+        }
+
+        // Create new session
+        const session = await this.agent.createSession();
+        this.userSessions.set(userId, session.id);
+        return { sessionId: session.id, history: null };
+    }
+
+    async chat(userId: string, message: string) {
+        const { sessionId } = await this.resumeConversation(userId);
+        // Always pass session ID explicitly
+        const response = await this.agent.generate(message, sessionId);
+        return response.content;
+    }
 }
 ```
 
@@ -409,35 +431,35 @@ class PersistentChatBot {
 ```typescript
 // OpenAI
 const openaiConfig = {
-  provider: 'openai',
-  model: 'gpt-5',
-  apiKey: process.env.OPENAI_API_KEY,
-  temperature: 0.7,
-  maxOutputTokens: 4000
+    provider: 'openai',
+    model: 'gpt-5',
+    apiKey: process.env.OPENAI_API_KEY,
+    temperature: 0.7,
+    maxOutputTokens: 4000,
 };
 
 // Anthropic
 const anthropicConfig = {
-  provider: 'anthropic', 
-  model: 'claude-sonnet-4-5-20250929',
-  apiKey: process.env.ANTHROPIC_API_KEY,
-  maxIterations: 5
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5-20250929',
+    apiKey: process.env.ANTHROPIC_API_KEY,
+    maxIterations: 5,
 };
 
 // Cohere
 const cohereConfig = {
-  provider: 'cohere',
-  model: 'command-a-03-2025',
-  apiKey: process.env.COHERE_API_KEY,
-  temperature: 0.3
+    provider: 'cohere',
+    model: 'command-a-03-2025',
+    apiKey: process.env.COHERE_API_KEY,
+    temperature: 0.3,
 };
 
 // Local/Custom OpenAI-compatible
 const localConfig = {
-  provider: 'openai',
-  model: 'llama-3.1-70b',
-  apiKey: 'not-needed',
-  baseURL: 'http://localhost:8080/v1'
+    provider: 'openai',
+    model: 'llama-3.1-70b',
+    apiKey: 'not-needed',
+    baseURL: 'http://localhost:8080/v1',
 };
 ```
 
@@ -446,20 +468,20 @@ const localConfig = {
 ```typescript
 // In-memory (development)
 const memoryStorage = {
-  cache: { type: 'in-memory' },
-  database: { type: 'in-memory' }
+    cache: { type: 'in-memory' },
+    database: { type: 'in-memory' },
 };
 
 // Production with Redis + PostgreSQL
 const productionStorage = {
-  cache: { 
-    type: 'redis',
-    url: 'redis://localhost:6379'
-  },
-  database: {
-    type: 'postgresql', 
-    url: process.env.DATABASE_URL
-  }
+    cache: {
+        type: 'redis',
+        url: 'redis://localhost:6379',
+    },
+    database: {
+        type: 'postgresql',
+        url: process.env.DATABASE_URL,
+    },
 };
 ```
 
@@ -473,20 +495,20 @@ await agent.start();
 
 // Handle MCP connection failures
 agent.on('mcp:server-connected', (data) => {
-  if (!data.success) {
-    console.warn(`⚠️ ${data.name} unavailable: ${data.error}`);
-    // Continue without this capability
-  }
+    if (!data.success) {
+        console.warn(`⚠️ ${data.name} unavailable: ${data.error}`);
+        // Continue without this capability
+    }
 });
 
 // Handle LLM errors
 agent.on('llm:error', (data) => {
-  if (data.recoverable) {
-    console.log('🔄 Retrying request...');
-  } else {
-    console.error('💥 Fatal error:', data.error);
-    // Implement fallback or user notification
-  }
+    if (data.recoverable) {
+        console.log('🔄 Retrying request...');
+    } else {
+        console.error('💥 Fatal error:', data.error);
+        // Implement fallback or user notification
+    }
 });
 ```
 
@@ -494,21 +516,21 @@ agent.on('llm:error', (data) => {
 
 ```typescript
 try {
-  const agent = new DextoAgent({
-    llm: primaryLLMConfig,
-    permissions: { mode: 'auto-approve' },
-    mcpServers: allServers
-  });
-  await agent.start();
+    const agent = new DextoAgent({
+        llm: primaryLLMConfig,
+        permissions: { mode: 'auto-approve' },
+        mcpServers: allServers,
+    });
+    await agent.start();
 } catch (error) {
-  console.warn('⚠️ Full setup failed, using minimal config');
+    console.warn('⚠️ Full setup failed, using minimal config');
 
-  // Fallback to basic configuration
-  const agent = new DextoAgent({
-    llm: fallbackLLMConfig
-    // No MCP servers in fallback mode
-  });
-  await agent.start();
+    // Fallback to basic configuration
+    const agent = new DextoAgent({
+        llm: fallbackLLMConfig,
+        // No MCP servers in fallback mode
+    });
+    await agent.start();
 }
 ```
 
@@ -522,8 +544,8 @@ const agent = new DextoAgent(config);
 await agent.start();
 
 process.on('SIGTERM', async () => {
-  await agent.stop();
-  process.exit(0);
+    await agent.stop();
+    process.exit(0);
 });
 ```
 
@@ -532,11 +554,11 @@ process.on('SIGTERM', async () => {
 ```typescript
 // Set session TTL to manage memory usage (chat history preserved in storage)
 const agent = new DextoAgent({
-  // ... other config
-  sessions: {
-    maxSessions: 1000,
-    sessionTTL: 24 * 60 * 60 * 1000 // 24 hours
-  }
+    // ... other config
+    sessions: {
+        maxSessions: 1000,
+        sessionTTL: 24 * 60 * 60 * 1000, // 24 hours
+    },
 });
 await agent.start();
 ```
@@ -546,15 +568,18 @@ await agent.start();
 ```typescript
 // Log all tool executions
 agent.on('llm:tool-call', (data) => {
-  console.log(`[${data.sessionId}] Tool: ${data.toolName}`, data.args);
+    console.log(`[${data.sessionId}] Tool: ${data.toolName}`, data.args);
 });
 
 agent.on('llm:tool-result', (data) => {
-  if (data.success) {
-    console.log(`[${data.sessionId}] ✅ ${data.toolName} completed`, data.sanitized);
-  } else {
-    console.error(`[${data.sessionId}] ❌ ${data.toolName} failed:`, data.rawResult ?? data.sanitized);
-  }
+    if (data.success) {
+        console.log(`[${data.sessionId}] ✅ ${data.toolName} completed`, data.sanitized);
+    } else {
+        console.error(
+            `[${data.sessionId}] ❌ ${data.toolName} failed:`,
+            data.rawResult ?? data.sanitized
+        );
+    }
 });
 ```
 

--- a/docs/docs/tutorials/sdk/multi-user-chat.md
+++ b/docs/docs/tutorials/sdk/multi-user-chat.md
@@ -156,11 +156,11 @@ app.post('/chat', async (req, res) => {
     try {
         const { userId, message } = req.body;
 
-        if (!message) {
-            return res.status(400).json({ error: 'Message required' });
+        if (!userId || !message) {
+            return res.status(400).json({ error: 'userId and message are required' });
         }
 
-        const sessionId = await getOrCreateSession(userId || 'anonymous');
+        const sessionId = await getOrCreateSession(userId);
         const response = await agent.generate(message, sessionId);
 
         res.json({ content: response.content, sessionId });

--- a/docs/docs/tutorials/sdk/multi-user-chat.md
+++ b/docs/docs/tutorials/sdk/multi-user-chat.md
@@ -1,7 +1,7 @@
 ---
 id: multi-user-chat
 sidebar_position: 4
-title: "Multi-User Chat"
+title: 'Multi-User Chat'
 ---
 
 # Multi-User Chat
@@ -9,6 +9,7 @@ title: "Multi-User Chat"
 In the last tutorial, you learned that sessions give agents memory. Now here's the key insight: **one agent can manage hundreds of sessions simultaneously**. You don't need a separate agent instance for each user—you just map each user to their own session ID.
 
 This tutorial has two parts:
+
 - **Part I:** Understand the pattern programmatically
 - **Part II:** Build an HTTP server to expose it
 
@@ -41,7 +42,7 @@ import { DextoAgent } from '@dexto/core';
 
 // One shared agent for all users
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -49,20 +50,20 @@ await agent.start();
 const userSessions = new Map<string, string>();
 
 async function getOrCreateSession(userId: string) {
-  // Check if this user already has a session
-  const existing = userSessions.get(userId);
-  if (existing) return existing;
+    // Check if this user already has a session
+    const existing = userSessions.get(userId);
+    if (existing) return existing;
 
-  // Create a new session for this user
-  const session = await agent.createSession(`user-${userId}`);
-  userSessions.set(userId, session.id);
-  return session.id;
+    // Create a new session for this user
+    const session = await agent.createSession();
+    userSessions.set(userId, session.id);
+    return session.id;
 }
 
 async function handleMessage(userId: string, message: string) {
-  const sessionId = await getOrCreateSession(userId);
-  const response = await agent.generate(message, sessionId);
-  return response.content;
+    const sessionId = await getOrCreateSession(userId);
+    const response = await agent.generate(message, sessionId);
+    return response.content;
 }
 ```
 
@@ -72,10 +73,10 @@ Add a test function to verify it works:
 
 ```typescript
 async function test() {
-  console.log('Alice:', await handleMessage('alice', 'My name is Alice'));
-  console.log('Bob:', await handleMessage('bob', 'My name is Bob'));
-  console.log('Alice:', await handleMessage('alice', 'What is my name?'));
-  // Should respond "Alice" - proving sessions are isolated
+    console.log('Alice:', await handleMessage('alice', 'My name is Alice'));
+    console.log('Bob:', await handleMessage('bob', 'My name is Bob'));
+    console.log('Alice:', await handleMessage('alice', 'What is my name?'));
+    // Should respond "Alice" - proving sessions are isolated
 }
 
 test().catch(console.error);
@@ -94,16 +95,17 @@ You should see Alice and Bob maintaining separate memories. This is the core pat
 
 ```typescript
 async function getOrCreateSession(userId: string) {
-  const existing = userSessions.get(userId);
-  if (existing) return existing;
+    const existing = userSessions.get(userId);
+    if (existing) return existing;
 
-  const session = await agent.createSession(`user-${userId}`);
-  userSessions.set(userId, session.id);
-  return session.id;
+    const session = await agent.createSession();
+    userSessions.set(userId, session.id);
+    return session.id;
 }
 ```
 
 This function ensures:
+
 - First message from a user → creates a new session
 - Subsequent messages → reuses existing session
 - Different users → different sessions
@@ -130,7 +132,7 @@ import { DextoAgent } from '@dexto/core';
 
 // One agent for everyone
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -138,12 +140,12 @@ await agent.start();
 const userSessions = new Map<string, string>();
 
 async function getOrCreateSession(userId: string) {
-  const existing = userSessions.get(userId);
-  if (existing) return existing;
+    const existing = userSessions.get(userId);
+    if (existing) return existing;
 
-  const session = await agent.createSession(`user-${userId}`);
-  userSessions.set(userId, session.id);
-  return session.id;
+    const session = await agent.createSession();
+    userSessions.set(userId, session.id);
+    return session.id;
 }
 
 // Express server
@@ -151,26 +153,26 @@ const app = express();
 app.use(express.json());
 
 app.post('/chat', async (req, res) => {
-  try {
-    const { userId, message } = req.body;
+    try {
+        const { userId, message } = req.body;
 
-    if (!message) {
-      return res.status(400).json({ error: 'Message required' });
+        if (!message) {
+            return res.status(400).json({ error: 'Message required' });
+        }
+
+        const sessionId = await getOrCreateSession(userId || 'anonymous');
+        const response = await agent.generate(message, sessionId);
+
+        res.json({ content: response.content, sessionId });
+    } catch (error) {
+        console.error('Chat error:', error);
+        res.status(500).json({ error: 'Internal server error' });
     }
-
-    const sessionId = await getOrCreateSession(userId || 'anonymous');
-    const response = await agent.generate(message, sessionId);
-
-    res.json({ content: response.content, sessionId });
-  } catch (error) {
-    console.error('Chat error:', error);
-    res.status(500).json({ error: 'Internal server error' });
-  }
 });
 
 const PORT = 3000;
 app.listen(PORT, () => {
-  console.log(`Chat server running on http://localhost:${PORT}`);
+    console.log(`Chat server running on http://localhost:${PORT}`);
 });
 ```
 
@@ -212,21 +214,21 @@ Add endpoints for managing user sessions:
 ```typescript
 // Reset a user's conversation
 app.post('/chat/reset', async (req, res) => {
-  const { userId } = req.body;
-  const sessionId = userSessions.get(userId);
+    const { userId } = req.body;
+    const sessionId = userSessions.get(userId);
 
-  if (sessionId) {
-    await agent.resetConversation(sessionId);
-    res.json({ success: true });
-  } else {
-    res.json({ success: false, message: 'No active session' });
-  }
+    if (sessionId) {
+        await agent.resetConversation(sessionId);
+        res.json({ success: true });
+    } else {
+        res.json({ success: false, message: 'No active session' });
+    }
 });
 
 // List active users
 app.get('/chat/users', async (req, res) => {
-  const users = Array.from(userSessions.keys());
-  res.json({ users, count: users.length });
+    const users = Array.from(userSessions.keys());
+    res.json({ users, count: users.length });
 });
 ```
 
@@ -241,11 +243,13 @@ curl -X POST http://localhost:3000/chat/reset \
 ## Key Takeaways
 
 **The Pattern:**
+
 - One agent instance shared across all users
 - One session per user, stored in a Map
 - Session lookup/creation handled by `getOrCreateSession()`
 
 **Why It Works:**
+
 - Agent instances are expensive (they load models, connect to services)
 - Sessions are cheap (just conversation history)
 - Sharing one agent is efficient and scales well

--- a/docs/docs/tutorials/sdk/sessions.md
+++ b/docs/docs/tutorials/sdk/sessions.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 3
-title: "Working with Sessions"
+title: 'Working with Sessions'
 ---
 
 # Working with Sessions
@@ -21,7 +21,7 @@ Here's a conversation with working memory:
 
 ```typescript
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -54,7 +54,7 @@ Sessions are cheap—create as many as you need:
 
 ```typescript
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-4o-mini', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -62,19 +62,20 @@ await agent.start();
 const session1 = await agent.createSession();
 console.log(session1.id); // "sess_abc123def456"
 
-// Custom ID (useful for mapping to users)
-const session2 = await agent.createSession('user-sarah-2024');
-console.log(session2.id); // "user-sarah-2024"
+// Create another session whenever you need a new conversation thread
+const session2 = await agent.createSession();
+console.log(session2.id); // "sess_xyz789ghi012"
 ```
 
-Custom IDs make it easy to tie sessions to your own user system. Just make sure they're unique.
+If you need to associate sessions with users, chats, or tasks, store the generated `session.id`
+in your own application state.
 
 ## Building Multi-Turn Conversations
 
 Pass the same `sessionId` on every message:
 
 ```typescript
-const session = await agent.createSession('demo');
+const session = await agent.createSession();
 
 await agent.generate('I want to build a REST API in Node.js.', session.id);
 
@@ -93,14 +94,16 @@ Each message adds to the session's history. The LLM sees the full conversation e
 Check what the agent remembers:
 
 ```typescript
-const history = await agent.getSessionHistory('demo');
+const session = await agent.createSession();
+const history = await agent.getSessionHistory(session.id);
 
 for (const message of history) {
-  console.log(`[${message.role}]: ${message.content.substring(0, 60)}...`);
+    console.log(`[${message.role}]: ${message.content.substring(0, 60)}...`);
 }
 ```
 
 Output:
+
 ```text
 [user]: I want to build a REST API in Node.js.
 [assistant]: Building a REST API in Node.js is a great choice. Here are...
@@ -124,12 +127,14 @@ console.log(`Active sessions: ${sessions.length}`);
 ### Check if a Session Exists
 
 ```typescript
-const session = await agent.getSession('user-sarah-2024');
-if (session) {
-  console.log('Session found');
+const session = await agent.createSession();
+const existingSessionId = session.id;
+const existingSession = await agent.getSession(existingSessionId);
+if (existingSession) {
+    console.log('Session found');
 } else {
-  console.log('Session not found - creating new one');
-  await agent.createSession('user-sarah-2024');
+    console.log('Session not found - creating new one');
+    await agent.createSession();
 }
 ```
 
@@ -138,8 +143,9 @@ if (session) {
 Clear history but keep the session ID:
 
 ```typescript
-await agent.resetConversation('demo');
-// Session 'demo' still exists, but all messages are gone
+const session = await agent.createSession();
+await agent.resetConversation(session.id);
+// Session still exists, but all messages are gone
 ```
 
 Use this for "start new conversation" buttons in your UI.
@@ -149,7 +155,8 @@ Use this for "start new conversation" buttons in your UI.
 Remove everything:
 
 ```typescript
-await agent.deleteSession('demo');
+const session = await agent.createSession();
+await agent.deleteSession(session.id);
 // Session no longer exists
 ```
 
@@ -162,12 +169,13 @@ await agent.deleteSession('demo');
 Simple apps where each user has one ongoing conversation:
 
 ```typescript
-// User logs in
-const sessionId = `user-${userId}`;
-const session = await agent.getSession(sessionId);
+const userSessions = new Map<string, string>();
 
-if (!session) {
-  await agent.createSession(sessionId);
+let sessionId = userSessions.get(userId);
+if (!sessionId) {
+    const session = await agent.createSession();
+    sessionId = session.id;
+    userSessions.set(userId, sessionId);
 }
 
 // Every message from this user uses the same session
@@ -179,12 +187,14 @@ await agent.generate(userMessage, sessionId);
 Apps like ChatGPT where users create multiple conversation threads:
 
 ```typescript
+const userChats = new Map<string, string>();
+
 // User creates a new chat
-const sessionId = `user-${userId}-chat-${chatId}`;
-await agent.createSession(sessionId);
+const chatSession = await agent.createSession();
+userChats.set(chatId, chatSession.id);
 
 // User switches between chats
-await agent.generate(message, currentChatId);
+await agent.generate(message, userChats.get(chatId)!);
 ```
 
 ### Pattern 3: Session Per Task
@@ -192,9 +202,13 @@ await agent.generate(message, currentChatId);
 Short-lived sessions for specific tasks:
 
 ```typescript
+const ticketSessions = new Map<string, string>();
+
 // User starts a support ticket
-const sessionId = `ticket-${ticketId}`;
-await agent.createSession(sessionId);
+const ticketSession = await agent.createSession();
+ticketSessions.set(ticketId, ticketSession.id);
+
+const sessionId = ticketSessions.get(ticketId)!;
 
 // All messages related to this ticket use this session
 await agent.generate(message, sessionId);

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -15446,7 +15446,7 @@
                 "properties": {
                   "sessionId": {
                     "type": "string",
-                    "description": "A custom ID for the new session"
+                    "description": "Optional integration override. Standard clients should omit this and use the agent-generated session ID."
                   }
                 },
                 "description": "Request body for creating a new session"

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -119,7 +119,7 @@ Upgrade/uninstall and migration troubleshooting live in docs:
 ### Run
 
 ```bash
-# Start Dexto
+# Start Dexto (launches setup wizard on first run)
 dexto
 ```
 
@@ -134,8 +134,6 @@ dexto --help                                       # Explore all options
 ```
 
 **Inside the interactive CLI**, type `/` to explore commands—switch models, manage sessions, configure tools, and more.
-
-If Dexto has not been set up yet, the first interactive launch opens the generic `dexto setup` flow before starting. Existing provider keys in your environment are detected there, so you can keep startup simple without inheriting the wrong bundled provider by accident.
 
 ### Manage Settings
 
@@ -627,8 +625,9 @@ Test tools before deploying:
 Usage: dexto [options] [command] [prompt...]
 
 Basic Usage:
-  dexto or dexto --mode cli  Start interactive CLI (default)
-  dexto "query"              Run one-shot query
+  dexto                    Start web UI (default)
+  dexto "query"            Run one-shot query
+  dexto --mode cli         Interactive CLI
 
 Session Management:
   dexto -c                 Continue last conversation

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,12 +42,12 @@ Dexto is an **agent harness**—the orchestration layer that turns LLMs into rel
 
 Think of it like an operating system for AI agents:
 
-| Component | Analogy | Role |
-|-----------|---------|------|
-| **LLM** | CPU | Raw processing power |
-| **Context Window** | RAM | Working memory |
-| **Dexto** | Operating System | Orchestration, state, tools, recovery |
-| **Your Agent** | Application | Domain-specific logic and clients |
+| Component          | Analogy          | Role                                  |
+| ------------------ | ---------------- | ------------------------------------- |
+| **LLM**            | CPU              | Raw processing power                  |
+| **Context Window** | RAM              | Working memory                        |
+| **Dexto**          | Operating System | Orchestration, state, tools, recovery |
+| **Your Agent**     | Application      | Domain-specific logic and clients     |
 
 ### Why Dexto?
 
@@ -78,6 +78,7 @@ dexto --agent coding-agent
 ```
 
 **What it can do:**
+
 - Build new apps from scratch
 - Read, write, and refactor code across your entire codebase
 - Execute shell commands and run tests
@@ -86,6 +87,7 @@ dexto --agent coding-agent
 - Work with any of 50+ LLMs (swap models mid-conversation)
 
 **Ready-to-use interfaces:**
+
 - **Web UI** – Chat interface with file uploads, syntax highlighting, and MCP tool browser
 - **CLI** – Terminal-native with `/commands`, streaming output, and session management
 
@@ -110,6 +112,7 @@ cd dexto && pnpm install && pnpm install-cli
 ```
 
 Upgrade/uninstall and migration troubleshooting live in docs:
+
 - Installation guide: https://docs.dexto.ai/docs/getting-started/installation
 - CLI command reference: https://docs.dexto.ai/docs/guides/cli/overview
 
@@ -151,15 +154,15 @@ Logs are stored in `~/.dexto/logs/`. Use `DEXTO_LOG_LEVEL=debug` for verbose out
 
 Switch models mid-conversation—no code changes, no restarts.
 
-| Provider | Models |
-|----------|--------|
-| **OpenAI** | gpt-5.2, gpt-5.2-pro, gpt-5.2-codex, o4-mini |
-| **Anthropic** | Claude Sonnet, Opus, Haiku (with extended thinking) |
-| **Google** | Gemini 3 Pro, 2.5 Pro/Flash |
-| **Groq** | Llama 4, Qwen, DeepSeek |
-| **xAI** | Grok 4, Grok 3 |
-| **Local** | Ollama, GGUF via node-llama-cpp (Llama, Qwen, Mistral, etc.) |
-| **+ Gateways** | OpenRouter, AWS Bedrock, Vertex AI, LiteLLM |
+| Provider       | Models                                                       |
+| -------------- | ------------------------------------------------------------ |
+| **OpenAI**     | gpt-5.2, gpt-5.2-pro, gpt-5.2-codex, o4-mini                 |
+| **Anthropic**  | Claude Sonnet, Opus, Haiku (with extended thinking)          |
+| **Google**     | Gemini 3 Pro, 2.5 Pro/Flash                                  |
+| **Groq**       | Llama 4, Qwen, DeepSeek                                      |
+| **xAI**        | Grok 4, Grok 3                                               |
+| **Local**      | Ollama, GGUF via node-llama-cpp (Llama, Qwen, Mistral, etc.) |
+| **+ Gateways** | OpenRouter, AWS Bedrock, Vertex AI, LiteLLM                  |
 
 **Run locally for privacy**: Local models keep data on your machine with automatic GPU detection (Metal, CUDA, Vulkan).
 
@@ -170,14 +173,14 @@ Connect to Model Context Protocol servers—Puppeteer, Linear, ElevenLabs, Firec
 ```yaml
 # agents/my-agent.yml
 mcpServers:
-  filesystem:
-    type: stdio
-    command: npx
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
-  browser:
-    type: stdio
-    command: npx
-    args: ['-y', '@anthropics/mcp-server-puppeteer']
+    filesystem:
+        type: stdio
+        command: npx
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    browser:
+        type: stdio
+        command: npx
+        args: ['-y', '@anthropics/mcp-server-puppeteer']
 ```
 
 Browse and add servers from the MCP Store in the Web UI or via `/mcp` commands in the CLI.
@@ -188,14 +191,14 @@ Fine-grained control over what your agent can do:
 
 ```yaml
 permissions:
-  mode: manual           # Require approval for each tool
-  # mode: auto-approve   # Trust mode for local development
-  toolPolicies:
-    alwaysAllow:
-      - mcp--filesystem--read_file
-      - mcp--filesystem--list_directory
-    alwaysDeny:
-      - mcp--filesystem--delete_file
+    mode: manual # Require approval for each tool
+    # mode: auto-approve   # Trust mode for local development
+    toolPolicies:
+        alwaysAllow:
+            - mcp--filesystem--read_file
+            - mcp--filesystem--list_directory
+        alwaysDeny:
+            - mcp--filesystem--delete_file
 ```
 
 Agents remember which tools you've approved per session.
@@ -222,13 +225,14 @@ Agents can spawn specialized sub-agents to handle complex subtasks. The coding a
 ```yaml
 # In your agent config
 tools:
-  - type: agent-spawner
-    allowedAgents: ["explore-agent"]
-    maxConcurrentAgents: 5
-    defaultTimeout: 300000  # 5 minutes
+    - type: agent-spawner
+      allowedAgents: ['explore-agent']
+      maxConcurrentAgents: 5
+      defaultTimeout: 300000 # 5 minutes
 ```
 
 **Built-in sub-agents:**
+
 - **explore-agent** – Fast, read-only codebase exploration
 
 Any agent in the [Agent Registry](#agent-registry) can be spawned as a sub-agent—including custom agents you create and register.
@@ -239,12 +243,12 @@ Sub-agents run ephemerally, auto-cleanup after completion, and forward tool appr
 
 ## Run Modes
 
-| Mode | Command | Use Case |
-|------|---------|----------|
-| **Web UI** | `dexto` | Chat interface with file uploads (default) |
-| **CLI** | `dexto --mode cli` | Terminal interaction |
-| **Web Server** | `dexto --mode server` | REST & SSE APIs |
-| **MCP Server** | `dexto --mode mcp` | Expose agent as an MCP server over stdio |
+| Mode           | Command               | Use Case                                   |
+| -------------- | --------------------- | ------------------------------------------ |
+| **Web UI**     | `dexto`               | Chat interface with file uploads (default) |
+| **CLI**        | `dexto --mode cli`    | Terminal interaction                       |
+| **Web Server** | `dexto --mode server` | REST & SSE APIs                            |
+| **MCP Server** | `dexto --mode mcp`    | Expose agent as an MCP server over stdio   |
 
 Platform integrations: [Discord](examples/discord-bot/), [Telegram](examples/telegram-bot/)
 
@@ -265,8 +269,17 @@ Example MCP config for Claude Code or Cursor:
 
 ```json
 {
-  "command": "npx",
-  "args": ["-y", "dexto", "--mode", "mcp", "--agent", "coding-agent", "--auto-approve", "--no-elicitation"]
+    "command": "npx",
+    "args": [
+        "-y",
+        "dexto",
+        "--mode",
+        "mcp",
+        "--agent",
+        "coding-agent",
+        "--auto-approve",
+        "--no-elicitation"
+    ]
 }
 ```
 
@@ -297,7 +310,7 @@ npm install @dexto/core
 import { DextoAgent } from '@dexto/core';
 
 const agent = new DextoAgent({
-  llm: { provider: 'openai', model: 'gpt-5.2', apiKey: process.env.OPENAI_API_KEY }
+    llm: { provider: 'openai', model: 'gpt-5.2', apiKey: process.env.OPENAI_API_KEY },
 });
 await agent.start();
 
@@ -307,14 +320,17 @@ console.log(response.content);
 
 // Streaming
 for await (const event of await agent.stream('Write a story', session.id)) {
-  if (event.name === 'llm:chunk') process.stdout.write(event.content);
+    if (event.name === 'llm:chunk') process.stdout.write(event.content);
 }
 
 // Multimodal
-await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64Data, mimeType: 'image/png' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64Data, mimeType: 'image/png' },
+    ],
+    session.id
+);
 
 // Switch models mid-conversation
 await agent.switchLLM({ model: 'claude-sonnet-4-5-20250929' });
@@ -348,13 +364,13 @@ const agent = new DextoAgent(config);
 await agent.start();
 
 // Create and manage sessions
-const session = await agent.createSession('user-123');
+const session = await agent.createSession();
 await agent.generate('Hello, how can you help me?', session.id);
 
 // List and manage sessions
 const sessions = await agent.listSessions();
-const history = await agent.getSessionHistory('user-123');
-await agent.deleteSession('user-123');
+const history = await agent.getSessionHistory(session.id);
+await agent.deleteSession(session.id);
 
 // Search across conversations
 const results = await agent.searchMessages('bug fix', { limit: 10 });
@@ -391,9 +407,9 @@ const manager = new MCPManager();
 
 // Connect to MCP servers
 await manager.connectServer('filesystem', {
-  type: 'stdio',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
 });
 
 // Access tools, prompts, and resources
@@ -414,19 +430,20 @@ Configure storage backends for production.
 ```yaml
 # agents/production-agent.yml
 storage:
-  cache:
-    type: redis
-    url: $REDIS_URL
-  database:
-    type: postgres
-    connectionString: $POSTGRES_CONNECTION_STRING
+    cache:
+        type: redis
+        url: $REDIS_URL
+    database:
+        type: postgres
+        connectionString: $POSTGRES_CONNECTION_STRING
 
 sessions:
-  maxSessions: 1000
-  sessionTTL: 86400000  # 24 hours
+    maxSessions: 1000
+    sessionTTL: 86400000 # 24 hours
 ```
 
 **Supported Backends:**
+
 - **Cache**: Redis, In-Memory
 - **Database**: PostgreSQL, SQLite, In-Memory
 
@@ -462,29 +479,29 @@ Dexto treats each configuration as a unique agent allowing you to define and sav
 ```yaml
 # agents/production-agent.yml
 llm:
-  provider: anthropic
-  model: claude-sonnet-4-5-20250929
-  apiKey: $ANTHROPIC_API_KEY
+    provider: anthropic
+    model: claude-sonnet-4-5-20250929
+    apiKey: $ANTHROPIC_API_KEY
 
 mcpServers:
-  filesystem:
-    type: stdio
-    command: npx
-    args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    filesystem:
+        type: stdio
+        command: npx
+        args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
 
 systemPrompt: |
-  You are a helpful assistant with filesystem access.
+    You are a helpful assistant with filesystem access.
 
 storage:
-  cache:
-    type: redis
-    url: $REDIS_URL
-  database:
-    type: postgres
-    connectionString: $POSTGRES_CONNECTION_STRING
+    cache:
+        type: redis
+        url: $REDIS_URL
+    database:
+        type: postgres
+        connectionString: $POSTGRES_CONNECTION_STRING
 
 permissions:
-  mode: manual
+    mode: manual
 ```
 
 ### LLM Providers
@@ -493,36 +510,36 @@ Switch between providers instantly—no code changes required.
 
 #### Built-in Providers
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **OpenAI** | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `o4-mini` | API key |
+| Provider      | Models                                                                      | Setup   |
+| ------------- | --------------------------------------------------------------------------- | ------- |
+| **OpenAI**    | `gpt-5.2`, `gpt-5.2-pro`, `gpt-5.2-codex`, `o4-mini`                        | API key |
 | **Anthropic** | `claude-sonnet-4-5-20250929`, `claude-opus-4-5-20250929`, extended thinking | API key |
-| **Google** | `gemini-3-pro`, `gemini-2.5-pro`, `gemini-2.5-flash` | API key |
-| **Groq** | `llama-4-scout`, `qwen-qwq`, `deepseek-r1-distill` | API key |
-| **xAI** | `grok-4`, `grok-3`, `grok-3-fast` | API key |
-| **Cohere** | `command-r-plus`, `command-r` | API key |
+| **Google**    | `gemini-3-pro`, `gemini-2.5-pro`, `gemini-2.5-flash`                        | API key |
+| **Groq**      | `llama-4-scout`, `qwen-qwq`, `deepseek-r1-distill`                          | API key |
+| **xAI**       | `grok-4`, `grok-3`, `grok-3-fast`                                           | API key |
+| **Cohere**    | `command-r-plus`, `command-r`                                               | API key |
 
 #### Local Models (Privacy-First)
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **Ollama** | Llama, Qwen, Mistral, DeepSeek, etc. | Local install |
-| **node-llama-cpp** | Any GGUF model | Bundled (auto GPU detection: Metal, CUDA, Vulkan) |
+| Provider           | Models                               | Setup                                             |
+| ------------------ | ------------------------------------ | ------------------------------------------------- |
+| **Ollama**         | Llama, Qwen, Mistral, DeepSeek, etc. | Local install                                     |
+| **node-llama-cpp** | Any GGUF model                       | Bundled (auto GPU detection: Metal, CUDA, Vulkan) |
 
 #### Cloud Platforms
 
-| Provider | Models | Setup |
-|----------|--------|-------|
-| **AWS Bedrock** | Claude, Llama, Mistral | AWS credentials |
-| **Google Vertex AI** | Gemini, Claude | GCP credentials |
+| Provider             | Models                 | Setup           |
+| -------------------- | ---------------------- | --------------- |
+| **AWS Bedrock**      | Claude, Llama, Mistral | AWS credentials |
+| **Google Vertex AI** | Gemini, Claude         | GCP credentials |
 
 #### Gateway Providers
 
-| Provider | Access | Setup |
-|----------|--------|-------|
-| **OpenRouter** | 100+ models from multiple providers | API key |
-| **LiteLLM** | Unified API for any provider | Self-hosted or API key |
-| **Glama** | Multi-provider gateway | API key |
+| Provider       | Access                              | Setup                  |
+| -------------- | ----------------------------------- | ---------------------- |
+| **OpenRouter** | 100+ models from multiple providers | API key                |
+| **LiteLLM**    | Unified API for any provider        | Self-hosted or API key |
+| **Glama**      | Multi-provider gateway              | API key                |
 
 ```bash
 # Switch models via CLI
@@ -539,50 +556,63 @@ See the [Configuration Guide](https://docs.dexto.ai/docs/category/agent-configur
 
 ## Demos & Examples
 
-| Image Editor | MCP Store | Portable Agents |
-|:---:|:---:|:---:|
+|                                   Image Editor                                   |                                 MCP Store                                  |                                    Portable Agents                                    |
+| :------------------------------------------------------------------------------: | :------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------: |
 | <img src=".github/assets/image_editor_demo.gif" alt="Image Editor" width="280"/> | <img src=".github/assets/mcp_store_demo.gif" alt="MCP Store" width="280"/> | <img src=".github/assets/portable_agent_demo.gif" alt="Portable Agents" width="280"/> |
-| Face detection & annotation using OpenCV | Browse and add MCPs | Use agents in Cursor, Claude Code via MCP|
+|                     Face detection & annotation using OpenCV                     |                            Browse and add MCPs                             |                       Use agents in Cursor, Claude Code via MCP                       |
 
 <details>
 <summary><strong>More Examples</strong></summary>
 
 ### Coding Agent
+
 Build applications from natural language:
+
 ```bash
 dexto --agent coding-agent
 # "Create a snake game and open it in the browser"
 ```
+
 <img src=".github/assets/coding_agent_demo.gif" alt="Coding Agent Demo" width="600"/>
 
 ### Podcast Agent
+
 Generate multi-speaker audio content:
+
 ```bash
 dexto --agent podcast-agent
 ```
+
 <img src="https://github.com/user-attachments/assets/cfd59751-3daa-4ccd-97b2-1b2862c96af1" alt="Podcast Agent Demo" width="600"/>
 
 ### Multi-Agent Triage
+
 Coordinate specialized agents:
+
 ```bash
 dexto --agent triage-agent
 ```
+
 <img src=".github/assets/triage_agent_demo.gif" alt="Triage Agent Demo" width="600">
 
 ### Memory System
+
 Persistent context that shapes behavior:
 <img src=".github/assets/memory_demo.gif" alt="Memory Demo" width="600">
 
 ### Dynamic Forms
+
 Agents generate forms for structured input:
 <img src=".github/assets/user_form_demo.gif" alt="User Form Demo" width="600">
 
 ### Browser Automation
+
 <a href="https://youtu.be/C-Z0aVbl4Ik">
   <img src="https://github.com/user-attachments/assets/3f5be5e2-7a55-4093-a071-8c52f1a83ba3" alt="Amazon Shopping Demo" width="600"/>
 </a>
 
 ### MCP Playground
+
 Test tools before deploying:
 <img src=".github/assets/playground_demo.gif" alt="Playground Demo" width="600">
 

--- a/packages/cli/src/cli/commands/init.ts
+++ b/packages/cli/src/cli/commands/init.ts
@@ -553,7 +553,7 @@ async function generateAgentSystemPromptFromDescription(
 
     try {
         await generatorAgent.start();
-        const session = await generatorAgent.createSession(PROMPT_GENERATOR_AGENT_ID);
+        const session = await generatorAgent.createSession();
         const response = await generatorAgent.generate(
             buildPromptGenerationRequest(displayName, roleDescription, options),
             session.id

--- a/packages/client-sdk/README.md
+++ b/packages/client-sdk/README.md
@@ -24,8 +24,8 @@ npm install @dexto/client-sdk
 import { DextoClient } from '@dexto/client-sdk';
 
 const client = new DextoClient({
-  baseUrl: 'https://your-dexto-server.com',
-  apiKey: 'optional-api-key'
+    baseUrl: 'https://your-dexto-server.com',
+    apiKey: 'optional-api-key',
 });
 
 // Connect to Dexto server
@@ -33,7 +33,7 @@ await client.connect();
 
 // Send a message
 const response = await client.sendMessage({
-  content: 'Hello, how can you help me?'
+    content: 'Hello, how can you help me?',
 });
 
 console.log(response.response);
@@ -42,36 +42,43 @@ console.log(response.response);
 ## Configuration
 
 ```typescript
-const client = new DextoClient({
-  baseUrl: 'https://your-dexto-server.com',  // Required: Dexto API base URL
-  apiKey: 'your-api-key',                   // Optional: API key for auth
-  timeout: 30000,                           // Optional: Request timeout (ms)
-  retries: 3,                              // Optional: Retry attempts
-}, {
-  reconnect: true,                         // Optional: Auto-reconnect
-  reconnectInterval: 5000,                 // Optional: Reconnect delay (ms)
-  debug: false                             // Optional: Debug logging
-});
+const client = new DextoClient(
+    {
+        baseUrl: 'https://your-dexto-server.com', // Required: Dexto API base URL
+        apiKey: 'your-api-key', // Optional: API key for auth
+        timeout: 30000, // Optional: Request timeout (ms)
+        retries: 3, // Optional: Retry attempts
+    },
+    {
+        reconnect: true, // Optional: Auto-reconnect
+        reconnectInterval: 5000, // Optional: Reconnect delay (ms)
+        debug: false, // Optional: Debug logging
+    }
+);
 ```
 
 ## API Methods
 
 ### Connection Management
+
 - `connect()` - Establish connection to Dexto server
 - `disconnect()` - Close connection
 - `isConnected` - Check connection status
 
 ### Messaging
+
 - `sendMessage(input)` - Send message (HTTP)
 - SSE streaming available via `/api/message-stream` endpoint
 
 ### Session Management
+
 - `listSessions()` - List all sessions
-- `createSession(id?)` - Create new session
+- `createSession()` - Create new session (standard clients should use the returned ID)
 - `getSession(id)` - Get session details
 - `deleteSession(id)` - Delete session
 
 ### Real-time Events
+
 - `on(eventType, handler)` - Subscribe to Dexto events
 - `onConnectionState(handler)` - Connection state changes
 
@@ -79,13 +86,13 @@ const client = new DextoClient({
 
 ```typescript
 try {
-  await client.sendMessage({ content: 'Hello' });
+    await client.sendMessage({ content: 'Hello' });
 } catch (error) {
-  if (error.name === 'ConnectionError') {
-    console.log('Failed to connect to Dexto server');
-  } else if (error.name === 'HttpError') {
-    console.log(`HTTP ${error.status}: ${error.statusText}`);
-  }
+    if (error.name === 'ConnectionError') {
+        console.log('Failed to connect to Dexto server');
+    } else if (error.name === 'HttpError') {
+        console.log(`HTTP ${error.status}: ${error.statusText}`);
+    }
 }
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,11 +41,11 @@ import { DextoAgent } from '@dexto/core';
 
 // Create and start agent
 const agent = new DextoAgent({
-  llm: {
-    provider: 'openai',
-    model: 'gpt-5-mini',
-    apiKey: process.env.OPENAI_API_KEY
-  }
+    llm: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: process.env.OPENAI_API_KEY,
+    },
 });
 await agent.start();
 
@@ -61,14 +61,17 @@ await agent.generate('Write a haiku about it', session.id);
 await agent.generate('Make it funnier', session.id);
 
 // Multimodal: send images or files
-await agent.generate([
-  { type: 'text', text: 'Describe this image' },
-  { type: 'image', image: base64Data, mimeType: 'image/png' }
-], session.id);
+await agent.generate(
+    [
+        { type: 'text', text: 'Describe this image' },
+        { type: 'image', image: base64Data, mimeType: 'image/png' },
+    ],
+    session.id
+);
 
 // Streaming for real-time UIs
 for await (const event of await agent.stream('Write a story', session.id)) {
-  if (event.name === 'llm:chunk') process.stdout.write(event.content);
+    if (event.name === 'llm:chunk') process.stdout.write(event.content);
 }
 
 await agent.stop();
@@ -88,18 +91,18 @@ import { startHonoApiServer } from 'dexto';
 
 // Create and configure agent
 const agent = new DextoAgent({
-  llm: {
-    provider: 'openai',
-    model: 'gpt-5-mini',
-    apiKey: process.env.OPENAI_API_KEY
-  },
-  mcpServers: {
-    filesystem: {
-      type: 'stdio',
-      command: 'npx',
-      args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
-    }
-  }
+    llm: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: process.env.OPENAI_API_KEY,
+    },
+    mcpServers: {
+        filesystem: {
+            type: 'stdio',
+            command: 'npx',
+            args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
+        },
+    },
 });
 
 // Start server on port 3001
@@ -123,13 +126,13 @@ const agent = new DextoAgent(config);
 await agent.start();
 
 // Create and manage sessions
-const session = await agent.createSession('user-123');
+const session = await agent.createSession();
 await agent.generate('Hello, how can you help me?', session.id);
 
 // List and manage sessions
 const sessions = await agent.listSessions();
-const sessionHistory = await agent.getSessionHistory('user-123');
-await agent.deleteSession('user-123');
+const sessionHistory = await agent.getSessionHistory(session.id);
+await agent.deleteSession(session.id);
 
 // Search across conversations
 const results = await agent.searchMessages('bug fix', { limit: 10 });
@@ -148,7 +151,7 @@ await agent.switchLLM({ model: 'gpt-5-mini' });
 await agent.switchLLM({ model: 'claude-sonnet-4-5-20250929' });
 
 // Switch model for a specific session id 1234
-await agent.switchLLM({ model: 'gpt-5-mini' }, '1234')
+await agent.switchLLM({ model: 'gpt-5-mini' }, '1234');
 
 // Get supported providers and models
 const providers = agent.getSupportedProviders();
@@ -167,9 +170,9 @@ const manager = new MCPManager();
 
 // Connect to MCP servers
 await manager.connectServer('filesystem', {
-  type: 'stdio',
-  command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-filesystem', '.']
+    type: 'stdio',
+    command: 'npx',
+    args: ['-y', '@modelcontextprotocol/server-filesystem', '.'],
 });
 
 // Access tools, prompts, and resources
@@ -191,43 +194,50 @@ Delegate tasks to other A2A-compliant agents using the built-in `delegate_to_url
 import { builtinToolsFactory } from '@dexto/tools-builtins';
 
 const tools = builtinToolsFactory.create({
-  type: 'builtin-tools',
-  enabledTools: ['delegate_to_url'],
+    type: 'builtin-tools',
+    enabledTools: ['delegate_to_url'],
 });
 
 const agent = new DextoAgent({
-  llm: { /* ... */ },
-  logger,   // provide a per-agent logger instance
-  storage,  // provide cache/database/blob implementations
-  tools,
-  permissions: { mode: 'auto-approve' }
+    llm: {
+        /* ... */
+    },
+    logger, // provide a per-agent logger instance
+    storage, // provide cache/database/blob implementations
+    tools,
+    permissions: { mode: 'auto-approve' },
 });
 await agent.start();
 
 const session = await agent.createSession();
 
 // Delegate via natural language
-await agent.generate(`
+await agent.generate(
+    `
   Please delegate this task to the PDF analyzer agent at http://localhost:3001:
   "Extract all tables from the Q4 sales report"
-`, session.id);
+`,
+    session.id
+);
 
 // Or call the tool directly
 await agent.executeTool('delegate_to_url', {
-  url: 'http://localhost:3001',
-  message: 'Extract all tables from the Q4 sales report',
+    url: 'http://localhost:3001',
+    message: 'Extract all tables from the Q4 sales report',
 });
 ```
 
 **Configuration (YAML):**
+
 ```yaml
 tools:
-  - type: builtin-tools
-    enabledTools:
-      - delegate_to_url
+    - type: builtin-tools
+      enabledTools:
+          - delegate_to_url
 ```
 
 **What it provides:**
+
 - Point-to-point delegation when you know the agent URL
 - A2A Protocol v0.3.0 compliant (JSON-RPC transport)
 - Session management for stateful multi-turn conversations
@@ -235,6 +245,7 @@ tools:
 - Timeout handling and error recovery
 
 **Use cases:**
+
 - Multi-agent systems with known agent URLs
 - Delegation to specialized agents
 - Building agent workflows and pipelines
@@ -246,15 +257,17 @@ Built-in OpenTelemetry distributed tracing for observability.
 
 ```typescript
 const agent = new DextoAgent({
-  llm: { /* ... */ },
-  telemetry: {
-    enabled: true,
-    serviceName: 'my-agent',
-    export: {
-      type: 'otlp',
-      endpoint: 'http://localhost:4318/v1/traces'
-    }
-  }
+    llm: {
+        /* ... */
+    },
+    telemetry: {
+        enabled: true,
+        serviceName: 'my-agent',
+        export: {
+            type: 'otlp',
+            endpoint: 'http://localhost:4318/v1/traces',
+        },
+    },
 });
 ```
 
@@ -266,14 +279,14 @@ Multi-transport logging system (v2) with console, file, and remote transports. C
 
 ```yaml
 logger:
-  level: info  # error | warn | info | debug | silly
-  transports:
-    - type: console
-      colorize: true
-    - type: file
-      path: ./logs/agent.log
-      maxSize: 10485760
-      maxFiles: 5
+    level: info # error | warn | info | debug | silly
+    transports:
+        - type: console
+          colorize: true
+        - type: file
+          path: ./logs/agent.log
+          maxSize: 10485760
+          maxFiles: 5
 ```
 
 CLI automatically adds per-agent file transport at `~/.dexto/logs/<agent-id>.log`. See architecture in `src/logger/v2/`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -150,8 +150,8 @@ const currentLLM = agent.getCurrentLLMConfig();
 await agent.switchLLM({ model: 'gpt-5-mini' });
 await agent.switchLLM({ model: 'claude-sonnet-4-5-20250929' });
 
-// Switch model for a specific session id 1234
-await agent.switchLLM({ model: 'gpt-5-mini' }, '1234');
+// Switch model for a specific session
+await agent.switchLLM({ model: 'gpt-5-mini' }, session.id);
 
 // Get supported providers and models
 const providers = agent.getSupportedProviders();

--- a/packages/core/src/agent/DextoAgent.lifecycle.test.ts
+++ b/packages/core/src/agent/DextoAgent.lifecycle.test.ts
@@ -582,27 +582,13 @@ describe('DextoAgent Lifecycle Management', () => {
     });
 
     describe('Stream Error Lifecycle', () => {
-        test('should emit session not found when streaming an unknown session', async () => {
+        test('should throw session not found when streaming an unknown session', async () => {
             const agent = createTestAgent(mockValidatedConfig);
             mockServices.sessionManager.getSession = vi.fn().mockResolvedValue(undefined);
 
             await agent.start();
 
-            const events: StreamingEvent[] = [];
-            for await (const event of await agent.stream('hello', 'missing-session')) {
-                events.push(event);
-            }
-
-            expect(events).toHaveLength(1);
-            expect(events[0]).toMatchObject({
-                name: 'llm:error',
-                context: 'run_failed',
-                recoverable: false,
-            });
-            if (events[0]?.name !== 'llm:error') {
-                throw new Error('Expected llm:error event');
-            }
-            expect(events[0].error).toMatchObject({
+            await expect(agent.stream('hello', 'missing-session')).rejects.toMatchObject({
                 code: SessionErrorCode.SESSION_NOT_FOUND,
                 scope: ErrorScope.SESSION,
                 type: ErrorType.NOT_FOUND,

--- a/packages/core/src/agent/DextoAgent.lifecycle.test.ts
+++ b/packages/core/src/agent/DextoAgent.lifecycle.test.ts
@@ -14,6 +14,7 @@ import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 import { ErrorScope, ErrorType } from '../errors/types.js';
 import { AgentErrorCode } from './error-codes.js';
 import { LLMErrorCode } from '../llm/error-codes.js';
+import { SessionErrorCode } from '../session/error-codes.js';
 import { createLogger } from '../logger/factory.js';
 import { AgentEventBus, type StreamingEvent } from '../events/index.js';
 import {
@@ -581,6 +582,34 @@ describe('DextoAgent Lifecycle Management', () => {
     });
 
     describe('Stream Error Lifecycle', () => {
+        test('should emit session not found when streaming an unknown session', async () => {
+            const agent = createTestAgent(mockValidatedConfig);
+            mockServices.sessionManager.getSession = vi.fn().mockResolvedValue(undefined);
+
+            await agent.start();
+
+            const events: StreamingEvent[] = [];
+            for await (const event of await agent.stream('hello', 'missing-session')) {
+                events.push(event);
+            }
+
+            expect(events).toHaveLength(1);
+            expect(events[0]).toMatchObject({
+                name: 'llm:error',
+                context: 'run_failed',
+                recoverable: false,
+            });
+            if (events[0]?.name !== 'llm:error') {
+                throw new Error('Expected llm:error event');
+            }
+            expect(events[0].error).toMatchObject({
+                code: SessionErrorCode.SESSION_NOT_FOUND,
+                scope: ErrorScope.SESSION,
+                type: ErrorType.NOT_FOUND,
+            });
+            expect(mockServices.sessionManager.createSession).not.toHaveBeenCalled();
+        });
+
         test('should prefer the terminal fatal event emitted on the agent bus over a fallback run_failed error', async () => {
             const agent = createTestAgent(mockValidatedConfig);
             const mappedError = new DextoRuntimeError(

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -919,6 +919,25 @@ export class DextoAgent {
         let completed = false;
         let sawFatalErrorEvent = false;
         let sawRunCompleteEvent = false;
+        let streamStartupState: 'pending' | 'resolved' | 'rejected' = 'pending';
+        let resolveStreamStartup!: () => void;
+        let rejectStreamStartup!: (error: Error) => void;
+        const streamStartup = new Promise<void>((resolve, reject) => {
+            resolveStreamStartup = () => {
+                if (streamStartupState !== 'pending') {
+                    return;
+                }
+                streamStartupState = 'resolved';
+                resolve();
+            };
+            rejectStreamStartup = (error: Error) => {
+                if (streamStartupState !== 'pending') {
+                    return;
+                }
+                streamStartupState = 'rejected';
+                reject(error);
+            };
+        });
 
         // Create AbortController for cleanup
         const controller = new AbortController();
@@ -1348,6 +1367,8 @@ export class DextoAgent {
                         throw SessionError.notFound(sessionId);
                     }
 
+                    resolveStreamStartup();
+
                     // Call session.stream() directly with ALL content parts
                     const _streamResult = await session.stream(
                         contentParts,
@@ -1370,6 +1391,14 @@ export class DextoAgent {
                             : err instanceof Error
                               ? err
                               : AgentError.streamFailed(String(err));
+
+                    if (streamStartupState === 'pending') {
+                        completed = true;
+                        cleanupListeners();
+                        controller.abort();
+                        rejectStreamStartup(error);
+                        return;
+                    }
 
                     if (sawFatalErrorEvent || sawRunCompleteEvent) {
                         if (!sawRunCompleteEvent) {
@@ -1440,6 +1469,7 @@ export class DextoAgent {
             },
         };
 
+        await streamStartup;
         return iterator;
     }
 

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -119,7 +119,7 @@ export interface AgentEventSubscriber {
  * - Thin wrapper around internal services with high-level methods
  * - Primary API for applications building on Dexto
  * - Internal services exposed as public readonly properties for advanced usage
- * - Backward compatibility through default session management
+ * - Explicit session management for conversation turns
  *
  * @example
  * ```typescript
@@ -135,14 +135,15 @@ export interface AgentEventSubscriber {
  * await agent.start();
  *
  * // Process user messages
- * const response = await agent.run("Hello, how are you?");
+ * const session = await agent.createSession();
+ * const response = await agent.run("Hello, how are you?", undefined, undefined, session.id);
  *
  * // Switch LLM models (provider inferred automatically)
  * await agent.switchLLM({ model: 'gpt-5' });
  *
  * // Manage sessions
- * const session = await agent.createSession('user-123');
- * const response = await agent.run("Hello", undefined, undefined, session.id);
+ * const secondSession = await agent.createSession();
+ * const secondResponse = await agent.run("Hello", undefined, undefined, secondSession.id);
  *
  * // Connect MCP servers
  * await agent.addMcpServer('filesystem', { command: 'mcp-filesystem' });
@@ -1589,8 +1590,10 @@ export class DextoAgent {
     // ============= SESSION MANAGEMENT =============
 
     /**
-     * Creates a new chat session or returns an existing one.
-     * @param sessionId Optional session ID. If not provided, a UUID will be generated.
+     * Creates a new chat session.
+     * Standard callers should omit sessionId and use the generated ID. Integration adapters may
+     * pass a stable external ID when they need to resume an existing session by alias.
+     * @param sessionId Optional integration-owned session ID.
      * @returns The created or existing ChatSession
      */
     public async createSession(sessionId?: string): Promise<ChatSession> {

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -1341,10 +1341,11 @@ export class DextoAgent {
                     // Validate the final prompt projection after any @resource expansion.
                     validatePromptContentParts(contentParts);
 
-                    // Get or create session
-                    const session: ChatSession =
-                        (await this.sessionManager.getSession(sessionId)) ||
-                        (await this.sessionManager.createSession(sessionId));
+                    const session: ChatSession | undefined =
+                        await this.sessionManager.getSession(sessionId);
+                    if (!session) {
+                        throw SessionError.notFound(sessionId);
+                    }
 
                     // Call session.stream() directly with ALL content parts
                     const _streamResult = await session.stream(

--- a/packages/core/src/approval/manager.test.ts
+++ b/packages/core/src/approval/manager.test.ts
@@ -25,6 +25,7 @@ function createDeferred<T>() {
 describe('ApprovalManager', () => {
     let agentEventBus: AgentEventBus;
     const mockLogger = createMockLogger();
+    const approvalSessionId = 'approval-session';
 
     function createApprovalManager(
         config: ConstructorParameters<typeof ApprovalManager>[0],
@@ -58,6 +59,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: { foo: 'bar' },
+                sessionId: approvalSessionId,
             });
 
             expect(toolResponse.status).toBe(ApprovalStatus.APPROVED);
@@ -126,6 +128,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: { foo: 'bar' },
+                sessionId: approvalSessionId,
             });
 
             expect(toolResponse.status).toBe(ApprovalStatus.DENIED);
@@ -172,6 +175,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: {},
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.APPROVED);
@@ -196,6 +200,7 @@ describe('ApprovalManager', () => {
                 toolName: 'bash_exec',
                 command: 'rm -rf /',
                 originalCommand: 'rm -rf /',
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.APPROVED);
@@ -456,6 +461,7 @@ describe('ApprovalManager', () => {
                 toolCallId: 'test-call-id',
                 args: { foo: 'bar' },
                 timeout: 30000, // Per-request override
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.APPROVED);
@@ -479,6 +485,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: {},
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.APPROVED);
@@ -502,6 +509,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: {},
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.DENIED);
@@ -576,6 +584,7 @@ describe('ApprovalManager', () => {
                 toolName: 'test_tool',
                 toolCallId: 'test-call-id',
                 args: {},
+                sessionId: approvalSessionId,
             });
 
             expect(response.status).toBe(ApprovalStatus.DENIED);
@@ -603,6 +612,7 @@ describe('ApprovalManager', () => {
                     toolName: 'test_tool',
                     toolCallId: 'test-call-id',
                     args: {},
+                    sessionId: approvalSessionId,
                 });
                 expect.fail('Should have thrown error');
             } catch (error) {
@@ -678,6 +688,7 @@ describe('ApprovalManager', () => {
     describe('Tool Pattern Approval', () => {
         let manager: ApprovalManager;
         const toolName = 'bash_exec';
+        const patternSessionId = 'pattern-session';
 
         beforeEach(() => {
             manager = createApprovalManager(
@@ -696,16 +707,16 @@ describe('ApprovalManager', () => {
 
         describe('addPattern', () => {
             it('should add a pattern to the approved list', async () => {
-                await manager.addPattern(toolName, 'git *');
-                expect(manager.getToolPatterns(toolName).has('git *')).toBe(true);
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                expect(manager.getToolPatterns(toolName, patternSessionId).has('git *')).toBe(true);
             });
 
             it('should add multiple patterns', async () => {
-                await manager.addPattern(toolName, 'git *');
-                await manager.addPattern(toolName, 'npm *');
-                await manager.addPattern(toolName, 'ls *');
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                await manager.addPattern(toolName, 'npm *', patternSessionId);
+                await manager.addPattern(toolName, 'ls *', patternSessionId);
 
-                const patterns = manager.getToolPatterns(toolName);
+                const patterns = manager.getToolPatterns(toolName, patternSessionId);
                 expect(patterns.size).toBe(3);
                 expect(patterns.has('git *')).toBe(true);
                 expect(patterns.has('npm *')).toBe(true);
@@ -713,10 +724,10 @@ describe('ApprovalManager', () => {
             });
 
             it('should not duplicate patterns', async () => {
-                await manager.addPattern(toolName, 'git *');
-                await manager.addPattern(toolName, 'git *');
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                await manager.addPattern(toolName, 'git *', patternSessionId);
 
-                expect(manager.getToolPatterns(toolName).size).toBe(1);
+                expect(manager.getToolPatterns(toolName, patternSessionId).size).toBe(1);
             });
         });
 
@@ -725,59 +736,79 @@ describe('ApprovalManager', () => {
             // not raw commands. ToolManager generates pattern keys from commands.
 
             it('should match exact pattern against exact stored pattern', async () => {
-                await manager.addPattern(toolName, 'git status *');
-                expect(manager.matchesPattern(toolName, 'git status *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'git push *')).toBe(false);
+                await manager.addPattern(toolName, 'git status *', patternSessionId);
+                expect(manager.matchesPattern(toolName, 'git status *', patternSessionId)).toBe(
+                    true
+                );
+                expect(manager.matchesPattern(toolName, 'git push *', patternSessionId)).toBe(
+                    false
+                );
             });
 
             it('should cover narrower pattern with broader pattern', async () => {
                 // "git *" is broader and should cover "git push *", "git status *", etc.
-                await manager.addPattern(toolName, 'git *');
-                expect(manager.matchesPattern(toolName, 'git *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'git push *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'git status *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'npm *')).toBe(false);
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                expect(manager.matchesPattern(toolName, 'git *', patternSessionId)).toBe(true);
+                expect(manager.matchesPattern(toolName, 'git push *', patternSessionId)).toBe(true);
+                expect(manager.matchesPattern(toolName, 'git status *', patternSessionId)).toBe(
+                    true
+                );
+                expect(manager.matchesPattern(toolName, 'npm *', patternSessionId)).toBe(false);
             });
 
             it('should not let narrower pattern cover broader pattern', async () => {
                 // "git push *" should NOT cover "git *"
-                await manager.addPattern(toolName, 'git push *');
-                expect(manager.matchesPattern(toolName, 'git push *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'git *')).toBe(false);
-                expect(manager.matchesPattern(toolName, 'git status *')).toBe(false);
+                await manager.addPattern(toolName, 'git push *', patternSessionId);
+                expect(manager.matchesPattern(toolName, 'git push *', patternSessionId)).toBe(true);
+                expect(manager.matchesPattern(toolName, 'git *', patternSessionId)).toBe(false);
+                expect(manager.matchesPattern(toolName, 'git status *', patternSessionId)).toBe(
+                    false
+                );
             });
 
             it('should match against multiple patterns', async () => {
-                await manager.addPattern(toolName, 'git *');
-                await manager.addPattern(toolName, 'npm install *');
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                await manager.addPattern(toolName, 'npm install *', patternSessionId);
 
-                expect(manager.matchesPattern(toolName, 'git status *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'npm install *')).toBe(true);
+                expect(manager.matchesPattern(toolName, 'git status *', patternSessionId)).toBe(
+                    true
+                );
+                expect(manager.matchesPattern(toolName, 'npm install *', patternSessionId)).toBe(
+                    true
+                );
                 // npm * is not covered, only npm install * specifically
-                expect(manager.matchesPattern(toolName, 'npm run *')).toBe(false);
+                expect(manager.matchesPattern(toolName, 'npm run *', patternSessionId)).toBe(false);
             });
 
             it('should return false when no patterns are set', () => {
-                expect(manager.matchesPattern(toolName, 'git status *')).toBe(false);
+                expect(manager.matchesPattern(toolName, 'git status *', patternSessionId)).toBe(
+                    false
+                );
             });
 
             it('should not cross-match unrelated commands', async () => {
-                await manager.addPattern(toolName, 'npm *');
+                await manager.addPattern(toolName, 'npm *', patternSessionId);
                 // "npx" starts with "np" but is not "npm " + something
-                expect(manager.matchesPattern(toolName, 'npx *')).toBe(false);
+                expect(manager.matchesPattern(toolName, 'npx *', patternSessionId)).toBe(false);
             });
 
             it('should handle multi-level subcommands', async () => {
-                await manager.addPattern(toolName, 'docker compose *');
-                expect(manager.matchesPattern(toolName, 'docker compose *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'docker compose up *')).toBe(true);
-                expect(manager.matchesPattern(toolName, 'docker *')).toBe(false);
+                await manager.addPattern(toolName, 'docker compose *', patternSessionId);
+                expect(manager.matchesPattern(toolName, 'docker compose *', patternSessionId)).toBe(
+                    true
+                );
+                expect(
+                    manager.matchesPattern(toolName, 'docker compose up *', patternSessionId)
+                ).toBe(true);
+                expect(manager.matchesPattern(toolName, 'docker *', patternSessionId)).toBe(false);
             });
 
             it('should isolate patterns by tool', async () => {
-                await manager.addPattern('tool-a', 'git *');
-                expect(manager.matchesPattern('tool-a', 'git push *')).toBe(true);
-                expect(manager.matchesPattern('tool-b', 'git push *')).toBe(false);
+                await manager.addPattern('tool-a', 'git *', patternSessionId);
+                expect(manager.matchesPattern('tool-a', 'git push *', patternSessionId)).toBe(true);
+                expect(manager.matchesPattern('tool-b', 'git push *', patternSessionId)).toBe(
+                    false
+                );
             });
 
             it('should serialize deleteSessionState with in-flight pattern persistence', async () => {
@@ -790,28 +821,22 @@ describe('ApprovalManager', () => {
                     approvedDirectories: [],
                 };
                 const store = {
-                    load: vi.fn().mockImplementation(async (requestedSessionId?: string) => {
-                        return structuredClone(
-                            persistedState.get(requestedSessionId ?? '__global__') ?? emptyState
-                        );
-                    }),
+                    load: vi
+                        .fn()
+                        .mockImplementation(async (requestedSessionId: string) =>
+                            structuredClone(persistedState.get(requestedSessionId) ?? emptyState)
+                        ),
                     save: vi
                         .fn()
                         .mockImplementation(
-                            async (
-                                requestedSessionId: string | undefined,
-                                state: SessionApprovalState
-                            ) => {
+                            async (requestedSessionId: string, state: SessionApprovalState) => {
                                 saveStarted.resolve();
                                 await releaseSave.promise;
-                                persistedState.set(
-                                    requestedSessionId ?? '__global__',
-                                    structuredClone(state)
-                                );
+                                persistedState.set(requestedSessionId, structuredClone(state));
                             }
                         ),
-                    delete: vi.fn().mockImplementation(async (requestedSessionId?: string) => {
-                        persistedState.delete(requestedSessionId ?? '__global__');
+                    delete: vi.fn().mockImplementation(async (requestedSessionId: string) => {
+                        persistedState.delete(requestedSessionId);
                     }),
                 };
                 const manager = new ApprovalManager(
@@ -856,32 +881,32 @@ describe('ApprovalManager', () => {
 
         describe('clearPatterns', () => {
             it('should clear patterns for a tool', async () => {
-                await manager.addPattern(toolName, 'git *');
-                await manager.addPattern(toolName, 'npm *');
-                expect(manager.getToolPatterns(toolName).size).toBe(2);
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                await manager.addPattern(toolName, 'npm *', patternSessionId);
+                expect(manager.getToolPatterns(toolName, patternSessionId).size).toBe(2);
 
-                await manager.clearPatterns(toolName);
-                expect(manager.getToolPatterns(toolName).size).toBe(0);
+                await manager.clearPatterns(toolName, patternSessionId);
+                expect(manager.getToolPatterns(toolName, patternSessionId).size).toBe(0);
             });
 
             it('should allow adding patterns after clearing', async () => {
-                await manager.addPattern(toolName, 'git *');
-                await manager.clearPatterns(toolName);
-                await manager.addPattern(toolName, 'npm *');
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                await manager.clearPatterns(toolName, patternSessionId);
+                await manager.addPattern(toolName, 'npm *', patternSessionId);
 
-                expect(manager.getToolPatterns(toolName).size).toBe(1);
-                expect(manager.getToolPatterns(toolName).has('npm *')).toBe(true);
+                expect(manager.getToolPatterns(toolName, patternSessionId).size).toBe(1);
+                expect(manager.getToolPatterns(toolName, patternSessionId).has('npm *')).toBe(true);
             });
         });
 
         describe('getToolPatterns', () => {
             it('should return empty set initially', () => {
-                expect(manager.getToolPatterns(toolName).size).toBe(0);
+                expect(manager.getToolPatterns(toolName, patternSessionId).size).toBe(0);
             });
 
             it('should return a copy that reflects current patterns', async () => {
-                await manager.addPattern(toolName, 'git *');
-                const patterns = manager.getToolPatterns(toolName);
+                await manager.addPattern(toolName, 'git *', patternSessionId);
+                const patterns = manager.getToolPatterns(toolName, patternSessionId);
                 expect(patterns.has('git *')).toBe(true);
             });
         });
@@ -889,6 +914,7 @@ describe('ApprovalManager', () => {
 
     describe('Directory Access Approval', () => {
         let manager: ApprovalManager;
+        const directorySessionId = 'directory-session';
 
         beforeEach(() => {
             manager = createApprovalManager(
@@ -907,22 +933,42 @@ describe('ApprovalManager', () => {
 
         describe('initializeWorkingDirectory', () => {
             it('should add working directory as session-approved', async () => {
-                await manager.initializeWorkingDirectory('/home/user/project');
-                expect(manager.isDirectorySessionApproved('/home/user/project/src/file.ts')).toBe(
-                    true
-                );
+                await manager.initializeWorkingDirectory('/home/user/project', directorySessionId);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/home/user/project/src/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
 
             it('should normalize the path before adding', async () => {
-                await manager.initializeWorkingDirectory('/home/user/../user/project');
-                expect(manager.isDirectorySessionApproved('/home/user/project/file.ts')).toBe(true);
+                await manager.initializeWorkingDirectory(
+                    '/home/user/../user/project',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/home/user/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
         });
 
         describe('addApprovedDirectory', () => {
             it('should add directory with session type by default', async () => {
-                await manager.addApprovedDirectory('/external/project');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
 
             it('should treat symlink-approved directory as approved for its realpath', async () => {
@@ -935,11 +981,19 @@ describe('ApprovalManager', () => {
                     const symlinkType = process.platform === 'win32' ? 'junction' : 'dir';
                     symlinkSync(actualDir, linkDir, symlinkType);
 
-                    await manager.addApprovedDirectory(linkDir, 'session');
+                    await manager.addApprovedDirectory(linkDir, 'session', directorySessionId);
 
-                    expect(manager.isDirectoryApproved(path.join(actualDir, 'file.ts'))).toBe(true);
                     expect(
-                        manager.isDirectorySessionApproved(path.join(actualDir, 'file.ts'))
+                        manager.isDirectoryApproved(
+                            path.join(actualDir, 'file.ts'),
+                            directorySessionId
+                        )
+                    ).toBe(true);
+                    expect(
+                        manager.isDirectorySessionApproved(
+                            path.join(actualDir, 'file.ts'),
+                            directorySessionId
+                        )
                     ).toBe(true);
                 } finally {
                     rmSync(baseDir, { recursive: true, force: true });
@@ -962,130 +1016,248 @@ describe('ApprovalManager', () => {
                     const approvedDir = path.join(linkDir, 'child');
 
                     // Approve a directory that doesn't exist yet (common for write/create flows).
-                    await manager.addApprovedDirectory(approvedDir, 'session');
+                    await manager.addApprovedDirectory(approvedDir, 'session', directorySessionId);
 
                     const actualChildDir = path.join(actualDir, 'child');
                     mkdirSync(actualChildDir);
 
                     const filePath = path.join(actualChildDir, 'file.ts');
-                    expect(manager.isDirectoryApproved(filePath)).toBe(true);
-                    expect(manager.isDirectorySessionApproved(filePath)).toBe(true);
+                    expect(manager.isDirectoryApproved(filePath, directorySessionId)).toBe(true);
+                    expect(manager.isDirectorySessionApproved(filePath, directorySessionId)).toBe(
+                        true
+                    );
                 } finally {
                     rmSync(baseDir, { recursive: true, force: true });
                 }
             });
 
             it('should add directory with explicit session type', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
 
             it('should add directory with once type', async () => {
-                await manager.addApprovedDirectory('/external/project', 'once');
+                await manager.addApprovedDirectory('/external/project', 'once', directorySessionId);
                 // 'once' type should NOT be session-approved (requires prompt each time)
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(false);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(false);
                 // But should be generally approved for execution
-                expect(manager.isDirectoryApproved('/external/project/file.ts')).toBe(true);
+                expect(
+                    manager.isDirectoryApproved('/external/project/file.ts', directorySessionId)
+                ).toBe(true);
             });
 
             it('should not downgrade from session to once', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                await manager.addApprovedDirectory('/external/project', 'once');
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                await manager.addApprovedDirectory('/external/project', 'once', directorySessionId);
                 // Should still be session-approved
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(true);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
 
             it('should upgrade from once to session', async () => {
-                await manager.addApprovedDirectory('/external/project', 'once');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(false);
+                await manager.addApprovedDirectory('/external/project', 'once', directorySessionId);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(false);
 
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
 
             it('should normalize paths before adding', async () => {
-                await manager.addApprovedDirectory('/external/../external/project');
-                expect(manager.isDirectoryApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/../external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectoryApproved('/external/project/file.ts', directorySessionId)
+                ).toBe(true);
             });
         });
 
         describe('isDirectorySessionApproved', () => {
             it('should return true for files within session-approved directory', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
                 expect(
-                    manager.isDirectorySessionApproved('/external/project/src/deep/file.ts')
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/src/deep/file.ts',
+                        directorySessionId
+                    )
                 ).toBe(true);
             });
 
             it('should return false for files within once-approved directory', async () => {
-                await manager.addApprovedDirectory('/external/project', 'once');
-                expect(manager.isDirectorySessionApproved('/external/project/file.ts')).toBe(false);
+                await manager.addApprovedDirectory('/external/project', 'once', directorySessionId);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external/project/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(false);
             });
 
             it('should return false for files outside approved directories', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectorySessionApproved('/other/file.ts')).toBe(false);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectorySessionApproved('/other/file.ts', directorySessionId)
+                ).toBe(false);
             });
 
             it('should handle path containment correctly', async () => {
-                await manager.addApprovedDirectory('/external', 'session');
+                await manager.addApprovedDirectory('/external', 'session', directorySessionId);
                 // Approving /external should cover /external/sub/file.ts
-                expect(manager.isDirectorySessionApproved('/external/sub/file.ts')).toBe(true);
+                expect(
+                    manager.isDirectorySessionApproved('/external/sub/file.ts', directorySessionId)
+                ).toBe(true);
                 // But not /external-other/file.ts (different directory)
-                expect(manager.isDirectorySessionApproved('/external-other/file.ts')).toBe(false);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/external-other/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(false);
             });
 
             it('should return true when working directory is initialized', async () => {
-                await manager.initializeWorkingDirectory('/home/user/project');
-                expect(manager.isDirectorySessionApproved('/home/user/project/any/file.ts')).toBe(
-                    true
-                );
+                await manager.initializeWorkingDirectory('/home/user/project', directorySessionId);
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/home/user/project/any/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
             });
         });
 
         describe('isDirectoryApproved', () => {
             it('should return true for files within session-approved directory', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectoryApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(
+                    manager.isDirectoryApproved('/external/project/file.ts', directorySessionId)
+                ).toBe(true);
             });
 
             it('should return true for files within once-approved directory', async () => {
-                await manager.addApprovedDirectory('/external/project', 'once');
-                expect(manager.isDirectoryApproved('/external/project/file.ts')).toBe(true);
+                await manager.addApprovedDirectory('/external/project', 'once', directorySessionId);
+                expect(
+                    manager.isDirectoryApproved('/external/project/file.ts', directorySessionId)
+                ).toBe(true);
             });
 
             it('should return false for files outside approved directories', async () => {
-                await manager.addApprovedDirectory('/external/project', 'session');
-                expect(manager.isDirectoryApproved('/other/file.ts')).toBe(false);
+                await manager.addApprovedDirectory(
+                    '/external/project',
+                    'session',
+                    directorySessionId
+                );
+                expect(manager.isDirectoryApproved('/other/file.ts', directorySessionId)).toBe(
+                    false
+                );
             });
 
             it('should handle multiple approved directories', async () => {
-                await manager.addApprovedDirectory('/external/project1', 'session');
-                await manager.addApprovedDirectory('/external/project2', 'once');
+                await manager.addApprovedDirectory(
+                    '/external/project1',
+                    'session',
+                    directorySessionId
+                );
+                await manager.addApprovedDirectory(
+                    '/external/project2',
+                    'once',
+                    directorySessionId
+                );
 
-                expect(manager.isDirectoryApproved('/external/project1/file.ts')).toBe(true);
-                expect(manager.isDirectoryApproved('/external/project2/file.ts')).toBe(true);
-                expect(manager.isDirectoryApproved('/external/project3/file.ts')).toBe(false);
+                expect(
+                    manager.isDirectoryApproved('/external/project1/file.ts', directorySessionId)
+                ).toBe(true);
+                expect(
+                    manager.isDirectoryApproved('/external/project2/file.ts', directorySessionId)
+                ).toBe(true);
+                expect(
+                    manager.isDirectoryApproved('/external/project3/file.ts', directorySessionId)
+                ).toBe(false);
             });
 
             it('should handle nested directory approvals', async () => {
-                await manager.addApprovedDirectory('/external', 'session');
+                await manager.addApprovedDirectory('/external', 'session', directorySessionId);
                 // Approving /external should cover all subdirectories
-                expect(manager.isDirectoryApproved('/external/sub/deep/file.ts')).toBe(true);
+                expect(
+                    manager.isDirectoryApproved('/external/sub/deep/file.ts', directorySessionId)
+                ).toBe(true);
             });
         });
 
         describe('getApprovedDirectories', () => {
             it('should return empty map initially', () => {
-                expect(manager.getApprovedDirectories().size).toBe(0);
+                expect(manager.getApprovedDirectories(directorySessionId).size).toBe(0);
             });
 
             it('should return map with type information', async () => {
-                await manager.addApprovedDirectory('/external/project1', 'session');
-                await manager.addApprovedDirectory('/external/project2', 'once');
+                await manager.addApprovedDirectory(
+                    '/external/project1',
+                    'session',
+                    directorySessionId
+                );
+                await manager.addApprovedDirectory(
+                    '/external/project2',
+                    'once',
+                    directorySessionId
+                );
 
-                const dirs = manager.getApprovedDirectories();
+                const dirs = manager.getApprovedDirectories(directorySessionId);
                 expect(dirs.size).toBeGreaterThanOrEqual(2);
                 // Check that paths are normalized (absolute)
                 const keys = Array.from(dirs.keys());
@@ -1094,8 +1266,8 @@ describe('ApprovalManager', () => {
             });
 
             it('should include working directory after initialization', async () => {
-                await manager.initializeWorkingDirectory('/home/user/project');
-                const dirs = manager.getApprovedDirectories();
+                await manager.initializeWorkingDirectory('/home/user/project', directorySessionId);
+                const dirs = manager.getApprovedDirectories(directorySessionId);
                 expect(dirs.size).toBeGreaterThanOrEqual(1);
                 expect(dirs.get(path.resolve('/home/user/project'))).toBe('session');
                 expect(new Set(dirs.values())).toEqual(new Set(['session']));
@@ -1106,31 +1278,44 @@ describe('ApprovalManager', () => {
             // These tests verify the expected prompting flow
 
             it('working directory should not require prompt (session-approved)', async () => {
-                await manager.initializeWorkingDirectory('/home/user/project');
+                await manager.initializeWorkingDirectory('/home/user/project', directorySessionId);
                 // isDirectorySessionApproved returns true → no directory prompt needed
-                expect(manager.isDirectorySessionApproved('/home/user/project/src/file.ts')).toBe(
+                expect(
+                    manager.isDirectorySessionApproved(
+                        '/home/user/project/src/file.ts',
+                        directorySessionId
+                    )
+                ).toBe(true);
+            });
+
+            it('external dir after session approval should not require prompt', async () => {
+                await manager.addApprovedDirectory('/external', 'session', directorySessionId);
+                // isDirectorySessionApproved returns true → no directory prompt needed
+                expect(
+                    manager.isDirectorySessionApproved('/external/file.ts', directorySessionId)
+                ).toBe(true);
+            });
+
+            it('external dir after once approval should require prompt each time', async () => {
+                await manager.addApprovedDirectory('/external', 'once', directorySessionId);
+                // isDirectorySessionApproved returns false → directory prompt needed
+                expect(
+                    manager.isDirectorySessionApproved('/external/file.ts', directorySessionId)
+                ).toBe(false);
+                // But isDirectoryApproved returns true → execution allowed
+                expect(manager.isDirectoryApproved('/external/file.ts', directorySessionId)).toBe(
                     true
                 );
             });
 
-            it('external dir after session approval should not require prompt', async () => {
-                await manager.addApprovedDirectory('/external', 'session');
-                // isDirectorySessionApproved returns true → no directory prompt needed
-                expect(manager.isDirectorySessionApproved('/external/file.ts')).toBe(true);
-            });
-
-            it('external dir after once approval should require prompt each time', async () => {
-                await manager.addApprovedDirectory('/external', 'once');
-                // isDirectorySessionApproved returns false → directory prompt needed
-                expect(manager.isDirectorySessionApproved('/external/file.ts')).toBe(false);
-                // But isDirectoryApproved returns true → execution allowed
-                expect(manager.isDirectoryApproved('/external/file.ts')).toBe(true);
-            });
-
             it('unapproved external dir should require prompt', () => {
                 // No directories approved
-                expect(manager.isDirectorySessionApproved('/external/file.ts')).toBe(false);
-                expect(manager.isDirectoryApproved('/external/file.ts')).toBe(false);
+                expect(
+                    manager.isDirectorySessionApproved('/external/file.ts', directorySessionId)
+                ).toBe(false);
+                expect(manager.isDirectoryApproved('/external/file.ts', directorySessionId)).toBe(
+                    false
+                );
             });
         });
     });

--- a/packages/core/src/approval/manager.test.ts
+++ b/packages/core/src/approval/manager.test.ts
@@ -181,31 +181,6 @@ describe('ApprovalManager', () => {
             expect(response.status).toBe(ApprovalStatus.APPROVED);
         });
 
-        it('should route command confirmations to tool confirmation handler', async () => {
-            const manager = createApprovalManager(
-                {
-                    permissions: {
-                        mode: 'auto-approve',
-                        timeout: 120000,
-                    },
-                    elicitation: {
-                        enabled: true,
-                        timeout: 120000,
-                    },
-                },
-                mockLogger
-            );
-
-            const response = await manager.requestCommandConfirmation({
-                toolName: 'bash_exec',
-                command: 'rm -rf /',
-                originalCommand: 'rm -rf /',
-                sessionId: approvalSessionId,
-            });
-
-            expect(response.status).toBe(ApprovalStatus.APPROVED);
-        });
-
         it('should route elicitation to elicitation provider when enabled', async () => {
             const manager = createApprovalManager(
                 {

--- a/packages/core/src/approval/manager.ts
+++ b/packages/core/src/approval/manager.ts
@@ -23,8 +23,6 @@ import {
     type SessionApprovalState,
 } from './session-approval-store.js';
 
-const GLOBAL_APPROVAL_SCOPE = '__global__';
-
 type ApprovalScopeState = {
     toolPatterns: Map<string, Set<string>>;
     approvedDirectories: Map<string, 'session' | 'once'>;
@@ -126,12 +124,25 @@ export class ApprovalManager {
         );
     }
 
-    private getScopeKey(sessionId?: string): string {
-        return sessionId ?? GLOBAL_APPROVAL_SCOPE;
+    private requireSessionScopeId(sessionId: string | undefined, reason: string): string {
+        if (typeof sessionId === 'string' && sessionId.length > 0) {
+            return sessionId;
+        }
+
+        throw ApprovalError.invalidRequest(reason, {
+            field: 'sessionId',
+        });
     }
 
-    private getScopeLabel(sessionId?: string): string {
-        return sessionId ?? 'global';
+    private getScopeKey(sessionId: string | undefined): string {
+        return this.requireSessionScopeId(
+            sessionId,
+            'sessionId is required for session-scoped approval state'
+        );
+    }
+
+    private getScopeLabel(sessionId: string | undefined): string {
+        return this.getScopeKey(sessionId);
     }
 
     private getApprovalTimeout(type: ApprovalType, timeout?: number): number | undefined {
@@ -199,7 +210,7 @@ export class ApprovalManager {
         );
     }
 
-    private async persistScope(sessionId?: string): Promise<void> {
+    private async persistScope(sessionId: string): Promise<void> {
         const scopeKey = this.getScopeKey(sessionId);
         const state: SessionApprovalState = {
             toolPatterns: this.snapshotToolPatterns(scopeKey),
@@ -208,7 +219,7 @@ export class ApprovalManager {
         await this.sessionApprovalStore.save(sessionId, state);
     }
 
-    private hydrateScope(sessionId: string | undefined, state: SessionApprovalState): void {
+    private hydrateScope(sessionId: string, state: SessionApprovalState): void {
         const scopeKey = this.getScopeKey(sessionId);
 
         const toolPatterns = new Map<string, Set<string>>();
@@ -227,7 +238,7 @@ export class ApprovalManager {
         });
     }
 
-    async restoreSessionState(sessionId?: string): Promise<void> {
+    async restoreSessionState(sessionId: string): Promise<void> {
         const scopeKey = this.getScopeKey(sessionId);
         if (this.loadedScopes.has(scopeKey)) {
             return;
@@ -250,13 +261,13 @@ export class ApprovalManager {
         });
     }
 
-    evictSessionState(sessionId?: string): void {
+    evictSessionState(sessionId: string): void {
         const scopeKey = this.getScopeKey(sessionId);
         this.scopes.delete(scopeKey);
         this.loadedScopes.delete(scopeKey);
     }
 
-    async deleteSessionState(sessionId?: string): Promise<void> {
+    async deleteSessionState(sessionId: string): Promise<void> {
         const scopeKey = this.getScopeKey(sessionId);
         await this.runWithScopeLock(scopeKey, async () => {
             this.evictSessionState(sessionId);
@@ -278,7 +289,7 @@ export class ApprovalManager {
     /**
      * Add an approval pattern for a tool.
      */
-    async addPattern(toolName: string, pattern: string, sessionId?: string): Promise<void> {
+    async addPattern(toolName: string, pattern: string, sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
         const scopeKey = this.getScopeKey(sessionId);
 
@@ -298,7 +309,7 @@ export class ApprovalManager {
      * Note: This expects a pattern key (e.g. "git push *"), not raw arguments.
      * Tools are responsible for generating the key via `tool.approval.patternKey()`.
      */
-    matchesPattern(toolName: string, patternKey: string, sessionId?: string): boolean {
+    matchesPattern(toolName: string, patternKey: string, sessionId: string): boolean {
         const scopeKey = this.getScopeKey(sessionId);
         const patterns = this.getScope(scopeKey).toolPatterns.get(toolName);
         if (!patterns || patterns.size === 0) return false;
@@ -317,7 +328,7 @@ export class ApprovalManager {
     /**
      * Clear all patterns for a tool (or all tools when omitted).
      */
-    async clearPatterns(toolName?: string, sessionId?: string): Promise<void> {
+    async clearPatterns(toolName: string | undefined, sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
         const scopeKey = this.getScopeKey(sessionId);
 
@@ -351,7 +362,7 @@ export class ApprovalManager {
     /**
      * Get patterns for a tool (for debugging/display).
      */
-    getToolPatterns(toolName: string, sessionId?: string): ReadonlySet<string> {
+    getToolPatterns(toolName: string, sessionId: string): ReadonlySet<string> {
         const scopeKey = this.getScopeKey(sessionId);
         return this.getScope(scopeKey).toolPatterns.get(toolName) ?? new Set<string>();
     }
@@ -359,7 +370,7 @@ export class ApprovalManager {
     /**
      * Get all tool patterns (for debugging/display).
      */
-    getAllToolPatterns(sessionId?: string): ReadonlyMap<string, Set<string>> {
+    getAllToolPatterns(sessionId: string): ReadonlyMap<string, Set<string>> {
         const scopeKey = this.getScopeKey(sessionId);
         return this.getScope(scopeKey).toolPatterns;
     }
@@ -384,7 +395,7 @@ export class ApprovalManager {
 
     private isPathWithinApprovedDirectory(
         targetPath: string,
-        sessionId: string | undefined,
+        sessionId: string,
         approvedTypes: ReadonlySet<'session' | 'once'>
     ): boolean {
         const scopeKey = this.getScopeKey(sessionId);
@@ -415,7 +426,7 @@ export class ApprovalManager {
      *
      * @param workingDir The working directory path
      */
-    async initializeWorkingDirectory(workingDir: string, sessionId?: string): Promise<void> {
+    async initializeWorkingDirectory(workingDir: string, sessionId: string): Promise<void> {
         await this.addApprovedDirectory(workingDir, 'session', sessionId);
     }
 
@@ -439,7 +450,7 @@ export class ApprovalManager {
     async addApprovedDirectory(
         directory: string,
         type: 'session' | 'once' = 'session',
-        sessionId?: string
+        sessionId: string
     ): Promise<void> {
         await this.restoreSessionState(sessionId);
         const scopeKey = this.getScopeKey(sessionId);
@@ -492,7 +503,7 @@ export class ApprovalManager {
      * @param filePath The file path to check (can be relative or absolute)
      * @returns true if the path is within a session-approved directory
      */
-    isDirectorySessionApproved(filePath: string, sessionId?: string): boolean {
+    isDirectorySessionApproved(filePath: string, sessionId: string): boolean {
         return this.isPathWithinApprovedDirectory(filePath, sessionId, new Set(['session']));
     }
 
@@ -504,7 +515,7 @@ export class ApprovalManager {
      * @param filePath The file path to check (can be relative or absolute)
      * @returns true if the path is within any approved directory
      */
-    isDirectoryApproved(filePath: string, sessionId?: string): boolean {
+    isDirectoryApproved(filePath: string, sessionId: string): boolean {
         return this.isPathWithinApprovedDirectory(
             filePath,
             sessionId,
@@ -516,7 +527,7 @@ export class ApprovalManager {
      * Clear all approved directories.
      * Should be called when session ends.
      */
-    async clearApprovedDirectories(sessionId?: string): Promise<void> {
+    async clearApprovedDirectories(sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
         const scopeKey = this.getScopeKey(sessionId);
 
@@ -536,7 +547,7 @@ export class ApprovalManager {
     /**
      * Get the current map of approved directories with their types (for debugging/display).
      */
-    getApprovedDirectories(sessionId?: string): ReadonlyMap<string, 'session' | 'once'> {
+    getApprovedDirectories(sessionId: string): ReadonlyMap<string, 'session' | 'once'> {
         const scopeKey = this.getScopeKey(sessionId);
         return this.getScope(scopeKey).approvedDirectories;
     }
@@ -544,7 +555,7 @@ export class ApprovalManager {
     /**
      * Get just the directory paths that are approved (for debugging/display).
      */
-    getApprovedDirectoryPaths(sessionId?: string): string[] {
+    getApprovedDirectoryPaths(sessionId: string): string[] {
         return Array.from(this.getApprovedDirectories(sessionId).keys());
     }
 
@@ -552,7 +563,7 @@ export class ApprovalManager {
      * Clear all session-scoped approvals (tool patterns and directories).
      * Convenience method for clearing all session state at once.
      */
-    async clearSessionApprovals(sessionId?: string): Promise<void> {
+    async clearSessionApprovals(sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
         const scopeKey = this.getScopeKey(sessionId);
 
@@ -649,14 +660,18 @@ export class ApprovalManager {
      * ```
      */
     async requestDirectoryAccess(
-        metadata: DirectoryAccessMetadata & { sessionId?: string; timeout?: number }
+        metadata: DirectoryAccessMetadata & { sessionId: string; timeout?: number }
     ): Promise<ApprovalResponse> {
         const { sessionId, timeout, ...directoryMetadata } = metadata;
+        const requiredSessionId = this.requireSessionScopeId(
+            sessionId,
+            'sessionId is required for directory access approvals'
+        );
         return this.requestApproval(
             this.createApprovalDetails(
                 ApprovalType.DIRECTORY_ACCESS,
                 directoryMetadata,
-                sessionId,
+                requiredSessionId,
                 timeout
             )
         );
@@ -688,7 +703,7 @@ export class ApprovalManager {
         if (request.type === ApprovalType.ELICITATION) {
             const handler = this.ensureHandler();
             this.logger.info(
-                `Elicitation requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'global'}`
+                `Elicitation requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'none'}`
             );
             return handler(request);
         }
@@ -721,7 +736,7 @@ export class ApprovalManager {
         // Manual mode - delegate to handler
         const handler = this.ensureHandler();
         this.logger.info(
-            `Manual approval '${request.type}' requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'global'}`
+            `Manual approval '${request.type}' requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'none'}`
         );
         return handler(request);
     }
@@ -730,15 +745,22 @@ export class ApprovalManager {
      * Request tool approval
      * Convenience method for tool execution approval
      *
-     * TODO: Make sessionId required once all callers are updated to pass it
-     * Tool confirmations always happen in session context during LLM execution
      */
     async requestToolApproval(
-        metadata: ToolApprovalMetadata & { sessionId?: string; timeout?: number }
+        metadata: ToolApprovalMetadata & { sessionId: string; timeout?: number }
     ): Promise<ApprovalResponse> {
         const { sessionId, timeout, ...toolMetadata } = metadata;
+        const requiredSessionId = this.requireSessionScopeId(
+            sessionId,
+            'sessionId is required for tool approvals'
+        );
         return this.requestApproval(
-            this.createApprovalDetails(ApprovalType.TOOL_APPROVAL, toolMetadata, sessionId, timeout)
+            this.createApprovalDetails(
+                ApprovalType.TOOL_APPROVAL,
+                toolMetadata,
+                requiredSessionId,
+                timeout
+            )
         );
     }
 
@@ -748,9 +770,6 @@ export class ApprovalManager {
      *
      * This is different from tool approval - it's for per-command approval
      * of dangerous operations (like rm, git push) within tools that are already approved.
-     *
-     * TODO: Make sessionId required once all callers are updated to pass it
-     * Command confirmations always happen during tool execution which has session context
      *
      * @example
      * ```typescript
@@ -764,14 +783,18 @@ export class ApprovalManager {
      * ```
      */
     async requestCommandConfirmation(
-        metadata: CommandConfirmationMetadata & { sessionId?: string; timeout?: number }
+        metadata: CommandConfirmationMetadata & { sessionId: string; timeout?: number }
     ): Promise<ApprovalResponse> {
         const { sessionId, timeout, ...commandMetadata } = metadata;
+        const requiredSessionId = this.requireSessionScopeId(
+            sessionId,
+            'sessionId is required for command confirmations'
+        );
         return this.requestApproval(
             this.createApprovalDetails(
                 ApprovalType.COMMAND_CONFIRMATION,
                 commandMetadata,
-                sessionId,
+                requiredSessionId,
                 timeout
             )
         );
@@ -803,7 +826,7 @@ export class ApprovalManager {
      * Throws appropriate error if denied
      */
     async checkToolApproval(
-        metadata: ToolApprovalMetadata & { sessionId?: string; timeout?: number }
+        metadata: ToolApprovalMetadata & { sessionId: string; timeout?: number }
     ): Promise<boolean> {
         const response = await this.requestToolApproval(metadata);
 

--- a/packages/core/src/approval/manager.ts
+++ b/packages/core/src/approval/manager.ts
@@ -674,7 +674,7 @@ export class ApprovalManager {
         metadata: ToolApprovalMetadata & { sessionId: string; timeout?: number }
     ): Promise<ApprovalResponse> {
         const { sessionId, timeout, ...toolMetadata } = metadata;
-        if (sessionId.length === 0) {
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
             throw ApprovalError.invalidRequest('sessionId is required for tool approvals', {
                 field: 'sessionId',
             });

--- a/packages/core/src/approval/manager.ts
+++ b/packages/core/src/approval/manager.ts
@@ -6,9 +6,7 @@ import type {
     ApprovalResponse,
     ApprovalRequestDetails,
     ToolApprovalMetadata,
-    CommandConfirmationMetadata,
     ElicitationMetadata,
-    DirectoryAccessMetadata,
 } from './types.js';
 import { ApprovalType, ApprovalStatus, DenialReason } from './types.js';
 import { createApprovalRequest } from './factory.js';
@@ -645,39 +643,6 @@ export class ApprovalManager {
     }
 
     /**
-     * Request directory access approval.
-     * Convenience method for directory access requests.
-     *
-     * @example
-     * ```typescript
-     * const response = await manager.requestDirectoryAccess({
-     *   path: '/external/project/src/file.ts',
-     *   parentDir: '/external/project',
-     *   operation: 'write',
-     *   toolName: 'write_file',
-     *   sessionId: 'session-123'
-     * });
-     * ```
-     */
-    async requestDirectoryAccess(
-        metadata: DirectoryAccessMetadata & { sessionId: string; timeout?: number }
-    ): Promise<ApprovalResponse> {
-        const { sessionId, timeout, ...directoryMetadata } = metadata;
-        const requiredSessionId = this.requireSessionScopeId(
-            sessionId,
-            'sessionId is required for directory access approvals'
-        );
-        return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.DIRECTORY_ACCESS,
-                directoryMetadata,
-                requiredSessionId,
-                timeout
-            )
-        );
-    }
-
-    /**
      * Request a generic approval
      */
     async requestApproval(details: ApprovalRequestDetails): Promise<ApprovalResponse> {
@@ -702,9 +667,10 @@ export class ApprovalManager {
         // Elicitation always uses manual mode (requires handler)
         if (request.type === ApprovalType.ELICITATION) {
             const handler = this.ensureHandler();
-            this.logger.info(
-                `Elicitation requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'none'}`
-            );
+            this.logger.info('Elicitation requested', {
+                approvalId: request.approvalId,
+                ...(request.sessionId !== undefined && { sessionId: request.sessionId }),
+            });
             return handler(request);
         }
 
@@ -735,9 +701,10 @@ export class ApprovalManager {
 
         // Manual mode - delegate to handler
         const handler = this.ensureHandler();
-        this.logger.info(
-            `Manual approval '${request.type}' requested, approvalId: ${request.approvalId}, sessionId: ${request.sessionId ?? 'none'}`
-        );
+        this.logger.info(`Manual approval '${request.type}' requested`, {
+            approvalId: request.approvalId,
+            ...(request.sessionId !== undefined && { sessionId: request.sessionId }),
+        });
         return handler(request);
     }
 
@@ -758,42 +725,6 @@ export class ApprovalManager {
             this.createApprovalDetails(
                 ApprovalType.TOOL_APPROVAL,
                 toolMetadata,
-                requiredSessionId,
-                timeout
-            )
-        );
-    }
-
-    /**
-     * Request command confirmation approval
-     * Convenience method for dangerous command execution within an already-approved tool
-     *
-     * This is different from tool approval - it's for per-command approval
-     * of dangerous operations (like rm, git push) within tools that are already approved.
-     *
-     * @example
-     * ```typescript
-     * // bash_exec tool is approved, but dangerous commands still require approval
-     * const response = await manager.requestCommandConfirmation({
-     *   toolName: 'bash_exec',
-     *   command: 'rm -rf /important',
-     *   originalCommand: 'rm -rf /important',
-     *   sessionId: 'session-123'
-     * });
-     * ```
-     */
-    async requestCommandConfirmation(
-        metadata: CommandConfirmationMetadata & { sessionId: string; timeout?: number }
-    ): Promise<ApprovalResponse> {
-        const { sessionId, timeout, ...commandMetadata } = metadata;
-        const requiredSessionId = this.requireSessionScopeId(
-            sessionId,
-            'sessionId is required for command confirmations'
-        );
-        return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.COMMAND_CONFIRMATION,
-                commandMetadata,
                 requiredSessionId,
                 timeout
             )

--- a/packages/core/src/approval/manager.ts
+++ b/packages/core/src/approval/manager.ts
@@ -122,27 +122,6 @@ export class ApprovalManager {
         );
     }
 
-    private requireSessionScopeId(sessionId: string | undefined, reason: string): string {
-        if (typeof sessionId === 'string' && sessionId.length > 0) {
-            return sessionId;
-        }
-
-        throw ApprovalError.invalidRequest(reason, {
-            field: 'sessionId',
-        });
-    }
-
-    private getScopeKey(sessionId: string | undefined): string {
-        return this.requireSessionScopeId(
-            sessionId,
-            'sessionId is required for session-scoped approval state'
-        );
-    }
-
-    private getScopeLabel(sessionId: string | undefined): string {
-        return this.getScopeKey(sessionId);
-    }
-
     private getApprovalTimeout(type: ApprovalType, timeout?: number): number | undefined {
         return timeout ?? this.getDefaultTimeout(type);
     }
@@ -209,17 +188,14 @@ export class ApprovalManager {
     }
 
     private async persistScope(sessionId: string): Promise<void> {
-        const scopeKey = this.getScopeKey(sessionId);
         const state: SessionApprovalState = {
-            toolPatterns: this.snapshotToolPatterns(scopeKey),
-            approvedDirectories: this.snapshotApprovedDirectories(scopeKey),
+            toolPatterns: this.snapshotToolPatterns(sessionId),
+            approvedDirectories: this.snapshotApprovedDirectories(sessionId),
         };
         await this.sessionApprovalStore.save(sessionId, state);
     }
 
     private hydrateScope(sessionId: string, state: SessionApprovalState): void {
-        const scopeKey = this.getScopeKey(sessionId);
-
         const toolPatterns = new Map<string, Set<string>>();
         for (const [toolName, patterns] of Object.entries(state.toolPatterns)) {
             toolPatterns.set(toolName, new Set(patterns));
@@ -230,29 +206,28 @@ export class ApprovalManager {
             approvedDirectories.set(entry.path, entry.type);
         }
 
-        this.scopes.set(scopeKey, {
+        this.scopes.set(sessionId, {
             toolPatterns,
             approvedDirectories,
         });
     }
 
     async restoreSessionState(sessionId: string): Promise<void> {
-        const scopeKey = this.getScopeKey(sessionId);
-        if (this.loadedScopes.has(scopeKey)) {
+        if (this.loadedScopes.has(sessionId)) {
             return;
         }
 
-        await this.runWithScopeLock(scopeKey, async () => {
-            if (this.loadedScopes.has(scopeKey)) {
+        await this.runWithScopeLock(sessionId, async () => {
+            if (this.loadedScopes.has(sessionId)) {
                 return;
             }
 
             const state = await this.sessionApprovalStore.load(sessionId);
             this.hydrateScope(sessionId, state);
-            this.loadedScopes.add(scopeKey);
+            this.loadedScopes.add(sessionId);
 
             this.logger.debug('Restored persisted approval state', {
-                sessionId: this.getScopeLabel(sessionId),
+                sessionId,
                 toolCount: Object.keys(state.toolPatterns).length,
                 directoryCount: state.approvedDirectories.length,
             });
@@ -260,14 +235,12 @@ export class ApprovalManager {
     }
 
     evictSessionState(sessionId: string): void {
-        const scopeKey = this.getScopeKey(sessionId);
-        this.scopes.delete(scopeKey);
-        this.loadedScopes.delete(scopeKey);
+        this.scopes.delete(sessionId);
+        this.loadedScopes.delete(sessionId);
     }
 
     async deleteSessionState(sessionId: string): Promise<void> {
-        const scopeKey = this.getScopeKey(sessionId);
-        await this.runWithScopeLock(scopeKey, async () => {
+        await this.runWithScopeLock(sessionId, async () => {
             this.evictSessionState(sessionId);
             await this.sessionApprovalStore.delete(sessionId);
         });
@@ -289,16 +262,13 @@ export class ApprovalManager {
      */
     async addPattern(toolName: string, pattern: string, sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
-        const scopeKey = this.getScopeKey(sessionId);
 
-        await this.runWithScopeLock(scopeKey, async () => {
-            this.getOrCreateToolPatternSet(toolName, scopeKey).add(pattern);
+        await this.runWithScopeLock(sessionId, async () => {
+            this.getOrCreateToolPatternSet(toolName, sessionId).add(pattern);
             await this.persistScope(sessionId);
         });
 
-        this.logger.debug(
-            `Added pattern for '${toolName}' in '${this.getScopeLabel(sessionId)}': "${pattern}"`
-        );
+        this.logger.debug(`Added pattern for '${toolName}' in '${sessionId}': "${pattern}"`);
     }
 
     /**
@@ -308,8 +278,7 @@ export class ApprovalManager {
      * Tools are responsible for generating the key via `tool.approval.patternKey()`.
      */
     matchesPattern(toolName: string, patternKey: string, sessionId: string): boolean {
-        const scopeKey = this.getScopeKey(sessionId);
-        const patterns = this.getScope(scopeKey).toolPatterns.get(toolName);
+        const patterns = this.getScope(sessionId).toolPatterns.get(toolName);
         if (!patterns || patterns.size === 0) return false;
 
         for (const storedPattern of patterns) {
@@ -328,10 +297,9 @@ export class ApprovalManager {
      */
     async clearPatterns(toolName: string | undefined, sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
-        const scopeKey = this.getScopeKey(sessionId);
 
-        await this.runWithScopeLock(scopeKey, async () => {
-            const scope = this.getOrCreateScope(scopeKey).toolPatterns;
+        await this.runWithScopeLock(sessionId, async () => {
+            const scope = this.getOrCreateScope(sessionId).toolPatterns;
             if (toolName) {
                 const patterns = scope.get(toolName);
                 if (!patterns) return;
@@ -340,7 +308,7 @@ export class ApprovalManager {
                 await this.persistScope(sessionId);
                 if (count > 0) {
                     this.logger.debug(
-                        `Cleared ${count} pattern(s) for '${toolName}' in '${this.getScopeLabel(sessionId)}'`
+                        `Cleared ${count} pattern(s) for '${toolName}' in '${sessionId}'`
                     );
                 }
                 return;
@@ -350,9 +318,7 @@ export class ApprovalManager {
             scope.clear();
             await this.persistScope(sessionId);
             if (count > 0) {
-                this.logger.debug(
-                    `Cleared ${count} total tool pattern(s) in '${this.getScopeLabel(sessionId)}'`
-                );
+                this.logger.debug(`Cleared ${count} total tool pattern(s) in '${sessionId}'`);
             }
         });
     }
@@ -361,16 +327,14 @@ export class ApprovalManager {
      * Get patterns for a tool (for debugging/display).
      */
     getToolPatterns(toolName: string, sessionId: string): ReadonlySet<string> {
-        const scopeKey = this.getScopeKey(sessionId);
-        return this.getScope(scopeKey).toolPatterns.get(toolName) ?? new Set<string>();
+        return this.getScope(sessionId).toolPatterns.get(toolName) ?? new Set<string>();
     }
 
     /**
      * Get all tool patterns (for debugging/display).
      */
     getAllToolPatterns(sessionId: string): ReadonlyMap<string, Set<string>> {
-        const scopeKey = this.getScopeKey(sessionId);
-        return this.getScope(scopeKey).toolPatterns;
+        return this.getScope(sessionId).toolPatterns;
     }
 
     // ==================== Directory Access Methods ====================
@@ -396,8 +360,7 @@ export class ApprovalManager {
         sessionId: string,
         approvedTypes: ReadonlySet<'session' | 'once'>
     ): boolean {
-        const scopeKey = this.getScopeKey(sessionId);
-        const directoryScope = this.getScope(scopeKey).approvedDirectories;
+        const directoryScope = this.getScope(sessionId).approvedDirectories;
         for (const normalized of this.getPathApprovalKeys(targetPath)) {
             for (const [approvedDir, type] of directoryScope) {
                 if (!approvedTypes.has(type)) {
@@ -451,11 +414,10 @@ export class ApprovalManager {
         sessionId: string
     ): Promise<void> {
         await this.restoreSessionState(sessionId);
-        const scopeKey = this.getScopeKey(sessionId);
 
-        await this.runWithScopeLock(scopeKey, async () => {
+        await this.runWithScopeLock(sessionId, async () => {
             const keys = this.getPathApprovalKeys(directory);
-            const directoryScope = this.getOrCreateScope(scopeKey).approvedDirectories;
+            const directoryScope = this.getOrCreateScope(sessionId).approvedDirectories;
 
             const existingTypes = keys
                 .map((key) => directoryScope.get(key))
@@ -486,7 +448,7 @@ export class ApprovalManager {
 
             const realKey = keys.length > 1 ? keys[1] : null;
             this.logger.debug(
-                `Added approved directory in '${this.getScopeLabel(sessionId)}': "${resolvedKey}" (type: ${effectiveType})${
+                `Added approved directory in '${sessionId}': "${resolvedKey}" (type: ${effectiveType})${
                     realKey ? `, realpath: "${realKey}"` : ''
                 }`
             );
@@ -527,17 +489,14 @@ export class ApprovalManager {
      */
     async clearApprovedDirectories(sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
-        const scopeKey = this.getScopeKey(sessionId);
 
-        await this.runWithScopeLock(scopeKey, async () => {
-            const scope = this.getOrCreateScope(scopeKey).approvedDirectories;
+        await this.runWithScopeLock(sessionId, async () => {
+            const scope = this.getOrCreateScope(sessionId).approvedDirectories;
             const count = scope.size;
             scope.clear();
             await this.persistScope(sessionId);
             if (count > 0) {
-                this.logger.debug(
-                    `Cleared ${count} approved directories in '${this.getScopeLabel(sessionId)}'`
-                );
+                this.logger.debug(`Cleared ${count} approved directories in '${sessionId}'`);
             }
         });
     }
@@ -546,8 +505,7 @@ export class ApprovalManager {
      * Get the current map of approved directories with their types (for debugging/display).
      */
     getApprovedDirectories(sessionId: string): ReadonlyMap<string, 'session' | 'once'> {
-        const scopeKey = this.getScopeKey(sessionId);
-        return this.getScope(scopeKey).approvedDirectories;
+        return this.getScope(sessionId).approvedDirectories;
     }
 
     /**
@@ -563,10 +521,9 @@ export class ApprovalManager {
      */
     async clearSessionApprovals(sessionId: string): Promise<void> {
         await this.restoreSessionState(sessionId);
-        const scopeKey = this.getScopeKey(sessionId);
 
-        await this.runWithScopeLock(scopeKey, async () => {
-            const scope = this.getOrCreateScope(scopeKey);
+        await this.runWithScopeLock(sessionId, async () => {
+            const scope = this.getOrCreateScope(sessionId);
             const patternCount = Array.from(scope.toolPatterns.values()).reduce(
                 (sum, set) => sum + set.size,
                 0
@@ -579,7 +536,7 @@ export class ApprovalManager {
 
             if (patternCount > 0 || directoryCount > 0) {
                 this.logger.debug(
-                    `Cleared ${patternCount} tool pattern(s) and ${directoryCount} approved director${directoryCount === 1 ? 'y' : 'ies'} in '${this.getScopeLabel(sessionId)}'`
+                    `Cleared ${patternCount} tool pattern(s) and ${directoryCount} approved director${directoryCount === 1 ? 'y' : 'ies'} in '${sessionId}'`
                 );
             }
         });
@@ -717,17 +674,13 @@ export class ApprovalManager {
         metadata: ToolApprovalMetadata & { sessionId: string; timeout?: number }
     ): Promise<ApprovalResponse> {
         const { sessionId, timeout, ...toolMetadata } = metadata;
-        const requiredSessionId = this.requireSessionScopeId(
-            sessionId,
-            'sessionId is required for tool approvals'
-        );
+        if (sessionId.length === 0) {
+            throw ApprovalError.invalidRequest('sessionId is required for tool approvals', {
+                field: 'sessionId',
+            });
+        }
         return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.TOOL_APPROVAL,
-                toolMetadata,
-                requiredSessionId,
-                timeout
-            )
+            this.createApprovalDetails(ApprovalType.TOOL_APPROVAL, toolMetadata, sessionId, timeout)
         );
     }
 

--- a/packages/core/src/approval/session-approval-store.ts
+++ b/packages/core/src/approval/session-approval-store.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { StorageManager } from '../storage/index.js';
 import type { Logger } from '../logger/v2/types.js';
+import { ApprovalError } from './errors.js';
 
 const ApprovedDirectoryTypeSchema = z.enum(['session', 'once']);
 
@@ -38,11 +39,18 @@ export class SessionApprovalStore {
         this.cacheTtlSeconds = Math.max(1, Math.floor(cacheTtlMs / 1000));
     }
 
-    private buildKey(sessionId?: string): string {
-        return sessionId ? `session-approvals:${sessionId}` : 'session-approvals:global';
+    private buildKey(sessionId: string | undefined): string {
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+            throw ApprovalError.invalidRequest(
+                'sessionId is required for persisted session approval state',
+                { field: 'sessionId' }
+            );
+        }
+
+        return `session-approvals:${sessionId}`;
     }
 
-    async load(sessionId?: string): Promise<SessionApprovalState> {
+    async load(sessionId: string): Promise<SessionApprovalState> {
         const key = this.buildKey(sessionId);
         const cached = await this.storageManager.getCache().get<unknown>(key);
         if (cached !== undefined) {
@@ -59,14 +67,14 @@ export class SessionApprovalStore {
         return parsed;
     }
 
-    async save(sessionId: string | undefined, state: SessionApprovalState): Promise<void> {
+    async save(sessionId: string, state: SessionApprovalState): Promise<void> {
         const key = this.buildKey(sessionId);
         const normalized = SessionApprovalStateSchema.parse(state);
         await this.storageManager.getDatabase().set(key, normalized);
         await this.storageManager.getCache().set(key, normalized, this.cacheTtlSeconds);
     }
 
-    async delete(sessionId?: string): Promise<void> {
+    async delete(sessionId: string): Promise<void> {
         const key = this.buildKey(sessionId);
         await Promise.all([
             this.storageManager.getDatabase().delete(key),

--- a/packages/core/src/session/chat-session.ts
+++ b/packages/core/src/session/chat-session.ts
@@ -58,7 +58,7 @@ import type { VercelLLMService } from '../llm/services/vercel.js';
  *
  * ```typescript
  * // Create a new session
- * const session = agent.createSession();
+ * const session = await agent.createSession();
  *
  * // Listen for session events
  * session.eventBus.on('llm:response', (payload) => {

--- a/packages/core/src/session/chat-session.ts
+++ b/packages/core/src/session/chat-session.ts
@@ -58,7 +58,7 @@ import type { VercelLLMService } from '../llm/services/vercel.js';
  *
  * ```typescript
  * // Create a new session
- * const session = agent.createSession('user-123');
+ * const session = agent.createSession();
  *
  * // Listen for session events
  * session.eventBus.on('llm:response', (payload) => {

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -257,9 +257,12 @@ export class SessionManager {
     }
 
     /**
-     * Creates a new chat session or returns an existing one.
+     * Creates a new chat session.
      *
-     * @param sessionId Optional session ID. If not provided, a UUID will be generated.
+     * Most callers should omit sessionId and use the generated ID. Integration adapters may pass
+     * a stable external ID when they need create-or-resume semantics.
+     *
+     * @param sessionId Optional integration-owned session ID. If not provided, a UUID is generated.
      * @returns The created or existing ChatSession
      * @throws Error if maximum sessions limit is reached
      */

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.test.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { InMemoryAllowedToolsProvider } from './in-memory.js';
+
+describe('InMemoryAllowedToolsProvider', () => {
+    it('should reject missing sessionId on read paths', async () => {
+        const provider = new InMemoryAllowedToolsProvider();
+
+        await expect(
+            (
+                provider as unknown as {
+                    isToolAllowed(toolName: string): Promise<boolean>;
+                }
+            ).isToolAllowed('test-tool')
+        ).rejects.toThrow('sessionId is required for remembered tool approvals');
+
+        await expect(
+            (
+                provider as unknown as {
+                    getAllowedTools(): Promise<Set<string>>;
+                }
+            ).getAllowedTools()
+        ).rejects.toThrow('sessionId is required for remembered tool approvals');
+    });
+
+    it('should not create empty session buckets during reads', async () => {
+        const provider = new InMemoryAllowedToolsProvider();
+        const store = (provider as unknown as { store: Map<string, Set<string>> }).store;
+
+        expect(await provider.isToolAllowed('test-tool', 'session-1')).toBe(false);
+        expect(await provider.getAllowedTools('session-1')).toEqual(new Set());
+        expect(store.has('session-1')).toBe(false);
+    });
+});

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.ts
@@ -1,43 +1,38 @@
 import type { AllowedToolsProvider } from './types.js';
+import { ToolError } from '../../errors.js';
 
 export class InMemoryAllowedToolsProvider implements AllowedToolsProvider {
-    /**
-     * Map key is sessionId (undefined => global approvals). Value is a set of
-     * approved tool names.
-     */
-    private store: Map<string | undefined, Set<string>> = new Map();
+    private store: Map<string, Set<string>> = new Map();
 
-    constructor(initialGlobal?: Set<string>) {
-        if (initialGlobal) {
-            this.store.set(undefined, new Set(initialGlobal));
+    private getSet(sessionId: string | undefined): Set<string> {
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+            throw ToolError.validationFailed(
+                'tool_approval_memory',
+                'sessionId is required for remembered tool approvals'
+            );
         }
-    }
 
-    private getSet(sessionId?: string): Set<string> {
-        const key = sessionId ?? undefined;
-        let set = this.store.get(key);
+        let set = this.store.get(sessionId);
         if (!set) {
             set = new Set<string>();
-            this.store.set(key, set);
+            this.store.set(sessionId, set);
         }
         return set;
     }
 
-    async allowTool(toolName: string, sessionId?: string): Promise<void> {
+    async allowTool(toolName: string, sessionId: string): Promise<void> {
         this.getSet(sessionId).add(toolName);
     }
 
-    async disallowTool(toolName: string, sessionId?: string): Promise<void> {
+    async disallowTool(toolName: string, sessionId: string): Promise<void> {
         this.getSet(sessionId).delete(toolName);
     }
 
-    async isToolAllowed(toolName: string, sessionId?: string): Promise<boolean> {
-        const scopedSet = this.store.get(sessionId ?? undefined);
-        const globalSet = this.store.get(undefined);
-        return Boolean(scopedSet?.has(toolName) || globalSet?.has(toolName));
+    async isToolAllowed(toolName: string, sessionId: string): Promise<boolean> {
+        return Boolean(this.store.get(sessionId)?.has(toolName));
     }
 
-    async getAllowedTools(sessionId?: string): Promise<Set<string>> {
+    async getAllowedTools(sessionId: string): Promise<Set<string>> {
         return new Set(this.getSet(sessionId));
     }
 }

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/in-memory.ts
@@ -4,14 +4,17 @@ import { ToolError } from '../../errors.js';
 export class InMemoryAllowedToolsProvider implements AllowedToolsProvider {
     private store: Map<string, Set<string>> = new Map();
 
-    private getSet(sessionId: string | undefined): Set<string> {
+    private requireSessionId(sessionId: string | undefined): string {
         if (typeof sessionId !== 'string' || sessionId.length === 0) {
             throw ToolError.validationFailed(
                 'tool_approval_memory',
                 'sessionId is required for remembered tool approvals'
             );
         }
+        return sessionId;
+    }
 
+    private getSet(sessionId: string): Set<string> {
         let set = this.store.get(sessionId);
         if (!set) {
             set = new Set<string>();
@@ -21,18 +24,20 @@ export class InMemoryAllowedToolsProvider implements AllowedToolsProvider {
     }
 
     async allowTool(toolName: string, sessionId: string): Promise<void> {
-        this.getSet(sessionId).add(toolName);
+        this.getSet(this.requireSessionId(sessionId)).add(toolName);
     }
 
     async disallowTool(toolName: string, sessionId: string): Promise<void> {
-        this.getSet(sessionId).delete(toolName);
+        this.getSet(this.requireSessionId(sessionId)).delete(toolName);
     }
 
     async isToolAllowed(toolName: string, sessionId: string): Promise<boolean> {
-        return Boolean(this.store.get(sessionId)?.has(toolName));
+        const bucket = this.store.get(this.requireSessionId(sessionId));
+        return Boolean(bucket?.has(toolName));
     }
 
     async getAllowedTools(sessionId: string): Promise<Set<string>> {
-        return new Set(this.getSet(sessionId));
+        const bucket = this.store.get(this.requireSessionId(sessionId));
+        return new Set(bucket ?? []);
     }
 }

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/storage.test.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/storage.test.ts
@@ -81,17 +81,17 @@ describe('StorageAllowedToolsProvider', () => {
             const result = await provider.isToolAllowed('globalTool', 'session123');
 
             expect(result).toBe(false);
+            expect(mockDatabase.get).toHaveBeenCalledTimes(1);
             expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:session123');
         });
 
-        it('should return false when tool not found in session or global', async () => {
-            mockDatabase.get
-                .mockResolvedValueOnce([]) // session-scoped (empty)
-                .mockResolvedValueOnce([]); // global (empty)
+        it('should return false when tool not found in session approvals', async () => {
+            mockDatabase.get.mockResolvedValueOnce([]); // session-scoped (empty)
 
             const result = await provider.isToolAllowed('unknownTool', 'session123');
 
             expect(result).toBe(false);
+            expect(mockDatabase.get).toHaveBeenCalledTimes(1);
         });
 
         it('should reject missing sessionId when checking approvals', async () => {

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/storage.test.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/storage.test.ts
@@ -35,12 +35,12 @@ describe('StorageAllowedToolsProvider', () => {
             expect(mockDatabase.set).toHaveBeenCalledWith('allowedTools:session123', ['testTool']);
         });
 
-        it('should store global tool approval when no sessionId provided', async () => {
-            mockDatabase.get.mockResolvedValue([]);
-
-            await provider.allowTool('testTool');
-
-            expect(mockDatabase.set).toHaveBeenCalledWith('allowedTools:global', ['testTool']);
+        it('should reject missing sessionId when storing approvals', async () => {
+            await expect(
+                (provider as unknown as { allowTool(toolName: string): Promise<void> }).allowTool(
+                    'testTool'
+                )
+            ).rejects.toThrow('sessionId is required');
         });
 
         it('should append to existing session-scoped approvals', async () => {
@@ -75,16 +75,13 @@ describe('StorageAllowedToolsProvider', () => {
             expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:session123');
         });
 
-        it('should fallback to global approvals when not found in session', async () => {
-            mockDatabase.get
-                .mockResolvedValueOnce([]) // session-scoped (empty)
-                .mockResolvedValueOnce(['globalTool']); // global
+        it('should not use approvals from other sessions', async () => {
+            mockDatabase.get.mockResolvedValueOnce([]);
 
             const result = await provider.isToolAllowed('globalTool', 'session123');
 
-            expect(result).toBe(true);
+            expect(result).toBe(false);
             expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:session123');
-            expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:global');
         });
 
         it('should return false when tool not found in session or global', async () => {
@@ -97,13 +94,12 @@ describe('StorageAllowedToolsProvider', () => {
             expect(result).toBe(false);
         });
 
-        it('should only check global when no sessionId provided', async () => {
-            mockDatabase.get.mockResolvedValueOnce(['globalTool']);
-
-            const result = await provider.isToolAllowed('globalTool');
-
-            expect(result).toBe(true);
-            expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:global');
+        it('should reject missing sessionId when checking approvals', async () => {
+            await expect(
+                (
+                    provider as unknown as { isToolAllowed(toolName: string): Promise<boolean> }
+                ).isToolAllowed('globalTool')
+            ).rejects.toThrow('sessionId is required');
         });
     });
 
@@ -119,12 +115,14 @@ describe('StorageAllowedToolsProvider', () => {
             ]);
         });
 
-        it('should handle removal from global approvals', async () => {
-            mockDatabase.get.mockResolvedValue(['tool1', 'tool2']);
-
-            await provider.disallowTool('tool1');
-
-            expect(mockDatabase.set).toHaveBeenCalledWith('allowedTools:global', ['tool2']);
+        it('should reject missing sessionId when removing approvals', async () => {
+            await expect(
+                (
+                    provider as unknown as {
+                        disallowTool(toolName: string): Promise<void>;
+                    }
+                ).disallowTool('tool1')
+            ).rejects.toThrow('sessionId is required');
         });
 
         it('should handle removal of non-existent tool gracefully', async () => {
@@ -154,13 +152,12 @@ describe('StorageAllowedToolsProvider', () => {
             expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:session123');
         });
 
-        it('should return global tools when no sessionId provided', async () => {
-            mockDatabase.get.mockResolvedValue(['globalTool']);
-
-            const result = await provider.getAllowedTools();
-
-            expect(result).toEqual(new Set(['globalTool']));
-            expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:global');
+        it('should reject missing sessionId when listing approvals', async () => {
+            await expect(
+                (
+                    provider as unknown as { getAllowedTools(): Promise<Set<string>> }
+                ).getAllowedTools()
+            ).rejects.toThrow('sessionId is required');
         });
 
         it('should return empty Set when no tools stored', async () => {
@@ -202,13 +199,12 @@ describe('StorageAllowedToolsProvider', () => {
             ]);
         });
 
-        it('should use correct key format for global storage', async () => {
-            mockDatabase.get.mockResolvedValue([]);
-
-            await provider.allowTool('testTool');
-
-            expect(mockDatabase.get).toHaveBeenCalledWith('allowedTools:global');
-            expect(mockDatabase.set).toHaveBeenCalledWith('allowedTools:global', ['testTool']);
+        it('should reject missing sessionId before building a storage key', async () => {
+            await expect(
+                (provider as unknown as { allowTool(toolName: string): Promise<void> }).allowTool(
+                    'testTool'
+                )
+            ).rejects.toThrow('sessionId is required');
         });
     });
 });

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/storage.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/storage.ts
@@ -1,12 +1,12 @@
 import type { StorageManager } from '../../../storage/index.js';
 import type { AllowedToolsProvider } from './types.js';
 import type { Logger } from '../../../logger/v2/types.js';
+import { ToolError } from '../../errors.js';
 
 /**
  * Storage-backed implementation that persists allowed tools in the Dexto
  * storage manager. The key scheme is:
  *   allowedTools:<sessionId>          – approvals scoped to a session
- *   allowedTools:global               – global approvals (sessionId undefined)
  *
  * Using the database backend for persistence.
  */
@@ -20,11 +20,18 @@ export class StorageAllowedToolsProvider implements AllowedToolsProvider {
         this.logger = logger;
     }
 
-    private buildKey(sessionId?: string) {
-        return sessionId ? `allowedTools:${sessionId}` : 'allowedTools:global';
+    private buildKey(sessionId: string | undefined) {
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+            throw ToolError.validationFailed(
+                'tool_approval_memory',
+                'sessionId is required for remembered tool approvals'
+            );
+        }
+
+        return `allowedTools:${sessionId}`;
     }
 
-    async allowTool(toolName: string, sessionId?: string): Promise<void> {
+    async allowTool(toolName: string, sessionId: string): Promise<void> {
         const key = this.buildKey(sessionId);
         this.logger.debug(`Adding allowed tool '${toolName}' for key '${key}'`);
 
@@ -38,7 +45,7 @@ export class StorageAllowedToolsProvider implements AllowedToolsProvider {
         this.logger.debug(`Added allowed tool '${toolName}' for key '${key}'`);
     }
 
-    async disallowTool(toolName: string, sessionId?: string): Promise<void> {
+    async disallowTool(toolName: string, sessionId: string): Promise<void> {
         const key = this.buildKey(sessionId);
         this.logger.debug(`Removing allowed tool '${toolName}' for key '${key}'`);
 
@@ -50,24 +57,18 @@ export class StorageAllowedToolsProvider implements AllowedToolsProvider {
         await this.storageManager.getDatabase().set(key, Array.from(newSet));
     }
 
-    async isToolAllowed(toolName: string, sessionId?: string): Promise<boolean> {
+    async isToolAllowed(toolName: string, sessionId: string): Promise<boolean> {
         const sessionArr = await this.storageManager
             .getDatabase()
             .get<string[]>(this.buildKey(sessionId));
-        if (Array.isArray(sessionArr) && sessionArr.includes(toolName)) return true;
-
-        // Fallback to global approvals
-        const globalArr = await this.storageManager
-            .getDatabase()
-            .get<string[]>(this.buildKey(undefined));
-        const allowed = Array.isArray(globalArr) ? globalArr.includes(toolName) : false;
+        const allowed = Array.isArray(sessionArr) ? sessionArr.includes(toolName) : false;
         this.logger.debug(
-            `Checked allowed tool '${toolName}' in session '${sessionId ?? 'global'}' – allowed=${allowed}`
+            `Checked allowed tool '${toolName}' in session '${sessionId}' – allowed=${allowed}`
         );
         return allowed;
     }
 
-    async getAllowedTools(sessionId?: string): Promise<Set<string>> {
+    async getAllowedTools(sessionId: string): Promise<Set<string>> {
         const arr = await this.storageManager.getDatabase().get<string[]>(this.buildKey(sessionId));
         return new Set<string>(Array.isArray(arr) ? arr : []);
     }

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/types.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/types.ts
@@ -1,19 +1,9 @@
 /**
- * Interface for allowed tools storage (in-memory, DB, etc.)
+ * Interface for session-scoped allowed tool storage (in-memory, DB, etc.).
  *
- * Multi-user support: For multi-tenancy, we can consider either:
- *  - Instantiating a provider per user (current pattern, recommended for most cases)
- *  - Or, add userId as a parameter to each method for batch/admin/multi-user operations:
- *      allowTool(toolName: string, userId: string): Promise<void>
- *      ...etc.
- *  - You can also add static/factory methods to create user-scoped providers, e.g.,
- *      AllowedToolsProvider.forUser(userId)
- *
- * AllowedToolsProvider supports both single-user and multi-user scenarios.
- * - If `userId` is omitted, the implementation will use a configured default user id.
- * - For multi-user/admin scenarios, always pass `userId` explicitly.
- * - We can enforce this by having a separate env variable/feature-flag for multi-user and having
- *   strict check for the user id if the feature flag is set.
+ * Implementations persist and query remembered tool approvals by `sessionId`.
+ * Every method requires an explicit non-empty session ID so approvals cannot
+ * leak across sessions.
  */
 export type AllowedToolsProvider = {
     /**

--- a/packages/core/src/tools/confirmation/allowed-tools-provider/types.ts
+++ b/packages/core/src/tools/confirmation/allowed-tools-provider/types.ts
@@ -17,20 +17,18 @@
  */
 export type AllowedToolsProvider = {
     /**
-     * Persist an approval for a tool. If `sessionId` is provided the approval is
-     * scoped to that session. When omitted the approval is treated as global.
+     * Persist an approval for a tool within a session.
      */
-    allowTool(toolName: string, sessionId?: string): Promise<void>;
+    allowTool(toolName: string, sessionId: string): Promise<void>;
 
     /** Remove an approval. */
-    disallowTool(toolName: string, sessionId?: string): Promise<void>;
+    disallowTool(toolName: string, sessionId: string): Promise<void>;
 
     /**
-     * Check whether the given tool is currently allowed. If `sessionId` is
-     * provided the session-scoped list is checked first, then any global entry.
+     * Check whether the given tool is currently allowed within the session.
      */
-    isToolAllowed(toolName: string, sessionId?: string): Promise<boolean>;
+    isToolAllowed(toolName: string, sessionId: string): Promise<boolean>;
 
     /** Optional helper to introspect all approvals for debugging. */
-    getAllowedTools?(sessionId?: string): Promise<Set<string>>;
+    getAllowedTools?(sessionId: string): Promise<Set<string>>;
 };

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -650,6 +650,96 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             );
         });
 
+        it('should reject empty custom approval session overrides', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
+
+            const tool = defineTool({
+                id: 'custom_session_override',
+                description: 'Custom approval tool',
+                inputSchema: z
+                    .object({
+                        value: z.string(),
+                    })
+                    .strict(),
+                approval: {
+                    override: vi.fn().mockResolvedValue({
+                        type: ApprovalType.CUSTOM,
+                        metadata: { prompt: 'Proceed?' },
+                        sessionId: '',
+                    }),
+                },
+                execute: vi.fn().mockResolvedValue('ok'),
+            });
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                mockAgentEventBus,
+                { alwaysAllow: [], alwaysDeny: [] },
+                [tool],
+                mockLogger
+            );
+            toolManager.setToolExecutionContextFactory((baseContext) => baseContext);
+
+            await expect(
+                toolManager.executeTool(
+                    'custom_session_override',
+                    { value: 'x' },
+                    'call-1',
+                    'session-1'
+                )
+            ).rejects.toThrow('sessionId is required for tool approval flows');
+            expect(mockApprovalManager.requestApproval).not.toHaveBeenCalled();
+        });
+
+        it('should reject mismatched custom approval session overrides', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
+
+            const tool = defineTool({
+                id: 'custom_session_mismatch',
+                description: 'Custom approval tool',
+                inputSchema: z
+                    .object({
+                        value: z.string(),
+                    })
+                    .strict(),
+                approval: {
+                    override: vi.fn().mockResolvedValue({
+                        type: ApprovalType.CUSTOM,
+                        metadata: { prompt: 'Proceed?' },
+                        sessionId: 'session-2',
+                    }),
+                },
+                execute: vi.fn().mockResolvedValue('ok'),
+            });
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                mockAgentEventBus,
+                { alwaysAllow: [], alwaysDeny: [] },
+                [tool],
+                mockLogger
+            );
+            toolManager.setToolExecutionContextFactory((baseContext) => baseContext);
+
+            await expect(
+                toolManager.executeTool(
+                    'custom_session_mismatch',
+                    { value: 'x' },
+                    'call-1',
+                    'session-1'
+                )
+            ).rejects.toThrow(
+                'custom approval sessionId must match the active tool execution session'
+            );
+            expect(mockApprovalManager.requestApproval).not.toHaveBeenCalled();
+        });
+
         it('should include directory access metadata in tool approval and remember directory when approved', async () => {
             mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
 

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -65,6 +65,7 @@ vi.mock('../logger/index.js', () => ({
 }));
 
 describe('ToolManager - Unit Tests (Pure Logic)', () => {
+    const approvalSessionId = 'approval-session';
     let mockMcpManager: MCPManager;
     let mockApprovalManager: ApprovalManager;
     let mockAllowedToolsProvider: AllowedToolsProvider;
@@ -1130,7 +1131,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             }
         });
 
-        it('should request approval without sessionId when not provided', async () => {
+        it('should reject manual approval when sessionId is not provided', async () => {
             mockMcpManager.executeTool = vi.fn().mockResolvedValue('result');
 
             const toolManager = createToolManager(
@@ -1144,16 +1145,10 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 mockLogger
             );
 
-            await toolManager.executeTool('mcp--file_read', { path: '/test' }, 'call-456');
-
-            expect(mockApprovalManager.requestToolApproval).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    toolName: 'mcp--file_read',
-                    toolCallId: 'call-456',
-                    args: { path: '/test' },
-                    presentationSnapshot: expect.objectContaining({ version: 1 }),
-                })
-            );
+            await expect(
+                toolManager.executeTool('mcp--file_read', { path: '/test' }, 'call-456')
+            ).rejects.toThrow('sessionId is required for tool approvals');
+            expect(mockApprovalManager.requestToolApproval).not.toHaveBeenCalled();
         });
 
         it('should throw execution denied error when approval denied', async () => {
@@ -1201,13 +1196,14 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             const result = await toolManager.executeTool(
                 'mcp--file_read',
                 { path: '/test' },
-                'test-call-id'
+                'test-call-id',
+                approvalSessionId
             );
 
             expect(mockMcpManager.executeTool).toHaveBeenCalledWith(
                 'file_read',
                 { path: '/test' },
-                undefined
+                approvalSessionId
             );
             expect(result).toEqual(
                 expect.objectContaining({
@@ -1236,12 +1232,13 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             const result = await toolManager.executeTool(
                 'mcp--file_read',
                 { path: '/test' },
-                'test-call-id'
+                'test-call-id',
+                approvalSessionId
             );
 
             expect(mockAllowedToolsProvider.isToolAllowed).toHaveBeenCalledWith(
                 'mcp--file_read',
-                undefined
+                approvalSessionId
             );
             expect(mockApprovalManager.requestToolApproval).not.toHaveBeenCalled();
             expect(result).toEqual(expect.objectContaining({ result: 'success' }));
@@ -1674,7 +1671,12 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             );
 
             await expect(
-                toolManager.executeTool('mcp--file_read', { path: '/test' }, 'test-call-id')
+                toolManager.executeTool(
+                    'mcp--file_read',
+                    { path: '/test' },
+                    'test-call-id',
+                    approvalSessionId
+                )
             ).rejects.toThrow('Tool execution failed');
         });
 
@@ -1694,7 +1696,12 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             );
 
             await expect(
-                toolManager.executeTool('mcp--file_read', { path: '/test' }, 'test-call-id')
+                toolManager.executeTool(
+                    'mcp--file_read',
+                    { path: '/test' },
+                    'test-call-id',
+                    approvalSessionId
+                )
             ).rejects.toThrow('Approval request failed');
         });
     });
@@ -1785,7 +1792,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(expect.objectContaining({ result: 'success' }));
@@ -1795,7 +1803,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                     {
                         path: '/test',
                     },
-                    undefined
+                    approvalSessionId
                 );
             });
 
@@ -1821,13 +1829,14 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(expect.objectContaining({ result: 'success' }));
                 expect(mockAllowedToolsProvider.isToolAllowed).toHaveBeenCalledWith(
                     'mcp--filesystem--read_file',
-                    undefined
+                    approvalSessionId
                 );
                 expect(mockApprovalManager.requestToolApproval).not.toHaveBeenCalled();
             });
@@ -1858,7 +1867,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(
@@ -1921,7 +1931,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(expect.objectContaining({ result: 'success' }));
@@ -1950,7 +1961,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(expect.objectContaining({ result: 'success' }));
@@ -2008,7 +2020,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(
@@ -2047,7 +2060,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--filesystem--read_file',
                     { path: '/test' },
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(
@@ -2242,7 +2256,8 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 const result = await toolManager.executeTool(
                     'mcp--read_file_metadata',
                     {},
-                    'test-call-id'
+                    'test-call-id',
+                    approvalSessionId
                 );
 
                 expect(result).toEqual(
@@ -2807,7 +2822,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 expect(mockApprovalManager.requestToolApproval).toHaveBeenCalled();
             });
 
-            it('should not auto-approve when no sessionId provided', async () => {
+            it('should reject manual approval when no sessionId is provided', async () => {
                 (mockMcpManager.getAllTools as ReturnType<typeof vi.fn>).mockResolvedValue({
                     test_tool: {
                         name: 'test_tool',
@@ -2833,10 +2848,10 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 toolManager.setSessionAutoApproveTools('session-1', ['mcp--test_tool']);
 
                 // Execute without sessionId
-                await toolManager.executeTool('mcp--test_tool', {}, 'call-1');
-
-                // Should have requested approval (no sessionId means no session auto-approve)
-                expect(mockApprovalManager.requestToolApproval).toHaveBeenCalled();
+                await expect(
+                    toolManager.executeTool('mcp--test_tool', {}, 'call-1')
+                ).rejects.toThrow('sessionId is required for tool approvals');
+                expect(mockApprovalManager.requestToolApproval).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -147,6 +147,32 @@ export class ToolManager {
         return this.resolveLocalToolIdOrAlias(pattern) ?? pattern;
     }
 
+    private requireApprovalSessionId(
+        toolName: string,
+        sessionId: string | undefined,
+        reason: string
+    ): string {
+        if (typeof sessionId === 'string' && sessionId.length > 0) {
+            return sessionId;
+        }
+
+        throw ToolError.validationFailed(toolName, reason);
+    }
+
+    private assertExecutableToolName(toolName: string): void {
+        if (toolName.startsWith(ToolManager.MCP_TOOL_PREFIX)) {
+            const actualToolName = toolName.substring(ToolManager.MCP_TOOL_PREFIX.length);
+            if (actualToolName.length === 0) {
+                throw ToolError.invalidName(toolName, 'tool name cannot be empty after prefix');
+            }
+            return;
+        }
+
+        if (!this.agentTools.has(toolName)) {
+            throw ToolError.notFound(toolName);
+        }
+    }
+
     constructor(
         mcpManager: MCPManager,
         approvalManager: ApprovalManager,
@@ -1056,7 +1082,7 @@ export class ToolManager {
      * @param toolName The tool name that was just remembered
      * @param sessionId The session ID for which the tool was allowed
      */
-    private autoApprovePendingToolRequests(toolName: string, sessionId?: string): void {
+    private autoApprovePendingToolRequests(toolName: string, sessionId: string): void {
         const count = this.approvalManager.autoApprovePendingRequests(
             (request: ApprovalRequest) => {
                 // Only match tool approval requests
@@ -1092,7 +1118,7 @@ export class ToolManager {
      * Auto-approve pending tool approval requests that are now covered by a remembered pattern.
      * Called after a user selects "remember pattern" for a tool.
      */
-    private autoApprovePendingPatternRequests(toolName: string, sessionId?: string): void {
+    private autoApprovePendingPatternRequests(toolName: string, sessionId: string): void {
         if (toolName.startsWith(ToolManager.MCP_TOOL_PREFIX)) {
             return;
         }
@@ -1160,7 +1186,7 @@ export class ToolManager {
      * Auto-approve pending tool approval requests that are now covered by a remembered directory.
      * Called after a user selects "remember directory" for a directory-access prompt.
      */
-    private autoApprovePendingDirectoryRequests(toolName: string, sessionId?: string): void {
+    private autoApprovePendingDirectoryRequests(toolName: string, sessionId: string): void {
         const count = this.approvalManager.autoApprovePendingRequests(
             (request: ApprovalRequest) => {
                 if (request.type !== ApprovalType.TOOL_APPROVAL) {
@@ -1491,6 +1517,8 @@ export class ToolManager {
 
         this.logger.debug(`🔧 Tool execution requested: '${toolName}' (toolCallId: ${toolCallId})`);
         this.logger.debug(`Tool args: ${JSON.stringify(toolArgs, null, 2)}`);
+
+        this.assertExecutableToolName(toolName);
 
         // IMPORTANT: Emit llm:tool-call FIRST, before approval handling.
         // This ensures correct event ordering - llm:tool-call must arrive before approval:request
@@ -1964,9 +1992,16 @@ export class ToolManager {
                             `Tool '${toolName}' requested custom approval: type=${approvalRequest.type}`
                         );
 
-                        // Add sessionId to the approval request if not already present
-                        if (sessionId && !approvalRequest.sessionId) {
-                            approvalRequest.sessionId = sessionId;
+                        const approvalSessionId =
+                            approvalRequest.sessionId ??
+                            this.requireApprovalSessionId(
+                                toolName,
+                                sessionId,
+                                'sessionId is required for tool approval flows'
+                            );
+
+                        if (approvalRequest.sessionId !== approvalSessionId) {
+                            approvalRequest.sessionId = approvalSessionId;
                         }
 
                         const response =
@@ -1981,7 +2016,7 @@ export class ToolManager {
                             }
 
                             this.logger.info(
-                                `Custom approval granted for '${toolName}', type=${approvalRequest.type}, session=${sessionId ?? 'global'}`
+                                `Custom approval granted for '${toolName}', type=${approvalRequest.type}, session=${approvalSessionId}`
                             );
                             return {
                                 requireApproval: true,
@@ -2049,12 +2084,20 @@ export class ToolManager {
         // This bypasses remembered-tool approvals and edit-mode auto-approvals for outside-root paths.
         if (directoryAccess) {
             if (this.approvalMode === 'auto-approve') {
+                const approvalSessionId = this.requireApprovalSessionId(
+                    toolName,
+                    sessionId,
+                    'sessionId is required for directory approval flows'
+                );
                 await this.approvalManager.addApprovedDirectory(
                     directoryAccess.parentDir,
                     'once',
-                    sessionId
+                    approvalSessionId
                 );
                 return { requireApproval: false };
+            }
+            if (this.approvalMode === 'auto-deny') {
+                throw ToolError.executionDenied(toolName, sessionId);
             }
             return null;
         }
@@ -2070,22 +2113,29 @@ export class ToolManager {
         // 4. Check static alwaysAllow list
         if (this.isInAlwaysAllowList(toolName)) {
             this.logger.info(
-                `Tool '${toolName}' is in static allow list – skipping confirmation (session: ${sessionId ?? 'global'})`
+                `Tool '${toolName}' is in static allow list – skipping confirmation (session: ${sessionId ?? 'none'})`
             );
             return { requireApproval: false };
         }
 
         // 5. Check dynamic "remembered" allowed list
-        if (await this.allowedToolsProvider.isToolAllowed(toolName, sessionId)) {
+        if (
+            sessionId !== undefined &&
+            (await this.allowedToolsProvider.isToolAllowed(toolName, sessionId))
+        ) {
             this.logger.info(
-                `Tool '${toolName}' already allowed for session '${sessionId ?? 'global'}' – skipping confirmation.`
+                `Tool '${toolName}' already allowed for session '${sessionId}' – skipping confirmation.`
             );
             return { requireApproval: false };
         }
 
         // 6. Check tool approval patterns
         const patternKey = this.getToolPatternKey(toolName, args);
-        if (patternKey && this.approvalManager.matchesPattern(toolName, patternKey, sessionId)) {
+        if (
+            sessionId !== undefined &&
+            patternKey &&
+            this.approvalManager.matchesPattern(toolName, patternKey, sessionId)
+        ) {
             this.logger.info(
                 `Tool '${toolName}' matched approved pattern key '${patternKey}' – skipping confirmation.`
             );
@@ -2121,8 +2171,13 @@ export class ToolManager {
         callDescription?: string,
         presentationSnapshot?: ToolPresentationSnapshotV1
     ): Promise<{ requireApproval: boolean; approvalStatus: 'approved' | 'rejected' }> {
+        const approvalSessionId = this.requireApprovalSessionId(
+            toolName,
+            sessionId,
+            'sessionId is required for tool approvals'
+        );
         this.logger.info(
-            `Tool approval requested for ${toolName}, sessionId: ${sessionId ?? 'global'}`
+            `Tool approval requested for ${toolName}, sessionId: ${approvalSessionId}`
         );
 
         try {
@@ -2131,7 +2186,7 @@ export class ToolManager {
                 toolName,
                 args,
                 toolCallId,
-                sessionId
+                approvalSessionId
             );
 
             // Get suggested patterns if applicable
@@ -2144,7 +2199,7 @@ export class ToolManager {
                 toolCallId,
                 args,
                 ...(callDescription !== undefined && { description: callDescription }),
-                ...(sessionId !== undefined && { sessionId }),
+                sessionId: approvalSessionId,
                 ...(displayPreview !== undefined && { displayPreview }),
                 ...(directoryAccess !== undefined && { directoryAccess }),
                 ...(suggestedPatterns !== undefined && { suggestedPatterns }),
@@ -2157,7 +2212,10 @@ export class ToolManager {
             ) {
                 const onGranted = this.getToolApprovalOnGrantedFn(toolName);
                 if (onGranted) {
-                    const context = this.buildToolExecutionContext({ sessionId, toolCallId });
+                    const context = this.buildToolExecutionContext({
+                        sessionId: approvalSessionId,
+                        toolCallId,
+                    });
                     await Promise.resolve(
                         onGranted(response, context, directoryAccessApprovalRequest)
                     );
@@ -2166,16 +2224,16 @@ export class ToolManager {
 
             // Handle "remember" choices if approved
             if (response.status === ApprovalStatus.APPROVED && response.data) {
-                await this.handleRememberChoice(toolName, response, sessionId);
+                await this.handleRememberChoice(toolName, response, approvalSessionId);
             }
 
             // Process response
             if (response.status !== ApprovalStatus.APPROVED) {
-                this.handleApprovalDenied(toolName, response, sessionId);
+                this.handleApprovalDenied(toolName, response, approvalSessionId);
             }
 
             this.logger.info(
-                `Tool approval approved for ${toolName}, sessionId: ${sessionId ?? 'global'}`
+                `Tool approval approved for ${toolName}, sessionId: ${approvalSessionId}`
             );
             return { requireApproval: true, approvalStatus: 'approved' };
         } catch (error) {
@@ -2228,7 +2286,7 @@ export class ToolManager {
     private async handleRememberChoice(
         toolName: string,
         response: { status: ApprovalStatus; data?: unknown; sessionId?: string | undefined },
-        sessionId?: string
+        sessionId: string
     ): Promise<void> {
         const data = response.data as Record<string, unknown> | undefined;
         if (!data) return;
@@ -2238,19 +2296,17 @@ export class ToolManager {
         const rememberDirectory = data.rememberDirectory as boolean | undefined;
 
         if (rememberChoice) {
-            const allowSessionId = sessionId ?? response.sessionId;
-            await this.allowedToolsProvider.allowTool(toolName, allowSessionId);
+            await this.allowedToolsProvider.allowTool(toolName, sessionId);
             this.logger.info(
-                `Tool '${toolName}' added to allowed tools for session '${allowSessionId ?? 'global'}' (remember choice selected)`
+                `Tool '${toolName}' added to allowed tools for session '${sessionId}' (remember choice selected)`
             );
-            this.autoApprovePendingToolRequests(toolName, allowSessionId);
+            this.autoApprovePendingToolRequests(toolName, sessionId);
         } else if (rememberPattern && this.getToolApprovalPatternKeyFn(toolName)) {
             await this.approvalManager.addPattern(toolName, rememberPattern, sessionId);
             this.logger.info(`Pattern '${rememberPattern}' added for tool '${toolName}' approval`);
             this.autoApprovePendingPatternRequests(toolName, sessionId);
         } else if (rememberDirectory) {
-            const allowSessionId = sessionId ?? response.sessionId;
-            this.autoApprovePendingDirectoryRequests(toolName, allowSessionId);
+            this.autoApprovePendingDirectoryRequests(toolName, sessionId);
         }
     }
 

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -1561,11 +1561,10 @@ export class ToolManager {
             callDescription
         );
         toolArgs = validatedToolArgs;
+        const sessionLogContext = sessionId !== undefined ? { sessionId } : undefined;
 
         this.logger.debug(`✅ Tool execution approved: ${toolName}`);
-        this.logger.info(
-            `🔧 Tool execution started for ${toolName}, sessionId: ${sessionId ?? 'global'}`
-        );
+        this.logger.info(`🔧 Tool execution started for ${toolName}`, sessionLogContext);
 
         // Emit tool:running event - tool is now actually executing (after approval if needed)
         // Only emit when sessionId is provided (LLM flow) - direct API calls don't need UI updates
@@ -1720,7 +1719,8 @@ export class ToolManager {
             const duration = Date.now() - startTime;
             this.logger.debug(`🎯 Tool execution completed in ${duration}ms: '${toolName}'`);
             this.logger.info(
-                `✅ Tool execution completed successfully for ${toolName} in ${duration}ms, sessionId: ${sessionId ?? 'global'}`
+                `✅ Tool execution completed successfully for ${toolName} in ${duration}ms`,
+                sessionLogContext
             );
 
             // Execute afterToolResult hooks if available
@@ -1766,7 +1766,8 @@ export class ToolManager {
         } catch (error) {
             const duration = Date.now() - startTime;
             this.logger.error(
-                `❌ Tool execution failed for ${toolName} after ${duration}ms, sessionId: ${sessionId ?? 'global'}: ${error instanceof Error ? error.message : String(error)}`
+                `❌ Tool execution failed for ${toolName} after ${duration}ms: ${error instanceof Error ? error.message : String(error)}`,
+                sessionLogContext
             );
 
             // Execute afterToolResult hooks for error case if available
@@ -1944,7 +1945,8 @@ export class ToolManager {
         // 1. Check static alwaysDeny list (highest priority - security-first)
         if (this.isInAlwaysDenyList(toolName)) {
             this.logger.info(
-                `Tool '${toolName}' is in static deny list – blocking execution (session: ${sessionId ?? 'global'})`
+                `Tool '${toolName}' is in static deny list – blocking execution`,
+                sessionId !== undefined ? { sessionId } : undefined
             );
             throw ToolError.executionDenied(toolName, sessionId);
         }
@@ -2113,7 +2115,8 @@ export class ToolManager {
         // 4. Check static alwaysAllow list
         if (this.isInAlwaysAllowList(toolName)) {
             this.logger.info(
-                `Tool '${toolName}' is in static allow list – skipping confirmation (session: ${sessionId ?? 'none'})`
+                `Tool '${toolName}' is in static allow list – skipping confirmation`,
+                sessionId !== undefined ? { sessionId } : undefined
             );
             return { requireApproval: false };
         }
@@ -2328,14 +2331,16 @@ export class ToolManager {
             response.reason === DenialReason.TIMEOUT
         ) {
             this.logger.info(
-                `Tool confirmation timed out for ${toolName}, sessionId: ${sessionId ?? 'global'}`
+                `Tool confirmation timed out for ${toolName}`,
+                sessionId !== undefined ? { sessionId } : undefined
             );
             throw ToolError.executionTimeout(toolName, response.timeoutMs ?? 0, sessionId);
         }
 
-        this.logger.info(
-            `Tool confirmation denied for ${toolName}, sessionId: ${sessionId ?? 'global'}, reason: ${response.reason ?? 'unknown'}`
-        );
+        this.logger.info(`Tool confirmation denied for ${toolName}`, {
+            ...(sessionId !== undefined && { sessionId }),
+            ...(response.reason !== undefined && { reason: response.reason }),
+        });
         throw ToolError.executionDenied(toolName, sessionId, response.message);
     }
 

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -1995,12 +1995,24 @@ export class ToolManager {
                         );
 
                         const approvalSessionId =
-                            approvalRequest.sessionId ??
-                            this.requireApprovalSessionId(
+                            approvalRequest.sessionId !== undefined
+                                ? this.requireApprovalSessionId(
+                                      toolName,
+                                      approvalRequest.sessionId,
+                                      'sessionId is required for tool approval flows'
+                                  )
+                                : this.requireApprovalSessionId(
+                                      toolName,
+                                      sessionId,
+                                      'sessionId is required for tool approval flows'
+                                  );
+
+                        if (sessionId !== undefined && approvalSessionId !== sessionId) {
+                            throw ToolError.validationFailed(
                                 toolName,
-                                sessionId,
-                                'sessionId is required for tool approval flows'
+                                'custom approval sessionId must match the active tool execution session'
                             );
+                        }
 
                         if (approvalRequest.sessionId !== approvalSessionId) {
                             approvalRequest.sessionId = approvalSessionId;

--- a/packages/server/src/hono/routes/sessions.ts
+++ b/packages/server/src/hono/routes/sessions.ts
@@ -23,7 +23,12 @@ import type { SessionSseEventSubscriber } from '../../events/session-sse-subscri
 
 const CreateSessionSchema = z
     .object({
-        sessionId: z.string().optional().describe('A custom ID for the new session'),
+        sessionId: z
+            .string()
+            .optional()
+            .describe(
+                'Optional integration override. Standard clients should omit this and use the agent-generated session ID.'
+            ),
     })
     .describe('Request body for creating a new session');
 

--- a/packages/server/src/mcp/mcp-handler.ts
+++ b/packages/server/src/mcp/mcp-handler.ts
@@ -8,7 +8,6 @@ import type { AgentCard, Logger } from '@dexto/core';
 import { logger } from '@dexto/core';
 import { z } from 'zod';
 import type { DextoAgent } from '@dexto/core';
-import { randomUUID } from 'crypto';
 
 export type McpTransportType = 'stdio' | 'sse' | 'http';
 
@@ -60,7 +59,7 @@ export async function initializeMcpServer(
                 `MCP tool '${toolName}' received message: ${message.substring(0, 100)}${message.length > 100 ? '...' : ''}`
             );
             // Create ephemeral session for this MCP tool call (stateless MCP interactions)
-            const session = await agent.createSession(`mcp-${randomUUID()}`);
+            const session = await agent.createSession();
             try {
                 const text = await agent.run(message, undefined, undefined, session.id);
                 agent.logger.info(

--- a/packages/tools-filesystem/src/directory-approval.integration.test.ts
+++ b/packages/tools-filesystem/src/directory-approval.integration.test.ts
@@ -197,6 +197,19 @@ describe('Directory Approval Integration Tests', () => {
             });
         });
 
+        it('should reject empty session ids for directory access prompts', async () => {
+            const tool = createReadFileTool(getFileSystemService);
+            const overrideFn = tool.approval?.override;
+            expect(overrideFn).toBeDefined();
+
+            await expect(
+                overrideFn!(
+                    tool.inputSchema.parse({ file_path: '/external/project/file.ts' }),
+                    createToolContext(mockLogger, approvalManager, '')
+                )
+            ).rejects.toThrow('sessionId is required for directory approval flows');
+        });
+
         it('should return null when external path is session-approved', async () => {
             await approvalManager.addApprovedDirectory(
                 '/external/project',
@@ -562,6 +575,41 @@ describe('Directory Approval Integration Tests', () => {
             );
             expect(injectedService.setWorkingDirectory).not.toHaveBeenCalled();
             expect(injectedService.setDirectoryApprovalChecker).not.toHaveBeenCalled();
+        });
+
+        it('should reject empty session ids during directory approval checks at execution time', async () => {
+            const workspace = path.join(tempDir, 'workspace-empty-session');
+            const externalDir = path.join(tempDir, 'external-empty-session');
+            const externalFile = path.join(externalDir, 'outside.txt');
+
+            await fs.mkdir(workspace, { recursive: true });
+            await fs.mkdir(externalDir, { recursive: true });
+            await fs.writeFile(externalFile, 'outside content');
+
+            const tools = fileSystemToolsFactory.create({
+                type: 'filesystem-tools',
+                allowedPaths: [workspace],
+                blockedPaths: [],
+                blockedExtensions: [],
+                maxFileSize: 10 * 1024 * 1024,
+                workingDirectory: workspace,
+                enableBackups: false,
+                backupRetentionDays: 7,
+                enabledTools: ['read_file'],
+            });
+            const readTool = tools.find((tool) => tool.id === 'read_file');
+            expect(readTool).toBeDefined();
+
+            const isDirectoryApprovedSpy = vi.spyOn(approvalManager, 'isDirectoryApproved');
+
+            await expect(
+                readTool!.execute!(
+                    readTool!.inputSchema.parse({ file_path: externalFile }),
+                    createToolContext(mockLogger, approvalManager, '')
+                )
+            ).rejects.toThrow('sessionId is required for directory approval checks');
+
+            expect(isDirectoryApprovedSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/tools-filesystem/src/directory-approval.integration.test.ts
+++ b/packages/tools-filesystem/src/directory-approval.integration.test.ts
@@ -62,25 +62,25 @@ function createInMemorySessionApprovalStore(): SessionApprovalStore {
     >();
 
     return {
-        async load(sessionId?: string) {
+        async load(sessionId: string) {
             return structuredClone(
-                states.get(sessionId ?? '__global__') ?? {
+                states.get(sessionId) ?? {
                     toolPatterns: {},
                     approvedDirectories: [],
                 }
             );
         },
         async save(
-            sessionId: string | undefined,
+            sessionId: string,
             state: {
                 toolPatterns: Record<string, string[]>;
                 approvedDirectories: Array<{ path: string; type: 'session' | 'once' }>;
             }
         ) {
-            states.set(sessionId ?? '__global__', structuredClone(state));
+            states.set(sessionId, structuredClone(state));
         },
-        async delete(sessionId?: string) {
-            states.delete(sessionId ?? '__global__');
+        async delete(sessionId: string) {
+            states.delete(sessionId);
         },
     } as SessionApprovalStore;
 }
@@ -105,6 +105,7 @@ function createToolContext(
 }
 
 describe('Directory Approval Integration Tests', () => {
+    const defaultSessionId = 'session-1';
     let mockLogger: Logger;
     let tempDir: string;
     let fileSystemService: FileSystemService;
@@ -143,7 +144,7 @@ describe('Directory Approval Integration Tests', () => {
             createInMemorySessionApprovalStore()
         );
 
-        toolContext = createToolContext(mockLogger, approvalManager);
+        toolContext = createToolContext(mockLogger, approvalManager, defaultSessionId);
 
         vi.clearAllMocks();
     });
@@ -197,7 +198,11 @@ describe('Directory Approval Integration Tests', () => {
         });
 
         it('should return null when external path is session-approved', async () => {
-            await approvalManager.addApprovedDirectory('/external/project', 'session');
+            await approvalManager.addApprovedDirectory(
+                '/external/project',
+                'session',
+                defaultSessionId
+            );
 
             const tool = createReadFileTool(getFileSystemService);
             const overrideFn = tool.approval?.override;
@@ -212,7 +217,11 @@ describe('Directory Approval Integration Tests', () => {
         });
 
         it('should still return metadata when external path is once-approved (prompt again)', async () => {
-            await approvalManager.addApprovedDirectory('/external/project', 'once');
+            await approvalManager.addApprovedDirectory(
+                '/external/project',
+                'once',
+                defaultSessionId
+            );
 
             const tool = createReadFileTool(getFileSystemService);
             const overrideFn = tool.approval?.override;
@@ -325,7 +334,11 @@ describe('Directory Approval Integration Tests', () => {
             const tool = createReadFileTool(getFileSystemService);
             const overrideFn = tool.approval?.override;
             expect(overrideFn).toBeDefined();
-            await approvalManager.addApprovedDirectory('/external/project', 'session');
+            await approvalManager.addApprovedDirectory(
+                '/external/project',
+                'session',
+                defaultSessionId
+            );
 
             const metadata1 = await overrideFn!(
                 tool.inputSchema.parse({ file_path: '/external/project/file.ts' }),
@@ -344,7 +357,11 @@ describe('Directory Approval Integration Tests', () => {
             const tool = createReadFileTool(getFileSystemService);
             const overrideFn = tool.approval?.override;
             expect(overrideFn).toBeDefined();
-            await approvalManager.addApprovedDirectory('/external/sub', 'session');
+            await approvalManager.addApprovedDirectory(
+                '/external/sub',
+                'session',
+                defaultSessionId
+            );
 
             const metadata1 = await overrideFn!(
                 tool.inputSchema.parse({ file_path: '/external/sub/file.ts' }),

--- a/packages/tools-filesystem/src/directory-approval.ts
+++ b/packages/tools-filesystem/src/directory-approval.ts
@@ -12,6 +12,17 @@ type DirectoryApprovalPaths = {
     parentDir: string;
 };
 
+function requireApprovalSessionId(toolName: string, sessionId: string | undefined): string {
+    if (sessionId !== undefined) {
+        return sessionId;
+    }
+
+    throw ToolError.validationFailed(
+        toolName,
+        'sessionId is required for directory approval flows'
+    );
+}
+
 export function resolveFilePath(
     workingDirectory: string,
     filePath: string
@@ -63,7 +74,8 @@ export function createDirectoryAccessApprovalHandlers<const TSchema extends ZodT
                         `${options.toolName} requires ToolExecutionContext.services.approval`
                     );
                 }
-                if (approvalManager.isDirectorySessionApproved(paths.path, context.sessionId)) {
+                const sessionId = requireApprovalSessionId(options.toolName, context.sessionId);
+                if (approvalManager.isDirectorySessionApproved(paths.path, sessionId)) {
                     return null;
                 }
 
@@ -96,10 +108,11 @@ export function createDirectoryAccessApprovalHandlers<const TSchema extends ZodT
                     return;
                 }
 
+                const sessionId = requireApprovalSessionId(options.toolName, context.sessionId);
                 await approvalManager.addApprovedDirectory(
                     metadata.parentDir,
                     rememberDirectory ? 'session' : 'once',
-                    context.sessionId
+                    sessionId
                 );
             },
         },

--- a/packages/tools-filesystem/src/directory-approval.ts
+++ b/packages/tools-filesystem/src/directory-approval.ts
@@ -13,7 +13,7 @@ type DirectoryApprovalPaths = {
 };
 
 function requireApprovalSessionId(toolName: string, sessionId: string | undefined): string {
-    if (sessionId !== undefined) {
+    if (typeof sessionId === 'string' && sessionId.length > 0) {
         return sessionId;
     }
 

--- a/packages/tools-filesystem/src/tool-factory.ts
+++ b/packages/tools-filesystem/src/tool-factory.ts
@@ -19,7 +19,7 @@ import type { Tool } from '@dexto/core';
 type FileSystemToolName = (typeof FILESYSTEM_TOOL_NAMES)[number];
 
 function requireApprovalSessionId(context: ToolExecutionContext): string {
-    if (context.sessionId !== undefined) {
+    if (typeof context.sessionId === 'string' && context.sessionId.length > 0) {
         return context.sessionId;
     }
 

--- a/packages/tools-filesystem/src/tool-factory.ts
+++ b/packages/tools-filesystem/src/tool-factory.ts
@@ -18,6 +18,17 @@ import type { Tool } from '@dexto/core';
 
 type FileSystemToolName = (typeof FILESYSTEM_TOOL_NAMES)[number];
 
+function requireApprovalSessionId(context: ToolExecutionContext): string {
+    if (context.sessionId !== undefined) {
+        return context.sessionId;
+    }
+
+    throw ToolError.validationFailed(
+        'filesystem_tools',
+        'sessionId is required for directory approval checks'
+    );
+}
+
 export const fileSystemToolsFactory: ToolFactory<FileSystemToolsConfig> = {
     configSchema: FileSystemToolsConfigSchema,
     metadata: {
@@ -59,7 +70,7 @@ export const fileSystemToolsFactory: ToolFactory<FileSystemToolsConfig> = {
                 context.logger
             );
             service.setDirectoryApprovalChecker((filePath: string) =>
-                approvalManager.isDirectoryApproved(filePath, context.sessionId)
+                approvalManager.isDirectoryApproved(filePath, requireApprovalSessionId(context))
             );
             return service;
         };

--- a/packages/tools-todo/src/todo-write-tool.test.ts
+++ b/packages/tools-todo/src/todo-write-tool.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ToolErrorCode } from '@dexto/core';
+import type { Logger, ToolExecutionContext } from '@dexto/core';
+import type { TodoService } from './todo-service.js';
+import { createTodoWriteTool, type TodoServiceGetter } from './todo-write-tool.js';
+
+function createMockLogger(): Logger {
+    const logger: Logger = {
+        debug: vi.fn(),
+        silly: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        createChild: vi.fn(() => logger),
+        createFileOnlyChild: vi.fn(() => logger),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'debug' as const),
+        getLogFilePath: vi.fn(() => null),
+        destroy: vi.fn(async () => undefined),
+    };
+    return logger;
+}
+
+function createToolContext(
+    logger: Logger,
+    overrides: Partial<ToolExecutionContext> = {}
+): ToolExecutionContext {
+    return { logger, ...overrides };
+}
+
+describe('todo_write tool', () => {
+    it('throws validation error when sessionId is missing', async () => {
+        const logger = createMockLogger();
+        const getTodoService = vi.fn<TodoServiceGetter>(async () => {
+            throw new Error('todo service should not be requested without a session');
+        });
+        const tool = createTodoWriteTool(getTodoService);
+        const input = tool.inputSchema.parse({
+            todos: [{ content: 'Test task', activeForm: 'Testing task', status: 'pending' }],
+        });
+
+        await expect(tool.execute(input, createToolContext(logger))).rejects.toMatchObject({
+            name: 'DextoRuntimeError',
+            code: ToolErrorCode.VALIDATION_FAILED,
+        });
+        expect(getTodoService).not.toHaveBeenCalled();
+    });
+
+    it('updates todos for the current session', async () => {
+        const logger = createMockLogger();
+        const initialize = vi.fn().mockResolvedValue(undefined);
+        const updateTodos = vi.fn().mockResolvedValue({
+            todos: [
+                {
+                    id: 'todo-1',
+                    sessionId: 'session-123',
+                    content: 'Test task',
+                    activeForm: 'Testing task',
+                    status: 'in_progress',
+                    position: 0,
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                },
+            ],
+        });
+        const getTodoService = vi.fn<TodoServiceGetter>().mockResolvedValue({
+            initialize,
+            updateTodos,
+        } as unknown as TodoService);
+        const tool = createTodoWriteTool(getTodoService);
+        const input = tool.inputSchema.parse({
+            todos: [{ content: 'Test task', activeForm: 'Testing task', status: 'in_progress' }],
+        });
+
+        const result = await tool.execute(
+            input,
+            createToolContext(logger, { sessionId: 'session-123' })
+        );
+
+        expect(getTodoService).toHaveBeenCalledOnce();
+        expect(initialize).toHaveBeenCalledOnce();
+        expect(updateTodos).toHaveBeenCalledWith('session-123', input.todos);
+        expect(result).toBe('Updated todos: 0/1 completed, 1 in progress');
+    });
+});

--- a/packages/tools-todo/src/todo-write-tool.ts
+++ b/packages/tools-todo/src/todo-write-tool.ts
@@ -5,7 +5,7 @@
  */
 
 import { z } from 'zod';
-import { createLocalToolCallHeader, defineTool } from '@dexto/core';
+import { createLocalToolCallHeader, defineTool, ToolError } from '@dexto/core';
 import type { Tool, ToolExecutionContext } from '@dexto/core';
 import type { TodoService } from './todo-service.js';
 import { TODO_STATUS_VALUES } from './types.js';
@@ -87,14 +87,15 @@ IMPORTANT: This replaces the entire todo list. Always include ALL tasks (pending
         },
 
         async execute(input, context: ToolExecutionContext): Promise<unknown> {
-            const resolvedTodoService = await getTodoService(context);
+            if (!context.sessionId) {
+                throw ToolError.validationFailed('todo_write', 'sessionId is required');
+            }
 
-            // Use session_id from context, otherwise default
-            const sessionId = context.sessionId ?? 'default';
+            const resolvedTodoService = await getTodoService(context);
 
             // Update todos in todo service
             await resolvedTodoService.initialize();
-            const result = await resolvedTodoService.updateTodos(sessionId, input.todos);
+            const result = await resolvedTodoService.updateTodos(context.sessionId, input.todos);
 
             // Count by status for summary
             const completed = result.todos.filter((t) => t.status === 'completed').length;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
                 __dirname,
                 'packages/agent-management/src/index.ts'
             ),
+            '@dexto/core': path.resolve(__dirname, 'packages/core/src/index.ts'),
             '@dexto/storage/schemas': path.resolve(__dirname, 'packages/storage/src/schemas.ts'),
             '@dexto/storage': path.resolve(__dirname, 'packages/storage/src/index.ts'),
         },


### PR DESCRIPTION
## Summary
- remove hidden session fallbacks from normal chat flows, including `agent.stream()` auto-create behavior and the todo tool
- remove global approval and remembered-tool fallbacks, plus dead approval helper entry points
- clean up session-facing docs/examples and stop generating custom session IDs in CLI/MCP helper flows

## Notes
- keeps `createSession(sessionId?)` and the A2A `taskId === sessionId` coupling unchanged for now
- keeps direct sessionless `executeTool()` intact for explicit programmatic tool execution

## Testing
- `bash scripts/quality-checks.sh all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reformatted docs/READMEs and examples; examples now show creating sessions without custom IDs (use createSession() and pass returned session.id).

* **Breaking Changes**
  * Session creation flows: omit custom session IDs and use generated session IDs for subsequent calls.
  * Global approval fallbacks removed; approval and tool APIs now require an explicit session ID.

* **Behavioral Changes**
  * Streams and tool execution now validate and enforce session context at startup.

* **Tests**
  * Added/updated tests covering session validation, stream errors, and approval/session-scoped behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->