### PR TITLE
expand ignored dirs and dotfiles in filesystem scanner

### DIFF
--- a/.changeset/pretty-horses-know.md
+++ b/.changeset/pretty-horses-know.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Expand ignored directories and dotfiles in filesystem scanner

--- a/packages/core/src/resources/handlers/filesystem-handler.ts
+++ b/packages/core/src/resources/handlers/filesystem-handler.ts
@@ -332,11 +332,21 @@ export class FileSystemResourceHandler implements InternalResourceHandler {
             '.cache',
             '.vscode',
             '.idea',
-            '.changeset',
             '.github',
             '.husky',
+            '.agents',
+            '.claude',
+            '.cursor',
+            '.dexto',
+            '.conductor',
+            '.logs',
             'tmp',
             'temp',
+            '__pycache__',
+            '.pytest_cache',
+            'target',
+            'vendor',
+            'site',
         ];
         return ignoredDirectories.includes(basename);
     }
@@ -353,15 +363,24 @@ export class FileSystemResourceHandler implements InternalResourceHandler {
             if (!includeHidden) {
                 const allowedDotfiles = [
                     '.gitignore',
+                    '.gitattributes',
                     '.env',
                     '.env.example',
+                    '.env.local',
+                    '.env.development',
+                    '.env.production',
                     '.npmignore',
                     '.dockerignore',
                     '.editorconfig',
+                    '.prettierignore',
+                    '.eslintignore',
+                    '.nvmrc',
+                    '.node-version',
                 ];
                 if (!allowedDotfiles.includes(basename)) return false;
             }
             if (basename === '.env' || basename.startsWith('.env.')) return true;
+            if (basename === '.nvmrc' || basename === '.node-version') return true;
         }
 
         if (!ext) {


### PR DESCRIPTION
### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [ ] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Patch / Minor / Major (choose patch for all if unsure)
  - Packages: ...




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file discovery to include additional hidden config files (env variants, gitattributes, prettier/eslint ignores, Node version files).
  * Refined directory scanning to ignore more project/build and agent-related folders and removed an outdated exclusion.
* **Chores**
  * Added a patch release entry reflecting the scanner behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->