### PR TITLE
Migrate to Zod v4

### DIFF
--- a/.changeset/clean-lamps-exist.md
+++ b/.changeset/clean-lamps-exist.md
@@ -1,5 +1,5 @@
 ---
-'@dexto/core': patch
+'@dexto/core': minor
 ---
 
 Upgrade internal schemas and validation flows to Zod 4 across the stack.

--- a/.changeset/clean-lamps-exist.md
+++ b/.changeset/clean-lamps-exist.md
@@ -1,0 +1,8 @@
+---
+'@dexto/core': patch
+---
+
+Upgrade internal schemas and validation flows to Zod 4 across the stack.
+
+This preserves existing YAML parsing, env expansion, and default handling while
+moving package internals to the Zod 4 APIs.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -6837,138 +6837,2268 @@
                       "properties": {
                         "providers": {
                           "type": "object",
-                          "additionalProperties": {
-                            "type": "object",
-                            "properties": {
-                              "name": {
-                                "type": "string",
-                                "description": "Provider display name"
-                              },
-                              "hasApiKey": {
-                                "type": "boolean",
-                                "description": "Whether API key is configured"
-                              },
-                              "primaryEnvVar": {
-                                "type": "string",
-                                "description": "Primary environment variable for API key"
-                              },
-                              "supportsBaseURL": {
-                                "type": "boolean",
-                                "description": "Whether custom base URLs are supported"
-                              },
-                              "models": {
-                                "type": "array",
-                                "items": {
-                                  "type": "object",
-                                  "properties": {
-                                    "name": {
-                                      "type": "string",
-                                      "description": "Model name identifier"
-                                    },
-                                    "maxInputTokens": {
-                                      "type": "integer",
-                                      "minimum": 0,
-                                      "exclusiveMinimum": true,
-                                      "description": "Maximum input tokens"
-                                    },
-                                    "default": {
-                                      "type": "boolean",
-                                      "description": "Whether this is a default model"
-                                    },
-                                    "supportedFileTypes": {
-                                      "type": "array",
-                                      "items": {
-                                        "type": "string",
-                                        "enum": [
-                                          "pdf",
-                                          "image",
-                                          "audio",
-                                          "video",
-                                          "document"
-                                        ]
-                                      },
-                                      "description": "File types this model supports"
-                                    },
-                                    "displayName": {
-                                      "type": "string",
-                                      "description": "Human-readable display name"
-                                    },
-                                    "pricing": {
-                                      "type": "object",
-                                      "properties": {
-                                        "inputPerM": {
-                                          "type": "number",
-                                          "description": "Input cost per million tokens (USD)"
-                                        },
-                                        "outputPerM": {
-                                          "type": "number",
-                                          "description": "Output cost per million tokens (USD)"
-                                        },
-                                        "cacheReadPerM": {
-                                          "type": "number",
-                                          "description": "Cache read cost per million tokens"
-                                        },
-                                        "cacheWritePerM": {
-                                          "type": "number",
-                                          "description": "Cache write cost per million tokens"
-                                        },
-                                        "currency": {
-                                          "type": "string",
-                                          "enum": [
-                                            "USD"
-                                          ],
-                                          "description": "Currency"
-                                        },
-                                        "unit": {
-                                          "type": "string",
-                                          "enum": [
-                                            "per_million_tokens"
-                                          ],
-                                          "description": "Unit"
-                                        }
-                                      },
-                                      "required": [
-                                        "inputPerM",
-                                        "outputPerM"
-                                      ],
-                                      "description": "Pricing information in USD per million tokens"
-                                    }
-                                  },
-                                  "required": [
-                                    "name",
-                                    "maxInputTokens",
-                                    "supportedFileTypes"
-                                  ],
-                                  "additionalProperties": false,
-                                  "description": "Model information from LLM registry"
-                                },
-                                "description": "Models available from this provider"
-                              },
-                              "supportedFileTypes": {
-                                "type": "array",
-                                "items": {
+                          "properties": {
+                            "openai": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
                                   "type": "string",
-                                  "enum": [
-                                    "pdf",
-                                    "image",
-                                    "audio",
-                                    "video",
-                                    "document"
-                                  ]
+                                  "description": "Provider display name"
                                 },
-                                "description": "Provider-level file type support"
-                              }
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
                             },
-                            "required": [
-                              "name",
-                              "hasApiKey",
-                              "primaryEnvVar",
-                              "supportsBaseURL",
-                              "models",
-                              "supportedFileTypes"
-                            ],
-                            "additionalProperties": false,
-                            "description": "Provider catalog entry with models and capabilities"
+                            "openai-compatible": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "anthropic": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "google": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "groq": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "xai": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "cohere": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "minimax": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "glm": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "openrouter": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "litellm": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "glama": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "vertex": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "bedrock": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "local": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "ollama": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            },
+                            "dexto-nova": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "description": "Provider display name"
+                                },
+                                "hasApiKey": {
+                                  "type": "boolean",
+                                  "description": "Whether API key is configured"
+                                },
+                                "primaryEnvVar": {
+                                  "type": "string",
+                                  "description": "Primary environment variable for API key"
+                                },
+                                "supportsBaseURL": {
+                                  "type": "boolean",
+                                  "description": "Whether custom base URLs are supported"
+                                },
+                                "models": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "description": "Model name identifier"
+                                      },
+                                      "maxInputTokens": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "exclusiveMinimum": true,
+                                        "description": "Maximum input tokens"
+                                      },
+                                      "default": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a default model"
+                                      },
+                                      "supportedFileTypes": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string",
+                                          "enum": [
+                                            "pdf",
+                                            "image",
+                                            "audio",
+                                            "video",
+                                            "document"
+                                          ]
+                                        },
+                                        "description": "File types this model supports"
+                                      },
+                                      "displayName": {
+                                        "type": "string",
+                                        "description": "Human-readable display name"
+                                      },
+                                      "pricing": {
+                                        "type": "object",
+                                        "properties": {
+                                          "inputPerM": {
+                                            "type": "number",
+                                            "description": "Input cost per million tokens (USD)"
+                                          },
+                                          "outputPerM": {
+                                            "type": "number",
+                                            "description": "Output cost per million tokens (USD)"
+                                          },
+                                          "cacheReadPerM": {
+                                            "type": "number",
+                                            "description": "Cache read cost per million tokens"
+                                          },
+                                          "cacheWritePerM": {
+                                            "type": "number",
+                                            "description": "Cache write cost per million tokens"
+                                          },
+                                          "currency": {
+                                            "type": "string",
+                                            "enum": [
+                                              "USD"
+                                            ],
+                                            "description": "Currency"
+                                          },
+                                          "unit": {
+                                            "type": "string",
+                                            "enum": [
+                                              "per_million_tokens"
+                                            ],
+                                            "description": "Unit"
+                                          }
+                                        },
+                                        "required": [
+                                          "inputPerM",
+                                          "outputPerM"
+                                        ],
+                                        "description": "Pricing information in USD per million tokens"
+                                      }
+                                    },
+                                    "required": [
+                                      "name",
+                                      "maxInputTokens",
+                                      "supportedFileTypes"
+                                    ],
+                                    "additionalProperties": false,
+                                    "description": "Model information from LLM registry"
+                                  },
+                                  "description": "Models available from this provider"
+                                },
+                                "supportedFileTypes": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string",
+                                    "enum": [
+                                      "pdf",
+                                      "image",
+                                      "audio",
+                                      "video",
+                                      "document"
+                                    ]
+                                  },
+                                  "description": "Provider-level file type support"
+                                }
+                              },
+                              "required": [
+                                "name",
+                                "hasApiKey",
+                                "primaryEnvVar",
+                                "supportsBaseURL",
+                                "models",
+                                "supportedFileTypes"
+                              ],
+                              "additionalProperties": false,
+                              "description": "Provider catalog entry with models and capabilities"
+                            }
                           },
                           "description": "Providers grouped by ID with their models and capabilities"
                         }

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.6.25",
+    "version": "1.6.26",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [
@@ -208,7 +208,9 @@
                                   "description": "Text content"
                                 },
                                 "metadata": {
-                                  "$ref": "#/components/schemas/JsonObject"
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "description": "Extension metadata"
                                 }
                               },
                               "required": [
@@ -272,7 +274,9 @@
                                   "description": "File data (bytes or URI)"
                                 },
                                 "metadata": {
-                                  "$ref": "#/components/schemas/JsonObject"
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "description": "Extension metadata"
                                 }
                               },
                               "required": [
@@ -291,17 +295,12 @@
                                   "description": "Part type discriminator"
                                 },
                                 "data": {
-                                  "allOf": [
-                                    {
-                                      "$ref": "#/components/schemas/JsonObject"
-                                    },
-                                    {
-                                      "description": "Structured JSON data"
-                                    }
-                                  ]
+                                  "$ref": "#/components/schemas/JsonObject"
                                 },
                                 "metadata": {
-                                  "$ref": "#/components/schemas/JsonObject"
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "description": "Extension metadata"
                                 }
                               },
                               "required": [
@@ -327,7 +326,9 @@
                         "description": "Context identifier"
                       },
                       "metadata": {
-                        "$ref": "#/components/schemas/JsonObject"
+                        "type": "object",
+                        "additionalProperties": true,
+                        "description": "Extension metadata"
                       },
                       "extensions": {
                         "type": "array",
@@ -401,14 +402,9 @@
                     "description": "Optional configuration"
                   },
                   "metadata": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/JsonObject"
-                      },
-                      {
-                        "description": "Optional metadata"
-                      }
-                    ]
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional metadata"
                   }
                 },
                 "required": [
@@ -483,7 +479,9 @@
                                         "description": "Text content"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -547,7 +545,9 @@
                                         "description": "File data (bytes or URI)"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -566,17 +566,12 @@
                                         "description": "Part type discriminator"
                                       },
                                       "data": {
-                                        "allOf": [
-                                          {
-                                            "$ref": "#/components/schemas/JsonObject"
-                                          },
-                                          {
-                                            "description": "Structured JSON data"
-                                          }
-                                        ]
+                                        "$ref": "#/components/schemas/JsonObject"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -602,7 +597,9 @@
                               "description": "Context identifier"
                             },
                             "metadata": {
-                              "$ref": "#/components/schemas/JsonObject"
+                              "type": "object",
+                              "additionalProperties": true,
+                              "description": "Extension metadata"
                             },
                             "extensions": {
                               "type": "array",
@@ -676,7 +673,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -740,7 +739,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -759,17 +760,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -795,7 +791,9 @@
                             "description": "Context identifier"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -865,7 +863,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -929,7 +929,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -948,17 +950,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -972,7 +969,9 @@
                             "description": "Artifact content parts"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -991,7 +990,9 @@
                       "description": "Task artifacts"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/JsonObject"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Extension metadata"
                     },
                     "kind": {
                       "type": "string",
@@ -1074,7 +1075,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "$ref": "#/components/schemas/JsonValue"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -1120,14 +1123,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -1230,14 +1228,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -1283,14 +1276,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -1493,7 +1481,9 @@
                                               "description": "Text content"
                                             },
                                             "metadata": {
-                                              "$ref": "#/components/schemas/JsonObject"
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "description": "Extension metadata"
                                             }
                                           },
                                           "required": [
@@ -1557,7 +1547,9 @@
                                               "description": "File data (bytes or URI)"
                                             },
                                             "metadata": {
-                                              "$ref": "#/components/schemas/JsonObject"
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "description": "Extension metadata"
                                             }
                                           },
                                           "required": [
@@ -1576,17 +1568,12 @@
                                               "description": "Part type discriminator"
                                             },
                                             "data": {
-                                              "allOf": [
-                                                {
-                                                  "$ref": "#/components/schemas/JsonObject"
-                                                },
-                                                {
-                                                  "description": "Structured JSON data"
-                                                }
-                                              ]
+                                              "$ref": "#/components/schemas/JsonObject"
                                             },
                                             "metadata": {
-                                              "$ref": "#/components/schemas/JsonObject"
+                                              "type": "object",
+                                              "additionalProperties": true,
+                                              "description": "Extension metadata"
                                             }
                                           },
                                           "required": [
@@ -1612,7 +1599,9 @@
                                     "description": "Context identifier"
                                   },
                                   "metadata": {
-                                    "$ref": "#/components/schemas/JsonObject"
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Extension metadata"
                                   },
                                   "extensions": {
                                     "type": "array",
@@ -1686,7 +1675,9 @@
                                             "description": "Text content"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1750,7 +1741,9 @@
                                             "description": "File data (bytes or URI)"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1769,17 +1762,12 @@
                                             "description": "Part type discriminator"
                                           },
                                           "data": {
-                                            "allOf": [
-                                              {
-                                                "$ref": "#/components/schemas/JsonObject"
-                                              },
-                                              {
-                                                "description": "Structured JSON data"
-                                              }
-                                            ]
+                                            "$ref": "#/components/schemas/JsonObject"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1805,7 +1793,9 @@
                                   "description": "Context identifier"
                                 },
                                 "metadata": {
-                                  "$ref": "#/components/schemas/JsonObject"
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "description": "Extension metadata"
                                 },
                                 "extensions": {
                                   "type": "array",
@@ -1875,7 +1865,9 @@
                                             "description": "Text content"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1939,7 +1931,9 @@
                                             "description": "File data (bytes or URI)"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1958,17 +1952,12 @@
                                             "description": "Part type discriminator"
                                           },
                                           "data": {
-                                            "allOf": [
-                                              {
-                                                "$ref": "#/components/schemas/JsonObject"
-                                              },
-                                              {
-                                                "description": "Structured JSON data"
-                                              }
-                                            ]
+                                            "$ref": "#/components/schemas/JsonObject"
                                           },
                                           "metadata": {
-                                            "$ref": "#/components/schemas/JsonObject"
+                                            "type": "object",
+                                            "additionalProperties": true,
+                                            "description": "Extension metadata"
                                           }
                                         },
                                         "required": [
@@ -1982,7 +1971,9 @@
                                   "description": "Artifact content parts"
                                 },
                                 "metadata": {
-                                  "$ref": "#/components/schemas/JsonObject"
+                                  "type": "object",
+                                  "additionalProperties": true,
+                                  "description": "Extension metadata"
                                 },
                                 "extensions": {
                                   "type": "array",
@@ -2001,7 +1992,9 @@
                             "description": "Task artifacts"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "kind": {
                             "type": "string",
@@ -2107,14 +2100,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -2160,14 +2148,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -2270,14 +2253,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -2323,14 +2301,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -2457,7 +2430,9 @@
                                         "description": "Text content"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -2521,7 +2496,9 @@
                                         "description": "File data (bytes or URI)"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -2540,17 +2517,12 @@
                                         "description": "Part type discriminator"
                                       },
                                       "data": {
-                                        "allOf": [
-                                          {
-                                            "$ref": "#/components/schemas/JsonObject"
-                                          },
-                                          {
-                                            "description": "Structured JSON data"
-                                          }
-                                        ]
+                                        "$ref": "#/components/schemas/JsonObject"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -2576,7 +2548,9 @@
                               "description": "Context identifier"
                             },
                             "metadata": {
-                              "$ref": "#/components/schemas/JsonObject"
+                              "type": "object",
+                              "additionalProperties": true,
+                              "description": "Extension metadata"
                             },
                             "extensions": {
                               "type": "array",
@@ -2650,7 +2624,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2714,7 +2690,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2733,17 +2711,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2769,7 +2742,9 @@
                             "description": "Context identifier"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -2839,7 +2814,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2903,7 +2880,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2922,17 +2901,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -2946,7 +2920,9 @@
                             "description": "Artifact content parts"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -2965,7 +2941,9 @@
                       "description": "Task artifacts"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/JsonObject"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Extension metadata"
                     },
                     "kind": {
                       "type": "string",
@@ -3093,7 +3071,9 @@
                                         "description": "Text content"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -3157,7 +3137,9 @@
                                         "description": "File data (bytes or URI)"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -3176,17 +3158,12 @@
                                         "description": "Part type discriminator"
                                       },
                                       "data": {
-                                        "allOf": [
-                                          {
-                                            "$ref": "#/components/schemas/JsonObject"
-                                          },
-                                          {
-                                            "description": "Structured JSON data"
-                                          }
-                                        ]
+                                        "$ref": "#/components/schemas/JsonObject"
                                       },
                                       "metadata": {
-                                        "$ref": "#/components/schemas/JsonObject"
+                                        "type": "object",
+                                        "additionalProperties": true,
+                                        "description": "Extension metadata"
                                       }
                                     },
                                     "required": [
@@ -3212,7 +3189,9 @@
                               "description": "Context identifier"
                             },
                             "metadata": {
-                              "$ref": "#/components/schemas/JsonObject"
+                              "type": "object",
+                              "additionalProperties": true,
+                              "description": "Extension metadata"
                             },
                             "extensions": {
                               "type": "array",
@@ -3286,7 +3265,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3350,7 +3331,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3369,17 +3352,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3405,7 +3383,9 @@
                             "description": "Context identifier"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -3475,7 +3455,9 @@
                                       "description": "Text content"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3539,7 +3521,9 @@
                                       "description": "File data (bytes or URI)"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3558,17 +3542,12 @@
                                       "description": "Part type discriminator"
                                     },
                                     "data": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonObject"
-                                        },
-                                        {
-                                          "description": "Structured JSON data"
-                                        }
-                                      ]
+                                      "$ref": "#/components/schemas/JsonObject"
                                     },
                                     "metadata": {
-                                      "$ref": "#/components/schemas/JsonObject"
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Extension metadata"
                                     }
                                   },
                                   "required": [
@@ -3582,7 +3561,9 @@
                             "description": "Artifact content parts"
                           },
                           "metadata": {
-                            "$ref": "#/components/schemas/JsonObject"
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Extension metadata"
                           },
                           "extensions": {
                             "type": "array",
@@ -3601,7 +3582,9 @@
                       "description": "Task artifacts"
                     },
                     "metadata": {
-                      "$ref": "#/components/schemas/JsonObject"
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Extension metadata"
                     },
                     "kind": {
                       "type": "string",
@@ -3746,14 +3729,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -3799,14 +3777,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -3909,14 +3882,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -3962,14 +3930,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -4228,14 +4191,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -4281,14 +4239,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -4391,14 +4344,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -4444,14 +4392,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -4812,14 +4755,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -4865,14 +4803,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -4975,14 +4908,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -5028,14 +4956,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -5195,14 +5118,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -5248,14 +5166,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -5358,14 +5271,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -5411,14 +5319,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -5521,14 +5424,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -5574,14 +5472,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -5891,14 +5784,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -5944,14 +5832,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -6054,14 +5937,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -6107,14 +5985,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -6284,8 +6157,7 @@
                         "provider",
                         "model"
                       ],
-                      "additionalProperties": false,
-                      "description": "LLM configuration (apiKey omitted for security)"
+                      "additionalProperties": false
                     },
                     "routing": {
                       "type": "object",
@@ -6372,14 +6244,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -6425,14 +6292,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -6535,14 +6397,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -6588,14 +6445,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -6698,14 +6550,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -6751,14 +6598,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -6995,2268 +6837,138 @@
                       "properties": {
                         "providers": {
                           "type": "object",
-                          "properties": {
-                            "openai": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
+                          "additionalProperties": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "description": "Provider display name"
+                              },
+                              "hasApiKey": {
+                                "type": "boolean",
+                                "description": "Whether API key is configured"
+                              },
+                              "primaryEnvVar": {
+                                "type": "string",
+                                "description": "Primary environment variable for API key"
+                              },
+                              "supportsBaseURL": {
+                                "type": "boolean",
+                                "description": "Whether custom base URLs are supported"
+                              },
+                              "models": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Model name identifier"
+                                    },
+                                    "maxInputTokens": {
+                                      "type": "integer",
+                                      "minimum": 0,
+                                      "exclusiveMinimum": true,
+                                      "description": "Maximum input tokens"
+                                    },
+                                    "default": {
+                                      "type": "boolean",
+                                      "description": "Whether this is a default model"
+                                    },
+                                    "supportedFileTypes": {
+                                      "type": "array",
+                                      "items": {
                                         "type": "string",
-                                        "description": "Model name identifier"
+                                        "enum": [
+                                          "pdf",
+                                          "image",
+                                          "audio",
+                                          "video",
+                                          "document"
+                                        ]
                                       },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
+                                      "description": "File types this model supports"
+                                    },
+                                    "displayName": {
+                                      "type": "string",
+                                      "description": "Human-readable display name"
+                                    },
+                                    "pricing": {
+                                      "type": "object",
+                                      "properties": {
+                                        "inputPerM": {
+                                          "type": "number",
+                                          "description": "Input cost per million tokens (USD)"
+                                        },
+                                        "outputPerM": {
+                                          "type": "number",
+                                          "description": "Output cost per million tokens (USD)"
+                                        },
+                                        "cacheReadPerM": {
+                                          "type": "number",
+                                          "description": "Cache read cost per million tokens"
+                                        },
+                                        "cacheWritePerM": {
+                                          "type": "number",
+                                          "description": "Cache write cost per million tokens"
+                                        },
+                                        "currency": {
                                           "type": "string",
                                           "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
+                                            "USD"
+                                          ],
+                                          "description": "Currency"
                                         },
-                                        "description": "File types this model supports"
+                                        "unit": {
+                                          "type": "string",
+                                          "enum": [
+                                            "per_million_tokens"
+                                          ],
+                                          "description": "Unit"
+                                        }
                                       },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
+                                      "required": [
+                                        "inputPerM",
+                                        "outputPerM"
+                                      ],
+                                      "description": "Pricing information in USD per million tokens"
+                                    }
                                   },
-                                  "description": "Models available from this provider"
+                                  "required": [
+                                    "name",
+                                    "maxInputTokens",
+                                    "supportedFileTypes"
+                                  ],
+                                  "additionalProperties": false,
+                                  "description": "Model information from LLM registry"
                                 },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
+                                "description": "Models available from this provider"
                               },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
+                              "supportedFileTypes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "pdf",
+                                    "image",
+                                    "audio",
+                                    "video",
+                                    "document"
+                                  ]
+                                },
+                                "description": "Provider-level file type support"
+                              }
                             },
-                            "openai-compatible": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "anthropic": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "google": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "groq": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "xai": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "cohere": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "minimax": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "glm": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "openrouter": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "litellm": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "glama": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "vertex": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "bedrock": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "local": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "ollama": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            },
-                            "dexto-nova": {
-                              "type": "object",
-                              "properties": {
-                                "name": {
-                                  "type": "string",
-                                  "description": "Provider display name"
-                                },
-                                "hasApiKey": {
-                                  "type": "boolean",
-                                  "description": "Whether API key is configured"
-                                },
-                                "primaryEnvVar": {
-                                  "type": "string",
-                                  "description": "Primary environment variable for API key"
-                                },
-                                "supportsBaseURL": {
-                                  "type": "boolean",
-                                  "description": "Whether custom base URLs are supported"
-                                },
-                                "models": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "name": {
-                                        "type": "string",
-                                        "description": "Model name identifier"
-                                      },
-                                      "maxInputTokens": {
-                                        "type": "integer",
-                                        "minimum": 0,
-                                        "exclusiveMinimum": true,
-                                        "description": "Maximum input tokens"
-                                      },
-                                      "default": {
-                                        "type": "boolean",
-                                        "description": "Whether this is a default model"
-                                      },
-                                      "supportedFileTypes": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string",
-                                          "enum": [
-                                            "pdf",
-                                            "image",
-                                            "audio",
-                                            "video",
-                                            "document"
-                                          ]
-                                        },
-                                        "description": "File types this model supports"
-                                      },
-                                      "displayName": {
-                                        "type": "string",
-                                        "description": "Human-readable display name"
-                                      },
-                                      "pricing": {
-                                        "type": "object",
-                                        "properties": {
-                                          "inputPerM": {
-                                            "type": "number",
-                                            "description": "Input cost per million tokens (USD)"
-                                          },
-                                          "outputPerM": {
-                                            "type": "number",
-                                            "description": "Output cost per million tokens (USD)"
-                                          },
-                                          "cacheReadPerM": {
-                                            "type": "number",
-                                            "description": "Cache read cost per million tokens"
-                                          },
-                                          "cacheWritePerM": {
-                                            "type": "number",
-                                            "description": "Cache write cost per million tokens"
-                                          },
-                                          "currency": {
-                                            "type": "string",
-                                            "enum": [
-                                              "USD"
-                                            ],
-                                            "description": "Currency"
-                                          },
-                                          "unit": {
-                                            "type": "string",
-                                            "enum": [
-                                              "per_million_tokens"
-                                            ],
-                                            "description": "Unit"
-                                          }
-                                        },
-                                        "required": [
-                                          "inputPerM",
-                                          "outputPerM"
-                                        ],
-                                        "description": "Pricing information in USD per million tokens"
-                                      }
-                                    },
-                                    "required": [
-                                      "name",
-                                      "maxInputTokens",
-                                      "supportedFileTypes"
-                                    ],
-                                    "additionalProperties": false,
-                                    "description": "Model information from LLM registry"
-                                  },
-                                  "description": "Models available from this provider"
-                                },
-                                "supportedFileTypes": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "string",
-                                    "enum": [
-                                      "pdf",
-                                      "image",
-                                      "audio",
-                                      "video",
-                                      "document"
-                                    ]
-                                  },
-                                  "description": "Provider-level file type support"
-                                }
-                              },
-                              "required": [
-                                "name",
-                                "hasApiKey",
-                                "primaryEnvVar",
-                                "supportsBaseURL",
-                                "models",
-                                "supportedFileTypes"
-                              ],
-                              "additionalProperties": false,
-                              "description": "Provider catalog entry with models and capabilities"
-                            }
+                            "required": [
+                              "name",
+                              "hasApiKey",
+                              "primaryEnvVar",
+                              "supportsBaseURL",
+                              "models",
+                              "supportedFileTypes"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Provider catalog entry with models and capabilities"
                           },
                           "description": "Providers grouped by ID with their models and capabilities"
                         }
@@ -9438,14 +7150,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -9491,14 +7198,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -9601,14 +7303,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -9654,14 +7351,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -9764,14 +7456,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -9817,14 +7504,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -10169,14 +7851,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -10222,14 +7899,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -10332,14 +8004,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -10385,14 +8052,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -10495,14 +8157,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -10548,14 +8205,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -10658,14 +8310,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -10711,14 +8358,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -10919,14 +8561,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -10972,14 +8609,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -11082,14 +8714,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -11135,14 +8762,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -11245,14 +8867,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -11298,14 +8915,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -11582,14 +9194,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -11635,14 +9242,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -11745,14 +9347,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -11798,14 +9395,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -11908,14 +9500,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -11961,14 +9548,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -12071,14 +9653,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -12124,14 +9701,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -12285,14 +9857,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -12338,14 +9905,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -12448,14 +10010,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -12501,14 +10058,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -12611,14 +10163,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -12664,14 +10211,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -13070,14 +10612,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13145,14 +10682,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13220,14 +10752,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13380,14 +10907,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13455,14 +10977,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13530,14 +11047,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13695,14 +11207,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13770,14 +11277,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -13845,14 +11347,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -14025,14 +11522,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -14100,14 +11592,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -14175,14 +11662,9 @@
                       "description": "Error type"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Error context"
                     },
                     "recovery": {
                       "anyOf": [
@@ -14466,14 +11948,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -14519,14 +11996,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -14629,14 +12101,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -14682,14 +12149,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -14792,14 +12254,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -14845,14 +12302,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -14949,27 +12401,33 @@
                             "properties": {
                               "inputTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Number of input tokens"
                               },
                               "outputTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Number of output tokens"
                               },
                               "reasoningTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Number of reasoning tokens"
                               },
                               "cacheReadTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Number of cache read tokens"
                               },
                               "cacheWriteTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Number of cache write tokens"
                               },
                               "totalTokens": {
                                 "type": "integer",
-                                "minimum": 0
+                                "minimum": 0,
+                                "description": "Total tokens used"
                               }
                             },
                             "required": [
@@ -15011,27 +12469,33 @@
                                   "properties": {
                                     "inputTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Number of input tokens"
                                     },
                                     "outputTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Number of output tokens"
                                     },
                                     "reasoningTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Number of reasoning tokens"
                                     },
                                     "cacheReadTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Number of cache read tokens"
                                     },
                                     "cacheWriteTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Number of cache write tokens"
                                     },
                                     "totalTokens": {
                                       "type": "integer",
-                                      "minimum": 0
+                                      "minimum": 0,
+                                      "description": "Total tokens used"
                                     }
                                   },
                                   "required": [
@@ -15181,14 +12645,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -15234,14 +12693,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -15344,14 +12798,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -15397,14 +12846,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -15513,27 +12957,33 @@
                           "properties": {
                             "inputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of input tokens"
                             },
                             "outputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of output tokens"
                             },
                             "reasoningTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of reasoning tokens"
                             },
                             "cacheReadTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache read tokens"
                             },
                             "cacheWriteTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache write tokens"
                             },
                             "totalTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Total tokens used"
                             }
                           },
                           "required": [
@@ -15575,27 +13025,33 @@
                                 "properties": {
                                   "inputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of input tokens"
                                   },
                                   "outputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of output tokens"
                                   },
                                   "reasoningTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of reasoning tokens"
                                   },
                                   "cacheReadTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache read tokens"
                                   },
                                   "cacheWriteTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache write tokens"
                                   },
                                   "totalTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Total tokens used"
                                   }
                                 },
                                 "required": [
@@ -15743,14 +13199,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -15796,14 +13247,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -15906,14 +13352,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -15959,14 +13400,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -16073,27 +13509,33 @@
                           "properties": {
                             "inputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of input tokens"
                             },
                             "outputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of output tokens"
                             },
                             "reasoningTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of reasoning tokens"
                             },
                             "cacheReadTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache read tokens"
                             },
                             "cacheWriteTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache write tokens"
                             },
                             "totalTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Total tokens used"
                             }
                           },
                           "required": [
@@ -16135,27 +13577,33 @@
                                 "properties": {
                                   "inputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of input tokens"
                                   },
                                   "outputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of output tokens"
                                   },
                                   "reasoningTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of reasoning tokens"
                                   },
                                   "cacheReadTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache read tokens"
                                   },
                                   "cacheWriteTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache write tokens"
                                   },
                                   "totalTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Total tokens used"
                                   }
                                 },
                                 "required": [
@@ -16303,14 +13751,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -16356,14 +13799,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -16466,14 +13904,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -16519,14 +13952,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -16629,14 +14057,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -16682,14 +14105,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -16796,27 +14214,33 @@
                           "properties": {
                             "inputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of input tokens"
                             },
                             "outputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of output tokens"
                             },
                             "reasoningTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of reasoning tokens"
                             },
                             "cacheReadTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache read tokens"
                             },
                             "cacheWriteTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache write tokens"
                             },
                             "totalTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Total tokens used"
                             }
                           },
                           "required": [
@@ -16858,27 +14282,33 @@
                                 "properties": {
                                   "inputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of input tokens"
                                   },
                                   "outputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of output tokens"
                                   },
                                   "reasoningTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of reasoning tokens"
                                   },
                                   "cacheReadTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache read tokens"
                                   },
                                   "cacheWriteTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache write tokens"
                                   },
                                   "totalTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Total tokens used"
                                   }
                                 },
                                 "required": [
@@ -17032,14 +14462,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17085,14 +14510,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -17195,14 +14615,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17248,14 +14663,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -17358,14 +14768,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17411,14 +14816,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -17570,14 +14970,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17623,14 +15018,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -17733,14 +15123,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17786,14 +15171,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -17896,14 +15276,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -17949,14 +15324,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -18081,27 +15451,33 @@
                           "properties": {
                             "inputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of input tokens"
                             },
                             "outputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of output tokens"
                             },
                             "reasoningTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of reasoning tokens"
                             },
                             "cacheReadTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache read tokens"
                             },
                             "cacheWriteTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache write tokens"
                             },
                             "totalTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Total tokens used"
                             }
                           },
                           "required": [
@@ -18143,27 +15519,33 @@
                                 "properties": {
                                   "inputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of input tokens"
                                   },
                                   "outputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of output tokens"
                                   },
                                   "reasoningTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of reasoning tokens"
                                   },
                                   "cacheReadTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache read tokens"
                                   },
                                   "cacheWriteTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache write tokens"
                                   },
                                   "totalTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Total tokens used"
                                   }
                                 },
                                 "required": [
@@ -18311,14 +15693,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -18364,14 +15741,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -18474,14 +15846,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -18527,14 +15894,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -18637,14 +15999,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -18690,14 +16047,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -19025,9 +16377,6 @@
                                   ],
                                   "description": "Message content part (text, image, file, resource, or UI resource)"
                                 }
-                              },
-                              {
-                                "nullable": true
                               }
                             ],
                             "description": "Message content (string, null, or array of parts)"
@@ -19261,14 +16610,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -19314,14 +16658,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -19424,14 +16763,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -19477,14 +16811,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -19587,14 +16916,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -19640,14 +16964,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -19813,14 +17132,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -19866,14 +17180,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -19976,14 +17285,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -20029,14 +17333,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -20243,14 +17542,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -20296,14 +17590,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -20406,14 +17695,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -20459,14 +17743,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -20569,14 +17848,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -20622,14 +17896,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -20808,14 +18077,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -20861,14 +18125,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -20971,14 +18230,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21024,14 +18278,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -21134,14 +18383,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21187,14 +18431,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -21297,14 +18536,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21350,14 +18584,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -21524,14 +18753,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21577,14 +18801,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -21687,14 +18906,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21740,14 +18954,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -21850,14 +19059,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -21903,14 +19107,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -22013,14 +19212,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -22066,14 +19260,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -22180,27 +19369,33 @@
                           "properties": {
                             "inputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of input tokens"
                             },
                             "outputTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of output tokens"
                             },
                             "reasoningTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of reasoning tokens"
                             },
                             "cacheReadTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache read tokens"
                             },
                             "cacheWriteTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Number of cache write tokens"
                             },
                             "totalTokens": {
                               "type": "integer",
-                              "minimum": 0
+                              "minimum": 0,
+                              "description": "Total tokens used"
                             }
                           },
                           "required": [
@@ -22242,27 +19437,33 @@
                                 "properties": {
                                   "inputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of input tokens"
                                   },
                                   "outputTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of output tokens"
                                   },
                                   "reasoningTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of reasoning tokens"
                                   },
                                   "cacheReadTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache read tokens"
                                   },
                                   "cacheWriteTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Number of cache write tokens"
                                   },
                                   "totalTokens": {
                                     "type": "integer",
-                                    "minimum": 0
+                                    "minimum": 0,
+                                    "description": "Total tokens used"
                                   }
                                 },
                                 "required": [
@@ -22341,27 +19542,33 @@
                               "properties": {
                                 "inputTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of input tokens"
                                 },
                                 "outputTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of output tokens"
                                 },
                                 "reasoningTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of reasoning tokens"
                                 },
                                 "cacheReadTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of cache read tokens"
                                 },
                                 "cacheWriteTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of cache write tokens"
                                 },
                                 "totalTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Total tokens used"
                                 }
                               },
                               "required": [
@@ -22407,27 +19614,33 @@
                                     "properties": {
                                       "inputTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of input tokens"
                                       },
                                       "outputTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of output tokens"
                                       },
                                       "reasoningTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of reasoning tokens"
                                       },
                                       "cacheReadTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of cache read tokens"
                                       },
                                       "cacheWriteTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of cache write tokens"
                                       },
                                       "totalTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Total tokens used"
                                       }
                                     },
                                     "required": [
@@ -22481,27 +19694,33 @@
                               "properties": {
                                 "inputTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of input tokens"
                                 },
                                 "outputTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of output tokens"
                                 },
                                 "reasoningTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of reasoning tokens"
                                 },
                                 "cacheReadTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of cache read tokens"
                                 },
                                 "cacheWriteTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Number of cache write tokens"
                                 },
                                 "totalTokens": {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "minimum": 0,
+                                  "description": "Total tokens used"
                                 }
                               },
                               "required": [
@@ -22547,27 +19766,33 @@
                                     "properties": {
                                       "inputTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of input tokens"
                                       },
                                       "outputTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of output tokens"
                                       },
                                       "reasoningTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of reasoning tokens"
                                       },
                                       "cacheReadTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of cache read tokens"
                                       },
                                       "cacheWriteTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Number of cache write tokens"
                                       },
                                       "totalTokens": {
                                         "type": "integer",
-                                        "minimum": 0
+                                        "minimum": 0,
+                                        "description": "Total tokens used"
                                       }
                                     },
                                     "required": [
@@ -22697,14 +19922,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -22750,14 +19970,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -22860,14 +20075,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -22913,14 +20123,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23023,14 +20228,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23076,14 +20276,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23237,14 +20432,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23290,14 +20480,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23400,14 +20585,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23453,14 +20633,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23563,14 +20738,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23616,14 +20786,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23775,14 +20940,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23828,14 +20988,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -23938,14 +21093,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -23991,14 +21141,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -24101,14 +21246,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -24154,14 +21294,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -24547,9 +21682,6 @@
                                       ],
                                       "description": "Message content part (text, image, file, resource, or UI resource)"
                                     }
-                                  },
-                                  {
-                                    "nullable": true
                                   }
                                 ],
                                 "description": "Message content (string, null, or array of parts)"
@@ -24819,14 +21951,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -24872,14 +21999,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -24982,14 +22104,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -25035,14 +22152,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -25390,9 +22502,6 @@
                                           ],
                                           "description": "Message content part (text, image, file, resource, or UI resource)"
                                         }
-                                      },
-                                      {
-                                        "nullable": true
                                       }
                                     ],
                                     "description": "Message content (string, null, or array of parts)"
@@ -25701,14 +22810,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -25754,14 +22858,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -25864,14 +22963,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -25917,14 +23011,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -26241,14 +23330,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -26294,14 +23378,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -26404,14 +23483,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -26457,14 +23531,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -26627,14 +23696,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -26680,14 +23744,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -26986,14 +24045,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -27039,14 +24093,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -27369,14 +24418,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -27422,14 +24466,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -27582,14 +24621,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -27635,14 +24669,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -27776,9 +24805,6 @@
                                           },
                                           {
                                             "nullable": true
-                                          },
-                                          {
-                                            "nullable": true
                                           }
                                         ],
                                         "description": "Allowed JSON Schema enum value"
@@ -27786,19 +24812,17 @@
                                       "description": "Enum values"
                                     },
                                     "default": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonValue"
-                                        },
-                                        {
-                                          "nullable": true
-                                        }
-                                      ]
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Default value"
                                     },
                                     "format": {
                                       "type": "string",
                                       "description": "JSON Schema format hint"
                                     }
+                                  },
+                                  "additionalProperties": {
+                                    "nullable": true
                                   },
                                   "description": "JSON Schema property definition"
                                 },
@@ -27812,17 +24836,15 @@
                                 "description": "Required property names"
                               }
                             },
+                            "additionalProperties": {
+                              "nullable": true
+                            },
                             "description": "JSON Schema for tool input parameters"
                           },
                           "_meta": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonObject"
-                              },
-                              {
-                                "description": "Optional tool metadata (e.g., MCP Apps UI resource info)"
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional tool metadata (e.g., MCP Apps UI resource info)"
                           }
                         },
                         "required": [
@@ -27907,14 +24929,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -27960,14 +24977,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -28122,14 +25134,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -28175,14 +25182,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -28284,14 +25286,9 @@
                       "description": "Whether tool execution succeeded"
                     },
                     "data": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Tool execution result data"
                     },
                     "error": {
                       "type": "string",
@@ -28369,14 +25366,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -28422,14 +25414,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -28610,14 +25597,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -28663,14 +25645,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -28760,14 +25737,7 @@
                       "type": "object",
                       "properties": {
                         "content": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "$ref": "#/components/schemas/JsonValue"
                         }
                       },
                       "required": [
@@ -28849,14 +25819,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -28902,14 +25867,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -29097,14 +26057,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -29150,14 +26105,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -29260,14 +26210,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -29313,14 +26258,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -29482,14 +26422,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -29535,14 +26470,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -29714,14 +26644,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -29767,14 +26692,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -29926,14 +26846,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -29979,14 +26894,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -30162,14 +27072,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -30215,14 +27120,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -30380,14 +27280,9 @@
                             "description": "Collision-resolved slash command name"
                           },
                           "metadata": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonObject"
-                              },
-                              {
-                                "description": "Additional metadata"
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Additional metadata"
                           }
                         },
                         "required": [
@@ -30471,14 +27366,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -30524,14 +27414,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -30773,14 +27658,9 @@
                           "description": "Collision-resolved slash command name"
                         },
                         "metadata": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonObject"
-                            },
-                            {
-                              "description": "Additional metadata"
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional metadata"
                         }
                       },
                       "required": [
@@ -30862,14 +27742,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -30915,14 +27790,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -31025,14 +27895,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -31078,14 +27943,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -31342,14 +28202,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -31395,14 +28250,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -31578,14 +28428,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -31631,14 +28476,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -31754,7 +28594,7 @@
                                   "$ref": "#/components/schemas/JsonValue"
                                 },
                                 {
-                                  "nullable": true
+                                  "$ref": "#/components/schemas/JsonValue"
                                 }
                               ]
                             },
@@ -31843,14 +28683,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -31896,14 +28731,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -32016,14 +28846,9 @@
                           "description": "Array of content items (typically one item)"
                         },
                         "_meta": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonObject"
-                            },
-                            {
-                              "description": "Optional metadata about the resource"
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Optional metadata about the resource"
                         }
                       },
                       "required": [
@@ -32105,14 +28930,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -32158,14 +28978,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -32268,14 +29083,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -32321,14 +29131,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -32431,14 +29236,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -32484,14 +29284,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -32610,6 +29405,9 @@
                         "description": "Whether this memory is pinned for auto-loading"
                       }
                     },
+                    "additionalProperties": {
+                      "nullable": true
+                    },
                     "description": "Optional metadata"
                   }
                 },
@@ -32688,6 +29486,9 @@
                               "type": "boolean",
                               "description": "Whether this memory is pinned for auto-loading"
                             }
+                          },
+                          "additionalProperties": {
+                            "nullable": true
                           },
                           "description": "Additional metadata"
                         }
@@ -32774,14 +29575,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -32827,14 +29623,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -32937,14 +29728,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -32990,14 +29776,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -33171,6 +29952,9 @@
                                 "description": "Whether this memory is pinned for auto-loading"
                               }
                             },
+                            "additionalProperties": {
+                              "nullable": true
+                            },
                             "description": "Additional metadata"
                           }
                         },
@@ -33258,14 +30042,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -33311,14 +30090,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -33421,14 +30195,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -33474,14 +30243,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -33612,6 +30376,9 @@
                               "description": "Whether this memory is pinned for auto-loading"
                             }
                           },
+                          "additionalProperties": {
+                            "nullable": true
+                          },
                           "description": "Additional metadata"
                         }
                       },
@@ -33697,14 +30464,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -33750,14 +30512,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -33860,14 +30617,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -33913,14 +30665,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -34023,14 +30770,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -34076,14 +30818,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -34183,6 +30920,9 @@
                         "description": "Whether this memory is pinned for auto-loading"
                       }
                     },
+                    "additionalProperties": {
+                      "nullable": true
+                    },
                     "description": "Updated metadata (merges with existing)"
                   }
                 },
@@ -34258,6 +30998,9 @@
                               "type": "boolean",
                               "description": "Whether this memory is pinned for auto-loading"
                             }
+                          },
+                          "additionalProperties": {
+                            "nullable": true
                           },
                           "description": "Additional metadata"
                         }
@@ -34344,14 +31087,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -34397,14 +31135,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -34507,14 +31240,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -34560,14 +31288,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -34670,14 +31393,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -34723,14 +31441,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -34884,14 +31597,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -34937,14 +31645,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -35047,14 +31750,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -35100,14 +31798,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -35210,14 +31903,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -35263,14 +31951,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -35442,14 +32125,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -35495,14 +32173,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -35671,14 +32344,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -35724,14 +32392,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -35922,14 +32585,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -35975,14 +32633,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -36085,14 +32738,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -36138,14 +32786,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -36312,14 +32955,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -36365,14 +33003,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -36464,14 +33097,9 @@
                                 "description": "Instruction to execute"
                               },
                               "metadata": {
-                                "allOf": [
-                                  {
-                                    "$ref": "#/components/schemas/JsonObject"
-                                  },
-                                  {
-                                    "description": "Optional task metadata"
-                                  }
-                                ]
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Optional task metadata"
                               }
                             },
                             "required": [
@@ -36597,14 +33225,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -36650,14 +33273,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -36770,14 +33388,9 @@
                               "description": "Instruction to execute"
                             },
                             "metadata": {
-                              "allOf": [
-                                {
-                                  "$ref": "#/components/schemas/JsonObject"
-                                },
-                                {
-                                  "description": "Optional task metadata"
-                                }
-                              ]
+                              "type": "object",
+                              "additionalProperties": true,
+                              "description": "Optional task metadata"
                             }
                           },
                           "required": [
@@ -36901,14 +33514,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -36954,14 +33562,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37007,14 +33610,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37060,14 +33658,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37190,14 +33783,9 @@
                               "description": "Instruction to execute"
                             },
                             "metadata": {
-                              "allOf": [
-                                {
-                                  "$ref": "#/components/schemas/JsonObject"
-                                },
-                                {
-                                  "description": "Optional task metadata"
-                                }
-                              ]
+                              "type": "object",
+                              "additionalProperties": true,
+                              "description": "Optional task metadata"
                             }
                           },
                           "required": [
@@ -37321,14 +33909,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37374,14 +33957,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37427,14 +34005,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37480,14 +34053,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37576,14 +34144,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37629,14 +34192,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37682,14 +34240,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37836,14 +34389,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37889,14 +34437,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -37942,14 +34485,9 @@
                           "description": "Error code"
                         },
                         "details": {
-                          "allOf": [
-                            {
-                              "$ref": "#/components/schemas/JsonValue"
-                            },
-                            {
-                              "nullable": true
-                            }
-                          ]
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Additional error details"
                         }
                       },
                       "required": [
@@ -38124,14 +34662,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -38177,14 +34710,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -38287,14 +34815,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -38340,14 +34863,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -38436,14 +34954,9 @@
                     "description": "The user decision"
                   },
                   "formData": {
-                    "allOf": [
-                      {
-                        "$ref": "#/components/schemas/JsonObject"
-                      },
-                      {
-                        "description": "Optional form data provided by the user (for elicitation)"
-                      }
-                    ]
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Optional form data provided by the user (for elicitation)"
                   },
                   "rememberChoice": {
                     "type": "boolean",
@@ -38582,14 +35095,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -38635,14 +35143,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -38745,14 +35248,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -38798,14 +35296,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -39125,14 +35618,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -39178,14 +35666,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -39288,14 +35771,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -39341,14 +35819,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -39490,14 +35963,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -39543,14 +36011,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -39653,14 +36116,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -39706,14 +36164,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -39959,14 +36412,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40012,14 +36460,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -40122,14 +36565,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40175,14 +36613,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -40285,14 +36718,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40338,14 +36766,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -40448,14 +36871,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40501,14 +36919,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -40681,14 +37094,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40734,14 +37142,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -40844,14 +37247,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -40897,14 +37295,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41007,14 +37400,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41060,14 +37448,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41170,14 +37553,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41223,14 +37601,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41398,14 +37771,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41451,14 +37819,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41561,14 +37924,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41614,14 +37972,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41724,14 +38077,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41777,14 +38125,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -41887,14 +38230,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -41940,14 +38278,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -42116,14 +38449,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -42169,14 +38497,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -42279,14 +38602,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -42332,14 +38650,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -42442,14 +38755,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -42495,14 +38803,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -42605,14 +38908,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -42658,14 +38956,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -42758,7 +39051,7 @@
                           "$ref": "#/components/schemas/JsonValue"
                         },
                         {
-                          "nullable": true
+                          "$ref": "#/components/schemas/JsonValue"
                         }
                       ]
                     },
@@ -42874,14 +39167,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -42927,14 +39215,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43037,14 +39320,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43090,14 +39368,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43200,14 +39473,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43253,14 +39521,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43363,14 +39626,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43416,14 +39674,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43573,14 +39826,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43626,14 +39874,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43736,14 +39979,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43789,14 +40027,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -43899,14 +40132,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -43952,14 +40180,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -44062,14 +40285,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -44115,14 +40333,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -44195,6 +40408,7 @@
                     },
                     "lastModified": {
                       "type": "string",
+                      "format": "date-time",
                       "description": "Last modification timestamp"
                     },
                     "warnings": {
@@ -44280,14 +40494,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -44333,14 +40542,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -44443,14 +40647,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -44496,14 +40695,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -44606,14 +40800,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -44659,14 +40848,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -44769,14 +40953,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -44822,14 +41001,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45013,14 +41187,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45066,14 +41235,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45176,14 +41340,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45229,14 +41388,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45339,14 +41493,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45392,14 +41541,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45502,14 +41646,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45555,14 +41694,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45674,6 +41808,9 @@
                           "message",
                           "code"
                         ],
+                        "additionalProperties": {
+                          "nullable": true
+                        },
                         "description": "Configuration validation error"
                       },
                       "description": "Validation errors"
@@ -45780,14 +41917,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45833,14 +41965,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -45943,14 +42070,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -45996,14 +42118,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -46106,14 +42223,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -46159,14 +42271,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -46269,14 +42376,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -46322,14 +42424,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -46673,14 +42770,9 @@
                             "description": "Unix timestamp when message was queued"
                           },
                           "metadata": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonObject"
-                              },
-                              {
-                                "description": "Optional metadata"
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional metadata"
                           },
                           "kind": {
                             "type": "string",
@@ -46778,14 +42870,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -46831,14 +42918,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -46941,14 +43023,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -46994,14 +43071,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -47104,14 +43176,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -47157,14 +43224,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -47441,14 +43503,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -47494,14 +43551,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -47604,14 +43656,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -47657,14 +43704,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -47767,14 +43809,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -47820,14 +43857,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -47981,14 +44013,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48034,14 +44061,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -48144,14 +44166,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48197,14 +44214,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -48307,14 +44319,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48360,14 +44367,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -48534,14 +44536,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48587,14 +44584,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -48697,14 +44689,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48750,14 +44737,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -48860,14 +44842,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -48913,14 +44890,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -49099,14 +45071,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -49152,14 +45119,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -49262,14 +45224,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -49315,14 +45272,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -49588,14 +45540,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -49641,14 +45588,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -49751,14 +45693,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -49804,14 +45741,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -50023,14 +45955,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -50076,14 +46003,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -50186,14 +46108,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -50239,14 +46156,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -50380,9 +46292,6 @@
                                           },
                                           {
                                             "nullable": true
-                                          },
-                                          {
-                                            "nullable": true
                                           }
                                         ],
                                         "description": "Allowed JSON Schema enum value"
@@ -50390,19 +46299,17 @@
                                       "description": "Enum values"
                                     },
                                     "default": {
-                                      "allOf": [
-                                        {
-                                          "$ref": "#/components/schemas/JsonValue"
-                                        },
-                                        {
-                                          "nullable": true
-                                        }
-                                      ]
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Default value"
                                     },
                                     "format": {
                                       "type": "string",
                                       "description": "JSON Schema format hint"
                                     }
+                                  },
+                                  "additionalProperties": {
+                                    "nullable": true
                                   },
                                   "description": "JSON Schema property definition"
                                 },
@@ -50416,6 +46323,9 @@
                                 "description": "Required property names"
                               }
                             },
+                            "additionalProperties": {
+                              "nullable": true
+                            },
                             "description": "JSON Schema for tool input parameters"
                           },
                           "_meta": {
@@ -50426,7 +46336,7 @@
                                   "$ref": "#/components/schemas/JsonValue"
                                 },
                                 {
-                                  "nullable": true
+                                  "$ref": "#/components/schemas/JsonValue"
                                 }
                               ]
                             },
@@ -50531,14 +46441,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -50584,14 +46489,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -50681,6 +46581,9 @@
                                 "description": "Factory description"
                               }
                             },
+                            "additionalProperties": {
+                              "nullable": true
+                            },
                             "description": "Optional metadata about the factory"
                           }
                         },
@@ -50722,6 +46625,9 @@
                                 "type": "string",
                                 "description": "Factory description"
                               }
+                            },
+                            "additionalProperties": {
+                              "nullable": true
                             },
                             "description": "Optional metadata about the factory"
                           }
@@ -50765,6 +46671,9 @@
                                 "description": "Factory description"
                               }
                             },
+                            "additionalProperties": {
+                              "nullable": true
+                            },
                             "description": "Optional metadata about the factory"
                           }
                         },
@@ -50806,6 +46715,9 @@
                                 "type": "string",
                                 "description": "Factory description"
                               }
+                            },
+                            "additionalProperties": {
+                              "nullable": true
                             },
                             "description": "Optional metadata about the factory"
                           }
@@ -50915,14 +46827,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -50968,14 +46875,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -51148,14 +47050,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -51201,14 +47098,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -51392,14 +47284,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -51445,14 +47332,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -51555,14 +47437,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -51608,14 +47485,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -51777,14 +47649,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -51830,14 +47697,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -51940,14 +47802,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -51993,14 +47850,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -52178,14 +48030,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -52231,14 +48078,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -52375,14 +48217,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -52428,14 +48265,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -52589,14 +48421,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -52642,14 +48469,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -52840,14 +48662,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -52893,14 +48710,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -53003,14 +48815,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -53056,14 +48863,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [
@@ -53207,14 +49009,9 @@
                       "description": "Optional recovery guidance"
                     },
                     "context": {
-                      "allOf": [
-                        {
-                          "$ref": "#/components/schemas/JsonValue"
-                        },
-                        {
-                          "nullable": true
-                        }
-                      ]
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Optional structured error context"
                     },
                     "issues": {
                       "type": "array",
@@ -53260,14 +49057,9 @@
                             "description": "Optional location for the issue"
                           },
                           "context": {
-                            "allOf": [
-                              {
-                                "$ref": "#/components/schemas/JsonValue"
-                              },
-                              {
-                                "nullable": true
-                              }
-                            ]
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Optional structured issue context"
                           }
                         },
                         "required": [

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -20,7 +20,8 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^22.13.5"
+    "@types/node": "^22.13.5",
+    "yaml": "^2.8.3"
   },
   "peerDependencies": {
     "zod": "^4.3.6"

--- a/packages/agent-config/package.json
+++ b/packages/agent-config/package.json
@@ -17,13 +17,13 @@
   "dependencies": {
     "@dexto/core": "workspace:*",
     "@dexto/storage": "workspace:*",
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.13.5"
   },
   "peerDependencies": {
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 tsup && node ../../scripts/clean-tsbuildinfo.mjs && cross-env NODE_OPTIONS=--max-old-space-size=4096 tsc -b tsconfig.json --emitDeclarationOnly && node scripts/fix-dist-aliases.mjs",

--- a/packages/agent-config/src/image/types.ts
+++ b/packages/agent-config/src/image/types.ts
@@ -86,7 +86,7 @@ export interface ToolFactory<
     THostContext extends DextoHostContext = DextoHostContext,
 > {
     /** Zod schema for validating factory-specific configuration. */
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     /** Create one or more tool instances from validated config. */
     create(config: TConfig, context?: ImageResolutionContext<THostContext>): Tool[];
     metadata?: ToolFactoryMetadata;
@@ -101,7 +101,7 @@ export interface BlobStoreFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(
         config: TConfig,
         logger: Logger,
@@ -114,7 +114,7 @@ export interface DatabaseFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(
         config: TConfig,
         logger: Logger,
@@ -127,7 +127,7 @@ export interface CacheFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(
         config: TConfig,
         logger: Logger,
@@ -143,7 +143,7 @@ export interface HookFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(config: TConfig, context?: ImageResolutionContext<THostContext>): Hook;
     metadata?: Record<string, unknown> | undefined;
 }
@@ -155,7 +155,7 @@ export interface CompactionFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(
         config: TConfig,
         context?: ImageResolutionContext<THostContext>
@@ -172,7 +172,7 @@ export interface LoggerFactory<
     TConfig = unknown,
     THostContext extends DextoHostContext = DextoHostContext,
 > {
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
     create(config: TConfig, context?: ImageResolutionContext<THostContext>): Logger;
     metadata?: Record<string, unknown> | undefined;
 }

--- a/packages/agent-config/src/resolver/resolve-services-from-config.test.ts
+++ b/packages/agent-config/src/resolver/resolve-services-from-config.test.ts
@@ -415,7 +415,7 @@ describe('resolveServicesFromConfig', () => {
         } satisfies AgentConfig);
 
         await expect(resolveServicesFromConfig(validated, image)).rejects.toThrow(
-            /Expected number/
+            /Invalid input: expected number, received string/
         );
     });
 
@@ -457,7 +457,7 @@ describe('resolveServicesFromConfig', () => {
         } satisfies AgentConfig);
 
         await expect(resolveServicesFromConfig(validated, image)).rejects.toThrow(
-            /Expected number/
+            /Invalid input: expected number, received string/
         );
     });
 

--- a/packages/agent-config/src/schemas/agent-config.test.ts
+++ b/packages/agent-config/src/schemas/agent-config.test.ts
@@ -1,8 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { AgentConfigSchema, type AgentConfig } from './agent-config.js';
 
 describe('AgentConfigSchema', () => {
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
     const validAgentConfig: AgentConfig = {
         systemPrompt: 'You are a helpful assistant',
         llm: {
@@ -244,6 +249,81 @@ describe('AgentConfigSchema', () => {
             expect(result.storage.cache.type).toBe('redis');
             expect(result.sessions.maxSessions).toBe(100);
             expect(result.permissions.timeout).toBe(45_000);
+        });
+    });
+
+    describe('YAML compatibility', () => {
+        it('preserves YAML defaults and env expansion semantics', () => {
+            vi.stubEnv('OPENAI_API_KEY', 'sk-from-env');
+            vi.stubEnv('MCP_STDIO_COMMAND', 'node');
+            vi.stubEnv('MCP_STDIO_ARG', 'server.js');
+            vi.stubEnv('MCP_STDIO_TOKEN', 'stdio-token');
+            vi.stubEnv('MCP_SSE_URL', 'https://mcp.example.com/sse');
+            vi.stubEnv('MCP_AUTH_TOKEN', 'sse-token');
+
+            const parsedYaml = parseYaml(`
+systemPrompt: You are a YAML-configured assistant
+llm:
+  provider: openai
+  model: gpt-4o-mini
+  apiKey: $OPENAI_API_KEY
+mcpServers:
+  local:
+    type: stdio
+    command: $MCP_STDIO_COMMAND
+    args:
+      - \${MCP_STDIO_ARG}
+    env:
+      TOKEN: $MCP_STDIO_TOKEN
+  remote:
+    type: sse
+    url: $MCP_SSE_URL
+    headers:
+      Authorization: Bearer \${MCP_AUTH_TOKEN}
+agentFile: {}
+sessions: {}
+permissions: {}
+elicitation: {}
+`);
+
+            const result = AgentConfigSchema.parse(parsedYaml);
+
+            expect(result.systemPrompt.contributors).toEqual([
+                {
+                    id: 'inline',
+                    type: 'static',
+                    content: 'You are a YAML-configured assistant',
+                    priority: 0,
+                    enabled: true,
+                },
+            ]);
+            expect(result.llm.apiKey).toBe('sk-from-env');
+
+            expect(result.agentFile.discoverInCwd).toBe(true);
+            expect(result.sessions.maxSessions).toBe(100);
+            expect(result.permissions.mode).toBe('auto-approve');
+            expect(result.permissions.allowedToolsStorage).toBe('storage');
+            expect(result.elicitation.enabled).toBe(false);
+
+            expect(result.mcpServers.local).toMatchObject({
+                type: 'stdio',
+                command: 'node',
+                args: ['server.js'],
+                env: { TOKEN: 'stdio-token' },
+                enabled: true,
+                timeout: 30000,
+                connectionMode: 'lenient',
+            });
+            expect(result.mcpServers.remote).toMatchObject({
+                type: 'sse',
+                url: 'https://mcp.example.com/sse',
+                headers: {
+                    Authorization: 'Bearer sse-token',
+                },
+                enabled: true,
+                timeout: 30000,
+                connectionMode: 'lenient',
+            });
         });
     });
 });

--- a/packages/agent-config/src/schemas/agent-config.ts
+++ b/packages/agent-config/src/schemas/agent-config.ts
@@ -92,7 +92,7 @@ export function createAgentConfigSchema() {
                         ),
                 })
                 .strict()
-                .default({})
+                .prefault({})
                 .describe('Agent instruction file discovery configuration'),
 
             image: z
@@ -114,7 +114,7 @@ export function createAgentConfigSchema() {
 
             mcpServers: McpServersConfigSchema.describe(
                 'Configurations for MCP (Model Context Protocol) servers used by the agent'
-            ).default({}),
+            ).prefault({}),
 
             tools: z
                 .array(ToolFactoryEntrySchema)
@@ -132,19 +132,19 @@ export function createAgentConfigSchema() {
 
             storage: StorageSchema.describe(
                 'Storage configuration for cache, database, and blob storage - defaults to in-memory, CLI enrichment provides filesystem paths'
-            ).default({
+            ).prefault({
                 cache: { type: 'in-memory' },
                 database: { type: 'in-memory' },
                 blob: { type: 'in-memory' },
             }),
 
-            sessions: SessionConfigSchema.describe('Session management configuration').default({}),
+            sessions: SessionConfigSchema.describe('Session management configuration').prefault({}),
 
             permissions: PermissionsConfigSchema.describe(
                 'Tool permissions and approval configuration'
-            ).default({}),
+            ).prefault({}),
 
-            elicitation: ElicitationConfigSchema.default({}).describe(
+            elicitation: ElicitationConfigSchema.prefault({}).describe(
                 'Elicitation configuration for user input requests (ask_user tool and MCP server elicitations). Independent from permissions mode.'
             ),
 

--- a/packages/agent-management/package.json
+++ b/packages/agent-management/package.json
@@ -20,13 +20,13 @@
     "@dexto/orchestration": "workspace:*",
     "@dexto/tools-builtins": "workspace:*",
     "yaml": "^2.8.3",
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^22.13.5"
   },
   "peerDependencies": {
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 tsup && node ../../scripts/clean-tsbuildinfo.mjs && cross-env NODE_OPTIONS=--max-old-space-size=4096 tsc -b tsconfig.json --emitDeclarationOnly && node scripts/fix-dist-aliases.mjs",

--- a/packages/agent-management/src/AgentManager.ts
+++ b/packages/agent-management/src/AgentManager.ts
@@ -140,7 +140,7 @@ export class AgentManager {
             if (error instanceof ZodError) {
                 throw RegistryError.registryParseError(
                     this.registryPath,
-                    `Invalid registry schema: ${error.errors.map((e) => e.message).join(', ')}`
+                    `Invalid registry schema: ${error.issues.map((e) => e.message).join(', ')}`
                 );
             }
             throw RegistryError.registryParseError(

--- a/packages/agent-management/src/images/image-store.ts
+++ b/packages/agent-management/src/images/image-store.ts
@@ -10,10 +10,12 @@ const ImageRegistryFileSchema = z
     .object({
         version: z.literal(1),
         images: z.record(
+            z.string(),
             z
                 .object({
                     active: z.string().optional(),
                     installed: z.record(
+                        z.string(),
                         z
                             .object({
                                 entryFile: z.string(),

--- a/packages/agent-management/src/plugins/marketplace/schemas.ts
+++ b/packages/agent-management/src/plugins/marketplace/schemas.ts
@@ -33,7 +33,7 @@ export const KnownMarketplacesFileSchema = z
     .object({
         version: z.number().default(1).describe('File format version'),
         marketplaces: z
-            .record(MarketplaceEntrySchema)
+            .record(z.string(), MarketplaceEntrySchema)
             .default({})
             .describe('Registered marketplaces by name'),
     })

--- a/packages/agent-management/src/plugins/schemas.ts
+++ b/packages/agent-management/src/plugins/schemas.ts
@@ -38,7 +38,10 @@ export const PluginManifestSchema = z
  */
 export const PluginMCPConfigSchema = z
     .object({
-        mcpServers: z.record(z.unknown()).optional().describe('MCP servers to register'),
+        mcpServers: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe('MCP servers to register'),
     })
     .passthrough()
     .describe('MCP configuration from .mcp.json');
@@ -80,7 +83,7 @@ export const InstalledPluginsFileSchema = z
     .object({
         version: z.number().optional().describe('Schema version'),
         plugins: z
-            .record(z.array(InstalledPluginEntrySchema))
+            .record(z.string(), z.array(InstalledPluginEntrySchema))
             .describe('Map of plugin identifiers to installation entries'),
     })
     .passthrough()

--- a/packages/agent-management/src/preferences/schemas.ts
+++ b/packages/agent-management/src/preferences/schemas.ts
@@ -223,11 +223,11 @@ export const GlobalPreferencesSchema = z
 
         defaults: PreferenceDefaultsSchema.describe('Default behavior preferences (required)'),
 
-        setup: PreferenceSetupSchema.default({ completed: false }).describe(
+        setup: PreferenceSetupSchema.prefault({ completed: false }).describe(
             'Setup completion tracking'
         ),
 
-        sounds: PreferenceSoundsSchema.default({}).describe(
+        sounds: PreferenceSoundsSchema.prefault({}).describe(
             'Sound notification preferences (defaults applied for legacy preferences)'
         ),
     })

--- a/packages/agent-management/src/runtime/schemas.ts
+++ b/packages/agent-management/src/runtime/schemas.ts
@@ -51,7 +51,7 @@ export type ValidatedAgentRuntimeConfig = z.output<typeof AgentRuntimeConfigSche
  */
 export const SpawnConfigSchema = z
     .object({
-        agentConfig: z.record(z.unknown()).describe('Base agent configuration'),
+        agentConfig: z.record(z.string(), z.unknown()).describe('Base agent configuration'),
 
         ephemeral: z
             .boolean()
@@ -71,7 +71,7 @@ export const SpawnConfigSchema = z
             .describe('Optional group identifier for logical grouping'),
 
         metadata: z
-            .record(z.unknown())
+            .record(z.string(), z.unknown())
             .optional()
             .describe('Optional metadata for tracking relationships or context'),
     })

--- a/packages/agent-management/src/tool-factories/agent-spawner/factory.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/factory.ts
@@ -1,5 +1,4 @@
 import type { ToolFactory } from '@dexto/agent-config';
-import { z } from 'zod';
 import { createLocalToolCallHeader, truncateForHeader } from '@dexto/core';
 import type { ToolExecutionContext } from '@dexto/core';
 import type { ToolBackgroundEvent } from '@dexto/core';
@@ -14,17 +13,18 @@ import {
     WaitForInputSchema,
     CheckTaskInputSchema,
     ListTasksInputSchema,
+    type WaitForInput,
+    type CheckTaskInput,
+    type ListTasksInput,
 } from '@dexto/orchestration';
 import {
     AgentSpawnerConfigSchema,
     SpawnAgentInputSchema,
     type AgentSpawnerConfig,
+    type SpawnAgentInput,
 } from './schemas.js';
 import { AgentSpawnerRuntime } from './runtime.js';
 import { createSpawnAgentTool } from './spawn-agent-tool.js';
-
-type WaitForInput = z.output<typeof WaitForInputSchema>;
-type CheckTaskInput = z.output<typeof CheckTaskInputSchema>;
 
 function requireAgentContext(context: ToolExecutionContext): {
     agent: NonNullable<ToolExecutionContext['agent']>;
@@ -335,10 +335,10 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                     return tool.description;
                 },
                 inputSchema: SpawnAgentInputSchema,
-                execute: (input, context) =>
+                execute: (input: SpawnAgentInput, context) =>
                     ensureToolsInitialized(context).spawnAgent.execute(input, context),
                 presentation: {
-                    describeHeader: (input) => {
+                    describeHeader: (input: SpawnAgentInput) => {
                         const agentId =
                             typeof input.agentId === 'string' ? input.agentId : undefined;
                         const agentLabel = agentId ? agentId.replace(/-agent$/, '') : undefined;
@@ -354,7 +354,7 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                             ...(argsText ? { argsText } : {}),
                         });
                     },
-                    preview: async (input, context) => {
+                    preview: async (input: SpawnAgentInput, context) => {
                         const tool = ensureToolsInitialized(context).spawnAgent;
                         const previewFn = tool.presentation?.preview;
                         if (!previewFn) {
@@ -368,7 +368,7 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                 id: 'wait_for',
                 description: 'Wait for background task(s) to complete.',
                 inputSchema: WaitForInputSchema,
-                execute: (input, context) =>
+                execute: (input: WaitForInput, context) =>
                     ensureToolsInitialized(context).waitFor.execute(input, context),
                 presentation: {
                     describeHeader: (input: WaitForInput) => {
@@ -383,7 +383,7 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                             ...(argsText ? { argsText } : {}),
                         });
                     },
-                    preview: async (input, context) => {
+                    preview: async (input: WaitForInput, context) => {
                         const tool = ensureToolsInitialized(context).waitFor;
                         const previewFn = tool.presentation?.preview;
                         if (!previewFn) {
@@ -397,7 +397,7 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                 id: 'check_task',
                 description: 'Check the status of a background task.',
                 inputSchema: CheckTaskInputSchema,
-                execute: (input, context) =>
+                execute: (input: CheckTaskInput, context) =>
                     ensureToolsInitialized(context).checkTask.execute(input, context),
                 presentation: {
                     describeHeader: (input: CheckTaskInput) => {
@@ -408,7 +408,7 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                             ...(argsText ? { argsText } : {}),
                         });
                     },
-                    preview: async (input, context) => {
+                    preview: async (input: CheckTaskInput, context) => {
                         const tool = ensureToolsInitialized(context).checkTask;
                         const previewFn = tool.presentation?.preview;
                         if (!previewFn) {
@@ -422,14 +422,14 @@ export const agentSpawnerToolsFactory: ToolFactory<AgentSpawnerConfig> = {
                 id: 'list_tasks',
                 description: 'List background tasks and their statuses.',
                 inputSchema: ListTasksInputSchema,
-                execute: (input, context) =>
+                execute: (input: ListTasksInput, context) =>
                     ensureToolsInitialized(context).listTasks.execute(input, context),
                 presentation: {
                     describeHeader: () =>
                         createLocalToolCallHeader({
                             title: 'List Tasks',
                         }),
-                    preview: async (input, context) => {
+                    preview: async (input: ListTasksInput, context) => {
                         const tool = ensureToolsInitialized(context).listTasks;
                         const previewFn = tool.presentation?.preview;
                         if (!previewFn) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,7 @@
     "tsx": "^4.19.2",
     "ws": "^8.18.1",
     "yaml": "^2.8.3",
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "scripts": {
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=4096 tsc -p tsconfig.json && pnpm run copy-agents && pnpm run copy-assets",

--- a/packages/cli/src/cli/commands/deploy/client.ts
+++ b/packages/cli/src/cli/commands/deploy/client.ts
@@ -343,7 +343,13 @@ async function request(
     });
 }
 
-function requireSuccessData<T extends z.ZodTypeAny>(
+type SuccessEnvelope = {
+    success: boolean;
+    error?: string | undefined;
+    data?: unknown;
+};
+
+function requireSuccessData<T extends z.ZodType<SuccessEnvelope, unknown>>(
     payload: unknown,
     response: Response,
     schema: T

--- a/packages/cli/src/cli/utils/options.ts
+++ b/packages/cli/src/cli/utils/options.ts
@@ -21,7 +21,7 @@ export function validateCliOptions(opts: any): void {
             strict: z.boolean().optional().default(false),
             verbose: z.boolean().optional().default(true),
             mode: z.enum(['web', 'cli', 'server', 'discord', 'telegram', 'mcp'], {
-                errorMap: () => ({
+                error: () => ({
                     message:
                         'Mode must be one of "web", "cli", "server", "discord", "telegram", or "mcp"',
                 }),
@@ -121,7 +121,7 @@ export function validateCliOptions(opts: any): void {
 export function handleCliOptionsError(error: unknown): never {
     if (error instanceof z.ZodError) {
         console.error(chalk.red('❌ Invalid command-line options detected:'));
-        error.errors.forEach((err) => {
+        error.issues.forEach((err) => {
             const fieldName = err.path.join('.') || 'Unknown Option';
             console.error(chalk.red(`   • Option '${fieldName}': ${err.message}`));
         });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,8 +46,7 @@
         "glob": "^12.0.0",
         "nanoid": "^5.1.6",
         "winston": "^3.17.0",
-        "yaml": "^2.8.3",
-        "zod-to-json-schema": "^3.24.6"
+        "yaml": "^2.8.3"
     },
     "devDependencies": {
         "@opentelemetry/instrumentation-http": "^0.210.0",
@@ -58,7 +57,7 @@
         "@opentelemetry/semantic-conventions": "^1.28.0",
         "@types/diff": "^8.0.0",
         "@types/json-schema": "^7.0.15",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "peerDependencies": {
         "@opentelemetry/core": "^1.28.0",
@@ -74,7 +73,7 @@
         "ioredis": "^5.7.0",
         "pg": "^8.15.4",
         "tsx": "^4.19.2",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "peerDependenciesMeta": {
         "@opentelemetry/core": {

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -35,7 +35,12 @@ import { DextoValidationError } from '../errors/DextoValidationError.js';
 import { ensureOk } from '../errors/result-bridge.js';
 import { fail, zodToIssues } from '../utils/result.js';
 import { resolveAndValidateMcpServerConfig } from '../mcp/resolver.js';
-import type { McpServerConfig, McpServerStatus, McpConnectionStatus } from '../mcp/schemas.js';
+import type {
+    McpServerConfig,
+    McpServerStatus,
+    McpConnectionStatus,
+    ValidatedMcpServerConfig,
+} from '../mcp/schemas.js';
 import {
     getSupportedProviders,
     getDefaultModelForProvider,
@@ -3454,7 +3459,7 @@ export class DextoAgent {
             : this.stateManager.getRuntimeConfig();
     }
 
-    public getMcpServerConfig(name: string): McpServerConfig | undefined {
+    public getMcpServerConfig(name: string): ValidatedMcpServerConfig | undefined {
         this.ensureStarted();
         const config = this.stateManager.getRuntimeConfig().mcpServers[name];
         if (config) return config;

--- a/packages/core/src/agent/schemas.ts
+++ b/packages/core/src/agent/schemas.ts
@@ -37,7 +37,7 @@ const OAuth2FlowSchema = z
         authorizationUrl: z.string().url().optional().describe('Authorization URL for the flow'),
         tokenUrl: z.string().url().optional().describe('Token URL for the flow'),
         refreshUrl: z.string().url().optional().describe('Refresh URL for the flow'),
-        scopes: z.record(z.string()).describe('Available scopes for the OAuth2 flow'),
+        scopes: z.record(z.string(), z.string()).describe('Available scopes for the OAuth2 flow'),
     })
     .strict();
 
@@ -206,7 +206,7 @@ export const AgentCardSchema = z
                     })
                     .strict()
             )
-            .default([
+            .prefault([
                 {
                     id: 'chat_with_agent',
                     name: 'chat_with_agent',
@@ -265,16 +265,16 @@ export const AgentCardSchema = z
                     .describe('Provides state transition history'),
             })
             .strict()
-            .default({})
+            .prefault({})
             .describe('Agent capabilities and features'),
 
         securitySchemes: z
-            .record(SecuritySchemeSchema)
+            .record(z.string(), SecuritySchemeSchema)
             .optional()
             .describe('Map of security scheme definitions (A2A format)'),
 
         security: z
-            .array(z.record(z.array(z.string())))
+            .array(z.record(z.string(), z.array(z.string())))
             .optional()
             .describe(
                 'Security requirements (array of security scheme references with required scopes)'

--- a/packages/core/src/approval/schemas.ts
+++ b/packages/core/src/approval/schemas.ts
@@ -11,7 +11,7 @@ import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
 import { HostRuntimeContextSchema } from '../runtime/index.js';
 
 // Zod schema that validates as object but types as JSONSchema7
-const JsonSchema7Schema = z.record(z.unknown()) as z.ZodType<JSONSchema7>;
+const JsonSchema7Schema = z.record(z.string(), z.unknown()) as z.ZodType<JSONSchema7>;
 
 /**
  * Schema for approval types
@@ -65,7 +65,7 @@ export const ToolApprovalMetadataSchema = z
             'Optional UI-agnostic presentation snapshot for the tool call. Clients MUST ignore unknown fields.'
         ),
         toolCallId: z.string().describe('Unique tool call ID for tracking parallel tool calls'),
-        args: z.record(z.unknown()).describe('Arguments for the tool'),
+        args: z.record(z.string(), z.unknown()).describe('Arguments for the tool'),
         description: z.string().optional().describe('Description of the tool'),
         displayPreview: ToolDisplayDataSchema.optional().describe(
             'Preview display data for approval UI (e.g., diff preview)'
@@ -108,7 +108,7 @@ export const ElicitationMetadataSchema = z
         schema: JsonSchema7Schema.describe('JSON Schema for the form'),
         prompt: z.string().describe('High-level prompt/context for the form (clients may show it)'),
         serverName: z.string().describe('MCP server requesting input'),
-        context: z.record(z.unknown()).optional().describe('Additional context'),
+        context: z.record(z.string(), z.unknown()).optional().describe('Additional context'),
     })
     .strict()
     .describe('Elicitation metadata');
@@ -116,7 +116,9 @@ export const ElicitationMetadataSchema = z
 /**
  * Custom approval metadata schema - flexible
  */
-export const CustomApprovalMetadataSchema = z.record(z.unknown()).describe('Custom metadata');
+export const CustomApprovalMetadataSchema = z
+    .record(z.string(), z.unknown())
+    .describe('Custom metadata');
 
 /**
  * Base approval request schema
@@ -232,7 +234,7 @@ export const CommandConfirmationResponseDataSchema = z
  */
 export const ElicitationResponseDataSchema = z
     .object({
-        formData: z.record(z.unknown()).describe('Form data matching schema'),
+        formData: z.record(z.string(), z.unknown()).describe('Form data matching schema'),
     })
     .strict()
     .describe('Elicitation response data');
@@ -241,7 +243,7 @@ export const ElicitationResponseDataSchema = z
  * Custom approval response data schema
  */
 export const CustomApprovalResponseDataSchema = z
-    .record(z.unknown())
+    .record(z.string(), z.unknown())
     .describe('Custom response data');
 
 /**

--- a/packages/core/src/approval/session-approval-store.ts
+++ b/packages/core/src/approval/session-approval-store.ts
@@ -13,7 +13,7 @@ const PersistedApprovedDirectorySchema = z
 
 const SessionApprovalStateSchema = z
     .object({
-        toolPatterns: z.record(z.array(z.string())).default({}),
+        toolPatterns: z.record(z.string(), z.array(z.string())).default({}),
         approvedDirectories: z.array(PersistedApprovedDirectorySchema).default([]),
     })
     .strict();

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -1143,7 +1143,7 @@ export function validateModelFileSupport(
  * 2. Registry lookup for known provider/model.
  *
  * @param config The validated LLM configuration.
- * @param logger Optional logger instance for logging.
+ * @param logger Logger instance for logging.
  * @returns The effective maximum input token count for the LLM.
  *
  * Notes:

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -13,7 +13,7 @@
  * For now, keeping SDK dependency is simpler and auto-updates with SDK releases.
  */
 
-import { LLMConfig } from '../schemas.js';
+import type { ValidatedLLMConfig } from '../schemas.js';
 import { LLMError } from '../errors.js';
 import { LLMErrorCode } from '../error-codes.js';
 import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
@@ -230,6 +230,11 @@ export interface ProviderInfo {
 
 /** Fallback when we cannot determine the model's input-token limit */
 export const DEFAULT_MAX_INPUT_TOKENS = 128000;
+
+type EffectiveMaxInputTokensConfig = Pick<
+    ValidatedLLMConfig,
+    'provider' | 'model' | 'baseURL' | 'maxInputTokens'
+>;
 
 // Use imported constant LLM_PROVIDERS
 
@@ -1147,7 +1152,10 @@ export function validateModelFileSupport(
  * - If `baseURL` is not set and the model isn't found in the registry, this throws.
  * TODO: make more readable
  */
-export function getEffectiveMaxInputTokens(config: LLMConfig, logger: Logger): number {
+export function getEffectiveMaxInputTokens(
+    config: EffectiveMaxInputTokensConfig,
+    logger: Logger
+): number {
     const configuredMaxInputTokens = config.maxInputTokens;
 
     // Priority 1: Explicit config override or required value with baseURL

--- a/packages/core/src/llm/resolver.ts
+++ b/packages/core/src/llm/resolver.ts
@@ -277,7 +277,6 @@ export function validateLLMConfig(
             {
                 provider: parsed.data.provider,
                 model: parsed.data.model,
-                apiKey: parsed.data.apiKey ?? candidate.apiKey ?? '',
                 baseURL: parsed.data.baseURL,
             },
             logger

--- a/packages/core/src/llm/schemas.test.ts
+++ b/packages/core/src/llm/schemas.test.ts
@@ -156,7 +156,7 @@ describe('LLMConfigSchema', () => {
 
             const result = LLMConfigSchema.safeParse(config);
             expect(result.success).toBe(false);
-            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(result.error?.issues[0]?.path).toEqual(['provider']);
         });
 
@@ -169,7 +169,7 @@ describe('LLMConfigSchema', () => {
 
             const result = LLMConfigSchema.safeParse(config);
             expect(result.success).toBe(false);
-            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(result.error?.issues[0]?.path).toEqual(['provider']);
         });
     });

--- a/packages/core/src/mcp/schemas.test.ts
+++ b/packages/core/src/mcp/schemas.test.ts
@@ -106,7 +106,7 @@ describe('MCP Schemas', () => {
                 };
                 const result = StdioServerConfigSchema.safeParse(invalidConfig);
                 expect(result.success).toBe(false);
-                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
                 expect(result.error?.issues[0]?.path).toEqual(['connectionMode']);
             });
 
@@ -257,7 +257,7 @@ describe('MCP Schemas', () => {
                 };
                 const result = SseServerConfigSchema.safeParse(invalidConfig);
                 expect(result.success).toBe(false);
-                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
                 expect(result.error?.issues[0]?.path).toEqual(['connectionMode']);
             });
 
@@ -403,7 +403,7 @@ describe('MCP Schemas', () => {
                 };
                 const result = HttpServerConfigSchema.safeParse(invalidConfig);
                 expect(result.success).toBe(false);
-                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+                expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
                 expect(result.error?.issues[0]?.path).toEqual(['connectionMode']);
             });
 

--- a/packages/core/src/mcp/schemas.ts
+++ b/packages/core/src/mcp/schemas.ts
@@ -59,7 +59,7 @@ export const StdioServerConfigSchema = z
             .default([])
             .describe("Array of arguments for the command (e.g., ['script.js'])"),
         env: z
-            .record(EnvExpandedString())
+            .record(z.string(), EnvExpandedString())
             .default({})
             .describe('Optional environment variables for the server process'),
         timeout: z.coerce.number().int().positive().default(30000),
@@ -79,7 +79,7 @@ export const SseServerConfigSchema = z
             .default(true)
             .describe('Whether this server is enabled (disabled servers are not connected)'),
         url: RequiredEnvURL(process.env).describe('URL for the SSE server endpoint'),
-        headers: z.record(EnvExpandedString()).default({}),
+        headers: z.record(z.string(), EnvExpandedString()).default({}),
         timeout: z.coerce.number().int().positive().default(30000),
         connectionMode: z.enum(MCP_CONNECTION_MODES).default(DEFAULT_MCP_CONNECTION_MODE),
     })
@@ -97,7 +97,7 @@ export const HttpServerConfigSchema = z
             .default(true)
             .describe('Whether this server is enabled (disabled servers are not connected)'),
         url: RequiredEnvURL(process.env).describe('URL for the HTTP server'),
-        headers: z.record(EnvExpandedString()).default({}),
+        headers: z.record(z.string(), EnvExpandedString()).default({}),
         timeout: z.coerce.number().int().positive().default(30000),
         connectionMode: z.enum(MCP_CONNECTION_MODES).default(DEFAULT_MCP_CONNECTION_MODE),
     })
@@ -122,7 +122,7 @@ export type McpServerConfig = z.input<typeof McpServerConfigSchema>;
 export type ValidatedMcpServerConfig = z.output<typeof McpServerConfigSchema>;
 
 export const ServersConfigSchema = z
-    .record(McpServerConfigSchema)
+    .record(z.string(), McpServerConfigSchema)
     .describe('A dictionary of server configurations, keyed by server name')
     .brand<'ValidatedServersConfig'>();
 

--- a/packages/core/src/systemPrompt/schemas.test.ts
+++ b/packages/core/src/systemPrompt/schemas.test.ts
@@ -135,11 +135,10 @@ You can help with:
             };
             const result = SystemPromptConfigSchema.safeParse(invalidStatic);
             expect(result.success).toBe(false);
-            // For union schemas, the actual error is in unionErrors[1] (second branch - the object branch)
-            // TODO: Fix typing - unionErrors not properly typed in Zod
-            const unionError = result.error?.issues[0] as any;
+            const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors = unionError?.unionErrors?.[1]?.issues;
+            const objectErrors =
+                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
             expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'content']);
             expect(objectErrors?.[0]?.code).toBe('invalid_type');
         });
@@ -158,13 +157,12 @@ You can help with:
             };
             const result = SystemPromptConfigSchema.safeParse(invalidDynamic);
             expect(result.success).toBe(false);
-            // For union schemas, the actual error is in unionErrors[1] (second branch - the object branch)
-            // TODO: Fix typing - unionErrors not properly typed in Zod
-            const unionError = result.error?.issues[0] as any;
+            const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors = unionError?.unionErrors?.[1]?.issues;
+            const objectErrors =
+                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
             expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'source']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_type');
+            expect(objectErrors?.[0]?.code).toBe('invalid_value');
         });
 
         it('should validate dynamic contributor source enum', () => {
@@ -185,13 +183,12 @@ You can help with:
             };
             const result = SystemPromptConfigSchema.safeParse(invalidSource);
             expect(result.success).toBe(false);
-            // For union schemas, the actual error is in unionErrors[1] (second branch - the object branch)
-            // TODO: Fix typing - unionErrors not properly typed in Zod
-            const unionError = result.error?.issues[0] as any;
+            const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors = unionError?.unionErrors?.[1]?.issues;
+            const objectErrors =
+                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
             expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'source']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_enum_value');
+            expect(objectErrors?.[0]?.code).toBe('invalid_value');
         });
 
         it('should validate file contributors', () => {
@@ -233,13 +230,12 @@ You can help with:
                 ],
             });
             expect(result.success).toBe(false);
-            // For union schemas, the actual error is in unionErrors[1] (second branch - the object branch)
-            // TODO: Fix typing - unionErrors not properly typed in Zod
-            const unionError = result.error?.issues[0] as any;
+            const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors = unionError?.unionErrors?.[1]?.issues;
+            const objectErrors =
+                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
             expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'type']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_union_discriminator');
+            expect(objectErrors?.[0]?.code).toBe('invalid_union');
         });
 
         it('should reject extra fields with strict validation', () => {
@@ -248,7 +244,11 @@ You can help with:
                 unknownField: 'should fail',
             });
             expect(result.success).toBe(false);
-            expect(result.error?.issues[0]?.code).toBe('unrecognized_keys');
+            const unionError = result.error?.issues[0];
+            expect(unionError?.code).toBe('invalid_union');
+            const objectErrors =
+                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
+            expect(objectErrors?.[0]?.code).toBe('unrecognized_keys');
         });
     });
 
@@ -331,7 +331,11 @@ You can help with:
 
             const result = SystemPromptConfigSchema.parse(complexConfig);
             expect(result.contributors).toHaveLength(3);
-            expect(result.contributors.map((c) => c.id)).toEqual(['main', 'context', 'date']);
+            expect(Array.from(result.contributors, (contributor) => contributor.id)).toEqual([
+                'main',
+                'context',
+                'date',
+            ]);
         });
 
         it('should handle template-style configuration', () => {

--- a/packages/core/src/systemPrompt/schemas.test.ts
+++ b/packages/core/src/systemPrompt/schemas.test.ts
@@ -1,10 +1,39 @@
 import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
 import * as path from 'path';
 import {
     SystemPromptConfigSchema,
     type SystemPromptConfig,
     type ValidatedSystemPromptConfig,
 } from './schemas.js';
+
+function flattenNestedIssues(issues: readonly z.core.$ZodIssue[]): z.core.$ZodIssue[] {
+    return issues.flatMap((issue) => {
+        if (issue.code === 'invalid_union') {
+            return [issue, ...flattenNestedIssues(issue.errors.flat())];
+        }
+
+        return [issue];
+    });
+}
+
+function findNestedIssue(
+    unionIssue: z.core.$ZodIssue | undefined,
+    expectedPath: Array<string | number>,
+    expectedCode?: string
+): z.core.$ZodIssue | undefined {
+    if (!unionIssue || unionIssue.code !== 'invalid_union') {
+        return undefined;
+    }
+
+    return flattenNestedIssues(unionIssue.errors.flat()).find((issue) => {
+        const matchesPath =
+            issue.path.length === expectedPath.length &&
+            issue.path.every((segment, index) => segment === expectedPath[index]);
+        const matchesCode = expectedCode ? issue.code === expectedCode : true;
+        return matchesPath && matchesCode;
+    });
+}
 
 describe('SystemPromptConfigSchema', () => {
     describe('String Input Transform', () => {
@@ -45,7 +74,7 @@ You can help with:
             expect(result.contributors).toHaveLength(1);
             const contributor = result.contributors[0];
             if (contributor?.type === 'static') {
-                expect((contributor! as any).content).toBe(multilinePrompt);
+                expect(contributor.content).toBe(multilinePrompt);
             }
         });
     });
@@ -137,10 +166,9 @@ You can help with:
             expect(result.success).toBe(false);
             const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors =
-                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
-            expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'content']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_type');
+            const nestedIssue = findNestedIssue(unionError, ['contributors', 0, 'content']);
+            expect(nestedIssue?.path).toEqual(['contributors', 0, 'content']);
+            expect(nestedIssue?.code).toBe('invalid_type');
         });
 
         it('should validate dynamic contributors', () => {
@@ -159,10 +187,9 @@ You can help with:
             expect(result.success).toBe(false);
             const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors =
-                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
-            expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'source']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_value');
+            const nestedIssue = findNestedIssue(unionError, ['contributors', 0, 'source']);
+            expect(nestedIssue?.path).toEqual(['contributors', 0, 'source']);
+            expect(nestedIssue?.code).toBe('invalid_value');
         });
 
         it('should validate dynamic contributor source enum', () => {
@@ -185,10 +212,9 @@ You can help with:
             expect(result.success).toBe(false);
             const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors =
-                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
-            expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'source']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_value');
+            const nestedIssue = findNestedIssue(unionError, ['contributors', 0, 'source']);
+            expect(nestedIssue?.path).toEqual(['contributors', 0, 'source']);
+            expect(nestedIssue?.code).toBe('invalid_value');
         });
 
         it('should validate file contributors', () => {
@@ -232,10 +258,13 @@ You can help with:
             expect(result.success).toBe(false);
             const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors =
-                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
-            expect(objectErrors?.[0]?.path).toEqual(['contributors', 0, 'type']);
-            expect(objectErrors?.[0]?.code).toBe('invalid_union');
+            const nestedIssue = findNestedIssue(
+                unionError,
+                ['contributors', 0, 'type'],
+                'invalid_union'
+            );
+            expect(nestedIssue?.path).toEqual(['contributors', 0, 'type']);
+            expect(nestedIssue?.code).toBe('invalid_union');
         });
 
         it('should reject extra fields with strict validation', () => {
@@ -246,9 +275,8 @@ You can help with:
             expect(result.success).toBe(false);
             const unionError = result.error?.issues[0];
             expect(unionError?.code).toBe('invalid_union');
-            const objectErrors =
-                unionError?.code === 'invalid_union' ? unionError.errors[1] : undefined;
-            expect(objectErrors?.[0]?.code).toBe('unrecognized_keys');
+            const nestedIssue = findNestedIssue(unionError, [], 'unrecognized_keys');
+            expect(nestedIssue?.code).toBe('unrecognized_keys');
         });
     });
 

--- a/packages/core/src/systemPrompt/schemas.ts
+++ b/packages/core/src/systemPrompt/schemas.ts
@@ -85,7 +85,7 @@ const FileContributorSchema = BaseContributorSchema.extend({
         })
         .strict()
         .optional()
-        .default({}),
+        .prefault({}),
 }).strict();
 
 export const ContributorConfigSchema = z
@@ -93,15 +93,7 @@ export const ContributorConfigSchema = z
         'type', // The field to discriminate on
         [StaticContributorSchema, DynamicContributorSchema, FileContributorSchema],
         {
-            // Optional: Custom error message for invalid discriminator
-            errorMap: (issue, ctx) => {
-                if (issue.code === z.ZodIssueCode.invalid_union_discriminator) {
-                    return {
-                        message: `Invalid contributor type. Expected 'static', 'dynamic', or 'file'. Note: memory contributors are now configured via the top-level 'memories' config.`,
-                    };
-                }
-                return { message: ctx.defaultError };
-            },
+            error: `Invalid contributor type. Expected 'static', 'dynamic', or 'file'. Note: memory contributors are now configured via the top-level 'memories' config.`,
         }
     )
     .describe(

--- a/packages/core/src/telemetry/schemas.ts
+++ b/packages/core/src/telemetry/schemas.ts
@@ -38,7 +38,7 @@ export const OtelConfigurationSchema = z.object({
                         z.string().regex(/^[\w.-]+:\d+$/), // host:port
                     ])
                     .optional(),
-                headers: z.record(z.string()).optional(),
+                headers: z.record(z.string(), z.string()).optional(),
             }),
             z.object({
                 type: z.literal('console'),

--- a/packages/core/src/tools/schemas.test.ts
+++ b/packages/core/src/tools/schemas.test.ts
@@ -20,7 +20,7 @@ describe('PermissionsConfigSchema', () => {
 
             const invalidResult = PermissionsConfigSchema.safeParse({ mode: 'invalid' });
             expect(invalidResult.success).toBe(false);
-            expect(invalidResult.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+            expect(invalidResult.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(invalidResult.error?.issues[0]?.path).toEqual(['mode']);
         });
 
@@ -63,7 +63,7 @@ describe('PermissionsConfigSchema', () => {
                 allowedToolsStorage: 'invalid',
             });
             expect(invalidResult.success).toBe(false);
-            expect(invalidResult.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_enum_value);
+            expect(invalidResult.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(invalidResult.error?.issues[0]?.path).toEqual(['allowedToolsStorage']);
         });
     });
@@ -150,13 +150,13 @@ describe('PermissionsConfigSchema', () => {
             // Number should fail
             let result = PermissionsConfigSchema.safeParse({ mode: 123 });
             expect(result.success).toBe(false);
-            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_type);
+            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(result.error?.issues[0]?.path).toEqual(['mode']);
 
             // Null should fail
             result = PermissionsConfigSchema.safeParse({ mode: null });
             expect(result.success).toBe(false);
-            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_type);
+            expect(result.error?.issues[0]?.code).toBe(z.ZodIssueCode.invalid_value);
             expect(result.error?.issues[0]?.path).toEqual(['mode']);
         });
 

--- a/packages/core/src/tools/schemas.ts
+++ b/packages/core/src/tools/schemas.ts
@@ -102,7 +102,7 @@ export const ToolLimitsSchema = z
     .strict();
 
 export const ToolsConfigSchema = z
-    .record(ToolLimitsSchema)
+    .record(z.string(), ToolLimitsSchema)
     .describe('Per-tool configuration limits');
 
 export type ToolsConfig = z.output<typeof ToolsConfigSchema>;

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -34,7 +34,7 @@ describe('zodToIssues', () => {
                 expect(issues).toHaveLength(1);
                 expect(issues[0]).toMatchObject({
                     code: 'schema_validation',
-                    message: 'Expected number, received string',
+                    message: 'Invalid input: expected number, received string',
                     path: ['age'],
                     severity: 'error',
                     scope: ErrorScope.AGENT,
@@ -126,7 +126,13 @@ describe('zodToIssues', () => {
             if (!result.success) {
                 const issues = zodToIssues(result.error);
                 expect(issues.length).toBeGreaterThan(0);
-                expect(issues.some((i) => i.path?.includes('field'))).toBe(true);
+                expect(
+                    issues.some(
+                        (i) =>
+                            i.message === 'Invalid input: expected string, received boolean' ||
+                            i.message === 'Invalid input: expected number, received boolean'
+                    )
+                ).toBe(true);
             }
         });
 
@@ -175,11 +181,11 @@ describe('zodToIssues', () => {
         });
 
         test('should handle fallback when no union errors are collected', () => {
-            // Create a manual ZodError with invalid_union but empty unionErrors
+            // Create a manual ZodError with invalid_union but empty nested errors
             const error = new ZodError([
                 {
                     code: 'invalid_union',
-                    unionErrors: [] as ZodError[],
+                    errors: [] as z.core.$ZodIssue[][],
                     path: ['field'],
                     message: 'Invalid union type',
                 } as any,

--- a/packages/core/src/utils/result.test.ts
+++ b/packages/core/src/utils/result.test.ts
@@ -182,14 +182,14 @@ describe('zodToIssues', () => {
 
         test('should handle fallback when no union errors are collected', () => {
             // Create a manual ZodError with invalid_union but empty nested errors
-            const error = new ZodError([
-                {
-                    code: 'invalid_union',
-                    errors: [] as z.core.$ZodIssue[][],
-                    path: ['field'],
-                    message: 'Invalid union type',
-                } as any,
-            ]);
+            const emptyUnionErrors: z.core.$ZodIssue[][] = [];
+            const invalidUnionIssue = {
+                code: 'invalid_union',
+                errors: emptyUnionErrors,
+                path: ['field'],
+                message: 'Invalid union type',
+            } satisfies z.core.$ZodIssue;
+            const error = new ZodError([invalidUnionIssue]);
 
             const issues = zodToIssues(error);
             expect(issues).toHaveLength(1);

--- a/packages/core/src/utils/result.ts
+++ b/packages/core/src/utils/result.ts
@@ -1,5 +1,5 @@
 // schemas/helpers.ts
-import { z, type ZodError } from 'zod';
+import { z, ZodError } from 'zod';
 import type { DextoErrorCode, Issue } from '../errors/types.js';
 import { ErrorScope, ErrorType } from '../errors/types.js';
 
@@ -234,17 +234,20 @@ export function zodToIssues<C = unknown>(
     severity: 'error' | 'warning' = 'error'
 ): Issue<C>[] {
     const issues: Issue<C>[] = [];
+    const normalizePath = (path: PropertyKey[]): Array<string | number> =>
+        path.filter((segment): segment is string | number => {
+            return typeof segment === 'string' || typeof segment === 'number';
+        });
 
-    for (const e of err.errors) {
-        // Handle invalid_union errors by extracting the actual validation errors from unionErrors
-        if (e.code === 'invalid_union' && (e as any).unionErrors) {
-            const unionErrors = (e as any).unionErrors as ZodError[];
-            // Iterate through ALL union errors to capture validation issues from every union branch
+    for (const e of err.issues) {
+        // Handle invalid_union errors by extracting the nested validation issues from each union branch
+        if (e.code === 'invalid_union' && 'errors' in e) {
+            const unionErrors = e.errors;
+            // Iterate through ALL union branch issue sets to capture validation issues from every branch
             let hasCollectedErrors = false;
-            for (const unionError of unionErrors) {
-                if (unionError && unionError.errors && unionError.errors.length > 0) {
-                    // Recursively process each union branch's errors
-                    issues.push(...zodToIssues<C>(unionError, severity));
+            for (const unionIssueSet of unionErrors) {
+                if (unionIssueSet.length > 0) {
+                    issues.push(...zodToIssues<C>(new ZodError(unionIssueSet), severity));
                     hasCollectedErrors = true;
                 }
             }
@@ -257,7 +260,7 @@ export function zodToIssues<C = unknown>(
                     message: e.message,
                     scope: params.scope ?? ErrorScope.AGENT,
                     type: params.type ?? ErrorType.USER,
-                    path: e.path,
+                    path: normalizePath(e.path),
                     severity,
                     context: params as C,
                 });
@@ -270,7 +273,7 @@ export function zodToIssues<C = unknown>(
                 message: e.message,
                 scope: params.scope ?? ErrorScope.AGENT,
                 type: params.type ?? ErrorType.USER,
-                path: e.path,
+                path: normalizePath(e.path),
                 severity,
                 context: params as C,
             });

--- a/packages/core/src/utils/schema.test.ts
+++ b/packages/core/src/utils/schema.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import type { Logger } from '../logger/v2/types.js';
+import { convertZodSchemaToJsonSchema } from './schema.js';
+
+function createMockLogger(): Logger {
+    const logger: Logger = {
+        debug: vi.fn(),
+        silly: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        createChild: vi.fn(() => logger),
+        createFileOnlyChild: vi.fn(() => logger),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'debug' as const),
+        getLogFilePath: vi.fn(() => null),
+        destroy: vi.fn(async () => undefined),
+    };
+
+    return logger;
+}
+
+describe('convertZodSchemaToJsonSchema', () => {
+    it('emits defaulted optional fields in input mode so they stay optional', () => {
+        const logger = createMockLogger();
+        const schema = z
+            .object({
+                command: z.string(),
+                timeout: z.number().int().positive().optional().default(120000),
+                run_in_background: z.boolean().optional().default(false),
+            })
+            .strict();
+
+        const jsonSchema = convertZodSchemaToJsonSchema(schema, logger);
+
+        expect(jsonSchema.required).toEqual(['command']);
+        expect(jsonSchema.properties).toMatchObject({
+            command: { type: 'string' },
+            timeout: { type: 'integer', default: 120000 },
+            run_in_background: { type: 'boolean', default: false },
+        });
+    });
+});

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -1,21 +1,17 @@
-import { zodToJsonSchema } from 'zod-to-json-schema';
+import { z } from 'zod';
 import type { JSONSchema7 } from 'json-schema';
-import type { ZodSchema } from 'zod';
 import type { Logger } from '../logger/v2/types.js';
 
 /**
  * Convert Zod schema to JSON Schema format for tool parameters
  *
- * TODO: Replace zod-to-json-schema with Zod v4 native JSON schema support
- * The zod-to-json-schema package is deprecated and adds ~19MB due to a packaging bug
- * (includes test files with full Zod copies in dist-test-v3 and dist-test-v4 folders).
- * Zod v4 has native toJsonSchema() support - migrate when upgrading to Zod v4.
- * See: https://github.com/StefanTerdell/zod-to-json-schema
  */
-export function convertZodSchemaToJsonSchema(zodSchema: ZodSchema, logger: Logger): JSONSchema7 {
+export function convertZodSchemaToJsonSchema(zodSchema: z.ZodType, logger: Logger): JSONSchema7 {
     try {
-        // Use proper library for Zod to JSON Schema conversion
-        const converted = zodToJsonSchema(zodSchema) as unknown;
+        const converted = z.toJSONSchema(zodSchema, {
+            target: 'draft-07',
+            unrepresentable: 'any',
+        }) as unknown;
         if (converted && typeof converted === 'object') {
             return converted as JSONSchema7;
         }

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -9,6 +9,7 @@ import type { Logger } from '../logger/v2/types.js';
 export function convertZodSchemaToJsonSchema(zodSchema: z.ZodType, logger: Logger): JSONSchema7 {
     try {
         const converted = z.toJSONSchema(zodSchema, {
+            io: 'input',
             target: 'draft-07',
             unrepresentable: 'any',
         }) as unknown;

--- a/packages/core/src/utils/zod-schema-converter.test.ts
+++ b/packages/core/src/utils/zod-schema-converter.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { getZodTypeFromProperty, jsonSchemaToZodShape } from './zod-schema-converter.js';
+
+describe('zod-schema-converter', () => {
+    it('preserves nullable JSON Schema types regardless of null position', () => {
+        const stringOrNull = getZodTypeFromProperty({ type: ['string', 'null'] });
+        const numberOrNull = getZodTypeFromProperty({ type: ['null', 'number'] });
+
+        expect(stringOrNull.safeParse('hello').success).toBe(true);
+        expect(stringOrNull.safeParse(null).success).toBe(true);
+        expect(stringOrNull.safeParse(123).success).toBe(false);
+
+        expect(numberOrNull.safeParse(42).success).toBe(true);
+        expect(numberOrNull.safeParse(null).success).toBe(true);
+        expect(numberOrNull.safeParse('nope').success).toBe(false);
+    });
+
+    it('preserves nullable object properties and array items when building shapes', () => {
+        const schema = z.object(
+            jsonSchemaToZodShape({
+                type: 'object',
+                properties: {
+                    name: {
+                        type: ['string', 'null'],
+                        description: 'Display name',
+                    },
+                    tags: {
+                        type: 'array',
+                        items: {
+                            type: ['null', 'string'],
+                        },
+                    },
+                },
+                required: ['name', 'tags'],
+            })
+        );
+
+        expect(
+            schema.safeParse({
+                name: null,
+                tags: ['alpha', null],
+            }).success
+        ).toBe(true);
+    });
+});

--- a/packages/core/src/utils/zod-schema-converter.test.ts
+++ b/packages/core/src/utils/zod-schema-converter.test.ts
@@ -6,6 +6,7 @@ describe('zod-schema-converter', () => {
     it('preserves nullable JSON Schema types regardless of null position', () => {
         const stringOrNull = getZodTypeFromProperty({ type: ['string', 'null'] });
         const numberOrNull = getZodTypeFromProperty({ type: ['null', 'number'] });
+        const stringNumberOrNull = getZodTypeFromProperty({ type: ['string', 'number', 'null'] });
 
         expect(stringOrNull.safeParse('hello').success).toBe(true);
         expect(stringOrNull.safeParse(null).success).toBe(true);
@@ -14,6 +15,11 @@ describe('zod-schema-converter', () => {
         expect(numberOrNull.safeParse(42).success).toBe(true);
         expect(numberOrNull.safeParse(null).success).toBe(true);
         expect(numberOrNull.safeParse('nope').success).toBe(false);
+
+        expect(stringNumberOrNull.safeParse('hello').success).toBe(true);
+        expect(stringNumberOrNull.safeParse(42).success).toBe(true);
+        expect(stringNumberOrNull.safeParse(null).success).toBe(true);
+        expect(stringNumberOrNull.safeParse(false).success).toBe(false);
     });
 
     it('preserves nullable object properties and array items when building shapes', () => {

--- a/packages/core/src/utils/zod-schema-converter.ts
+++ b/packages/core/src/utils/zod-schema-converter.ts
@@ -1,74 +1,58 @@
 import { z } from 'zod';
+import type { JSONSchema7, JSONSchema7Definition, JSONSchema7TypeName } from 'json-schema';
+
+function isJsonSchemaObject(schema: unknown): schema is JSONSchema7 {
+    return !!schema && typeof schema === 'object' && !Array.isArray(schema);
+}
+
+function getJsonSchemaType(schema: JSONSchema7): JSONSchema7TypeName | undefined {
+    const { type } = schema;
+    return Array.isArray(type) ? type[0] : type;
+}
+
+function getPropertySchema(
+    schema: JSONSchema7Definition | JSONSchema7Definition[] | undefined
+): JSONSchema7 | null {
+    return isJsonSchemaObject(schema) ? schema : null;
+}
 
 /**
  * Converts a JSON Schema object to a Zod raw shape.
  * This is a simplified converter that handles common MCP tool schemas.
  */
-export function jsonSchemaToZodShape(jsonSchema: any): z.ZodRawShape {
-    if (!jsonSchema || typeof jsonSchema !== 'object' || jsonSchema.type !== 'object') {
+export function jsonSchemaToZodShape(jsonSchema: unknown): z.ZodRawShape {
+    if (!isJsonSchemaObject(jsonSchema) || getJsonSchemaType(jsonSchema) !== 'object') {
         return {};
     }
 
-    const shape: z.ZodRawShape = {};
+    const shape: Record<string, z.ZodType> = {};
 
-    if (jsonSchema.properties) {
-        for (const [key, property] of Object.entries(jsonSchema.properties)) {
-            const propSchema = property as any;
-            let zodType: z.ZodTypeAny;
-            switch (propSchema.type) {
-                case 'string':
-                    zodType = z.string();
-                    break;
-                case 'number':
-                    zodType = z.number();
-                    break;
-                case 'integer':
-                    zodType = z.number().int();
-                    break;
-                case 'boolean':
-                    zodType = z.boolean();
-                    break;
-                case 'array':
-                    if (propSchema.items) {
-                        const itemType = getZodTypeFromProperty(propSchema.items);
-                        zodType = z.array(itemType);
-                    } else {
-                        zodType = z.array(z.any());
-                    }
-                    break;
-                case 'object':
-                    zodType = z.object(jsonSchemaToZodShape(propSchema));
-                    break;
-                default:
-                    zodType = z.any();
-            }
+    const properties = jsonSchema.properties ?? {};
+    for (const [key, property] of Object.entries(properties)) {
+        const propSchema = getPropertySchema(property);
+        let zodType = propSchema ? getZodTypeFromProperty(propSchema) : z.unknown();
 
-            // Add description if present using custom metadata
-            if (propSchema.description) {
-                // Try to add description as custom property (this might get picked up by the SDK)
-                (zodType as any)._def.description = propSchema.description;
-                zodType = zodType.describe(propSchema.description);
-            }
-
-            // Make optional if not in required array
-            if (!jsonSchema.required || !jsonSchema.required.includes(key)) {
-                zodType = zodType.optional();
-            }
-
-            shape[key] = zodType;
+        if (propSchema?.description) {
+            zodType = zodType.describe(propSchema.description);
         }
+
+        if (!Array.isArray(jsonSchema.required) || !jsonSchema.required.includes(key)) {
+            zodType = zodType.optional();
+        }
+
+        shape[key] = zodType;
     }
 
-    return shape;
+    return shape as z.ZodRawShape;
 }
 
 /**
  * Helper function to get a Zod type from a property schema
  */
-export function getZodTypeFromProperty(propSchema: any): z.ZodTypeAny {
-    let zodType: z.ZodTypeAny;
+export function getZodTypeFromProperty(propSchema: JSONSchema7): z.ZodType {
+    let zodType: z.ZodType;
 
-    switch (propSchema.type) {
+    switch (getJsonSchemaType(propSchema)) {
         case 'string':
             zodType = z.string();
             break;
@@ -85,20 +69,23 @@ export function getZodTypeFromProperty(propSchema: any): z.ZodTypeAny {
             zodType = z.object(jsonSchemaToZodShape(propSchema));
             break;
         case 'array':
-            if (propSchema.items) {
-                zodType = z.array(getZodTypeFromProperty(propSchema.items));
-            } else {
-                zodType = z.array(z.any());
+            {
+                const itemSchema = getPropertySchema(propSchema.items);
+                if (itemSchema) {
+                    zodType = z.array(getZodTypeFromProperty(itemSchema));
+                } else {
+                    zodType = z.array(z.unknown());
+                }
             }
             break;
+        case 'null':
+            zodType = z.null();
+            break;
         default:
-            zodType = z.any();
+            zodType = z.unknown();
     }
 
-    // Add description if present using custom metadata
     if (propSchema.description) {
-        // Try to add description as custom property (this might get picked up by the SDK)
-        (zodType as any)._def.description = propSchema.description;
         zodType = zodType.describe(propSchema.description);
     }
 

--- a/packages/core/src/utils/zod-schema-converter.ts
+++ b/packages/core/src/utils/zod-schema-converter.ts
@@ -22,6 +22,32 @@ function hasNullableJsonSchemaType(schema: JSONSchema7): boolean {
     return getJsonSchemaTypes(schema).includes('null');
 }
 
+function getZodTypeForJsonSchemaType(
+    propSchema: JSONSchema7,
+    type: JSONSchema7TypeName | undefined
+): z.ZodType {
+    switch (type) {
+        case 'string':
+            return z.string();
+        case 'number':
+            return z.number();
+        case 'integer':
+            return z.number().int();
+        case 'boolean':
+            return z.boolean();
+        case 'object':
+            return z.object(jsonSchemaToZodShape(propSchema));
+        case 'array': {
+            const itemSchema = getPropertySchema(propSchema.items);
+            return z.array(itemSchema ? getZodTypeFromProperty(itemSchema) : z.unknown());
+        }
+        case 'null':
+            return z.null();
+        default:
+            return z.unknown();
+    }
+}
+
 function getPropertySchema(
     schema: JSONSchema7Definition | JSONSchema7Definition[] | undefined
 ): JSONSchema7 | null {
@@ -58,43 +84,24 @@ export function jsonSchemaToZodShape(jsonSchema: unknown): z.ZodRawShape {
  * Helper function to get a Zod type from a property schema
  */
 export function getZodTypeFromProperty(propSchema: JSONSchema7): z.ZodType {
-    let zodType: z.ZodType;
-    const primaryType = getJsonSchemaType(propSchema);
+    const nonNullTypes = getJsonSchemaTypes(propSchema).filter(
+        (type): type is Exclude<JSONSchema7TypeName, 'null'> => type !== 'null'
+    );
 
-    switch (primaryType) {
-        case 'string':
-            zodType = z.string();
-            break;
-        case 'number':
-            zodType = z.number();
-            break;
-        case 'integer':
-            zodType = z.number().int();
-            break;
-        case 'boolean':
-            zodType = z.boolean();
-            break;
-        case 'object':
-            zodType = z.object(jsonSchemaToZodShape(propSchema));
-            break;
-        case 'array':
-            {
-                const itemSchema = getPropertySchema(propSchema.items);
-                if (itemSchema) {
-                    zodType = z.array(getZodTypeFromProperty(itemSchema));
-                } else {
-                    zodType = z.array(z.unknown());
-                }
-            }
-            break;
-        case 'null':
-            zodType = z.null();
-            break;
-        default:
+    let zodType: z.ZodType;
+    if (nonNullTypes.length === 0) {
+        zodType = hasNullableJsonSchemaType(propSchema) ? z.null() : z.unknown();
+    } else {
+        const zodTypes = nonNullTypes.map((type) => getZodTypeForJsonSchemaType(propSchema, type));
+        const [firstType, secondType, ...restTypes] = zodTypes;
+        if (!firstType) {
             zodType = z.unknown();
+        } else {
+            zodType = secondType ? z.union([firstType, secondType, ...restTypes]) : firstType;
+        }
     }
 
-    if (hasNullableJsonSchemaType(propSchema) && primaryType !== 'null') {
+    if (hasNullableJsonSchemaType(propSchema) && nonNullTypes.length > 0) {
         zodType = zodType.nullable();
     }
 

--- a/packages/core/src/utils/zod-schema-converter.ts
+++ b/packages/core/src/utils/zod-schema-converter.ts
@@ -5,9 +5,21 @@ function isJsonSchemaObject(schema: unknown): schema is JSONSchema7 {
     return !!schema && typeof schema === 'object' && !Array.isArray(schema);
 }
 
-function getJsonSchemaType(schema: JSONSchema7): JSONSchema7TypeName | undefined {
+function getJsonSchemaTypes(schema: JSONSchema7): JSONSchema7TypeName[] {
     const { type } = schema;
-    return Array.isArray(type) ? type[0] : type;
+    if (Array.isArray(type)) {
+        return type;
+    }
+    return type ? [type] : [];
+}
+
+function getJsonSchemaType(schema: JSONSchema7): JSONSchema7TypeName | undefined {
+    const types = getJsonSchemaTypes(schema);
+    return types.find((type) => type !== 'null') ?? types[0];
+}
+
+function hasNullableJsonSchemaType(schema: JSONSchema7): boolean {
+    return getJsonSchemaTypes(schema).includes('null');
 }
 
 function getPropertySchema(
@@ -32,10 +44,6 @@ export function jsonSchemaToZodShape(jsonSchema: unknown): z.ZodRawShape {
         const propSchema = getPropertySchema(property);
         let zodType = propSchema ? getZodTypeFromProperty(propSchema) : z.unknown();
 
-        if (propSchema?.description) {
-            zodType = zodType.describe(propSchema.description);
-        }
-
         if (!Array.isArray(jsonSchema.required) || !jsonSchema.required.includes(key)) {
             zodType = zodType.optional();
         }
@@ -51,8 +59,9 @@ export function jsonSchemaToZodShape(jsonSchema: unknown): z.ZodRawShape {
  */
 export function getZodTypeFromProperty(propSchema: JSONSchema7): z.ZodType {
     let zodType: z.ZodType;
+    const primaryType = getJsonSchemaType(propSchema);
 
-    switch (getJsonSchemaType(propSchema)) {
+    switch (primaryType) {
         case 'string':
             zodType = z.string();
             break;
@@ -83,6 +92,10 @@ export function getZodTypeFromProperty(propSchema: JSONSchema7): z.ZodType {
             break;
         default:
             zodType = z.unknown();
+    }
+
+    if (hasNullableJsonSchemaType(propSchema) && primaryType !== 'null') {
+        zodType = zodType.nullable();
     }
 
     if (propSchema.description) {

--- a/packages/image-local/package.json
+++ b/packages/image-local/package.json
@@ -38,7 +38,7 @@
         "@dexto/tools-process": "workspace:*",
         "@dexto/tools-scheduler": "workspace:*",
         "@dexto/tools-todo": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/image-logger-agent/package.json
+++ b/packages/image-logger-agent/package.json
@@ -30,7 +30,7 @@
         "@dexto/agent-management": "workspace:*",
         "@dexto/core": "workspace:*",
         "@dexto/image-local": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/orchestration/package.json
+++ b/packages/orchestration/package.json
@@ -26,7 +26,7 @@
     ],
     "dependencies": {
         "@dexto/core": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,7 @@
     "@dexto/storage": "workspace:*",
     "@dexto/tools-scheduler": "workspace:*",
     "@hono/node-server": "1.19.13",
-    "@hono/zod-openapi": "^0.19.1",
+    "@hono/zod-openapi": "^1.3.0",
     "hono": "^4.12.12",
     "ws": "^8.18.1",
     "yaml": "^2.8.3",
@@ -55,9 +55,9 @@
   "sideEffects": false,
   "devDependencies": {
     "@types/ws": "^8.5.11",
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "zod": "^3.25.0"
+    "zod": "^4.3.6"
   }
 }

--- a/packages/server/src/hono/routes/a2a-tasks.ts
+++ b/packages/server/src/hono/routes/a2a-tasks.ts
@@ -282,7 +282,7 @@ const MessageSendRequestSchema = z
                     .object({
                         url: z.string().describe('Push notification webhook URL'),
                         headers: z
-                            .record(z.string())
+                            .record(z.string(), z.string())
                             .optional()
                             .describe('HTTP headers for webhook'),
                     })

--- a/packages/server/src/hono/routes/agents.ts
+++ b/packages/server/src/hono/routes/agents.ts
@@ -956,9 +956,9 @@ export function createAgentsRouter(
 
             if (!validationResult.success) {
                 throw new DextoValidationError(
-                    validationResult.error.issues.map((err) => ({
+                    zodToIssues(validationResult.error).map((err) => ({
                         code: AgentErrorCode.INVALID_CONFIG,
-                        message: `${err.path.join('.')}: ${err.message}`,
+                        message: `${err.path?.join('.') || 'root'}: ${err.message}`,
                         scope: ErrorScope.AGENT,
                         type: ErrorType.USER,
                         severity: 'error',

--- a/packages/server/src/hono/routes/agents.ts
+++ b/packages/server/src/hono/routes/agents.ts
@@ -956,7 +956,7 @@ export function createAgentsRouter(
 
             if (!validationResult.success) {
                 throw new DextoValidationError(
-                    validationResult.error.errors.map((err) => ({
+                    validationResult.error.issues.map((err) => ({
                         code: AgentErrorCode.INVALID_CONFIG,
                         message: `${err.path.join('.')}: ${err.message}`,
                         scope: ErrorScope.AGENT,

--- a/packages/server/src/hono/routes/llm.ts
+++ b/packages/server/src/hono/routes/llm.ts
@@ -259,7 +259,7 @@ const catalogRoute = createRoute({
                             z
                                 .object({
                                     providers: z
-                                        .record(z.enum(LLM_PROVIDERS), ProviderCatalogSchema)
+                                        .record(z.string(), ProviderCatalogSchema)
                                         .describe(
                                             'Providers grouped by ID with their models and capabilities'
                                         ),

--- a/packages/server/src/hono/routes/llm.ts
+++ b/packages/server/src/hono/routes/llm.ts
@@ -259,7 +259,7 @@ const catalogRoute = createRoute({
                             z
                                 .object({
                                     providers: z
-                                        .record(z.string(), ProviderCatalogSchema)
+                                        .partialRecord(z.enum(LLM_PROVIDERS), ProviderCatalogSchema)
                                         .describe(
                                             'Providers grouped by ID with their models and capabilities'
                                         ),
@@ -876,7 +876,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
             const includeModels = queryParams.includeModels ?? true;
             const scope = queryParams.scope ?? 'all';
 
-            const providers: Record<string, ProviderCatalog> = {};
+            const providers: Partial<Record<LLMProvider, ProviderCatalog>> = {};
 
             for (const provider of LLM_PROVIDERS) {
                 // Skip dexto-nova provider when feature is not enabled
@@ -912,7 +912,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                 };
             }
 
-            let filtered: Record<string, ProviderCatalog> = { ...providers };
+            let filtered: Partial<Record<LLMProvider, ProviderCatalog>> = { ...providers };
 
             if (queryParams.provider && queryParams.provider.length > 0) {
                 const allowed = new Set(
@@ -920,27 +920,27 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                         (LLM_PROVIDERS as readonly string[]).includes(p)
                     )
                 );
-                const filteredByProvider: Record<string, ProviderCatalog> = {};
+                const filteredByProvider: Partial<Record<LLMProvider, ProviderCatalog>> = {};
                 for (const [id, catalog] of Object.entries(filtered)) {
                     if (allowed.has(id)) {
-                        filteredByProvider[id] = catalog;
+                        filteredByProvider[id as LLMProvider] = catalog;
                     }
                 }
                 filtered = filteredByProvider;
             }
 
             if (typeof queryParams.hasKey === 'boolean') {
-                const byKey: Record<string, ProviderCatalog> = {};
+                const byKey: Partial<Record<LLMProvider, ProviderCatalog>> = {};
                 for (const [id, catalog] of Object.entries(filtered)) {
                     if (catalog.hasApiKey === queryParams.hasKey) {
-                        byKey[id] = catalog;
+                        byKey[id as LLMProvider] = catalog;
                     }
                 }
                 filtered = byKey;
             }
 
             if (queryParams.fileType) {
-                const byFileType: Record<string, ProviderCatalog> = {};
+                const byFileType: Partial<Record<LLMProvider, ProviderCatalog>> = {};
                 for (const [id, catalog] of Object.entries(filtered)) {
                     const models = catalog.models.filter((model) => {
                         const modelTypes =
@@ -951,18 +951,18 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                         return modelTypes.includes(queryParams.fileType!);
                     });
                     if (models.length > 0) {
-                        byFileType[id] = { ...catalog, models };
+                        byFileType[id as LLMProvider] = { ...catalog, models };
                     }
                 }
                 filtered = byFileType;
             }
 
             if (queryParams.defaultOnly) {
-                const byDefault: Record<string, ProviderCatalog> = {};
+                const byDefault: Partial<Record<LLMProvider, ProviderCatalog>> = {};
                 for (const [id, catalog] of Object.entries(filtered)) {
                     const models = catalog.models.filter((model) => model.default === true);
                     if (models.length > 0) {
-                        byDefault[id] = { ...catalog, models };
+                        byDefault[id as LLMProvider] = { ...catalog, models };
                     }
                 }
                 filtered = byDefault;

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -26,7 +26,7 @@
     ],
     "dependencies": {
         "@dexto/core": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "peerDependencies": {
         "better-sqlite3": "^11.10.0",

--- a/packages/storage/src/blob/factory.ts
+++ b/packages/storage/src/blob/factory.ts
@@ -13,7 +13,7 @@ export interface BlobStoreFactory<TConfig = unknown> {
      * Zod schema for validating factory-specific configuration.
      * The schema must output the `TConfig` type.
      */
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
 
     /**
      * Factory function to create a BlobStore instance.

--- a/packages/storage/src/cache/factory.ts
+++ b/packages/storage/src/cache/factory.ts
@@ -13,7 +13,7 @@ export interface CacheFactory<TConfig = unknown> {
      * Zod schema for validating factory-specific configuration.
      * The schema must output the `TConfig` type.
      */
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
 
     /**
      * Factory function to create a Cache instance.

--- a/packages/storage/src/cache/schemas.ts
+++ b/packages/storage/src/cache/schemas.ts
@@ -18,7 +18,7 @@ const BaseCacheSchema = z.object({
         .positive()
         .optional()
         .describe('Connection timeout in milliseconds'),
-    options: z.record(z.unknown()).optional().describe('Backend-specific options'),
+    options: z.record(z.string(), z.unknown()).optional().describe('Backend-specific options'),
 });
 
 // Memory cache - minimal configuration

--- a/packages/storage/src/database/factory.ts
+++ b/packages/storage/src/database/factory.ts
@@ -13,7 +13,7 @@ export interface DatabaseFactory<TConfig = unknown> {
      * Zod schema for validating factory-specific configuration.
      * The schema must output the `TConfig` type.
      */
-    configSchema: z.ZodType<TConfig, z.ZodTypeDef, unknown>;
+    configSchema: z.ZodType<TConfig, unknown>;
 
     /**
      * Factory function to create a Database instance.

--- a/packages/storage/src/database/schemas.ts
+++ b/packages/storage/src/database/schemas.ts
@@ -18,7 +18,7 @@ const BaseDatabaseSchema = z.object({
         .positive()
         .optional()
         .describe('Connection timeout in milliseconds'),
-    options: z.record(z.unknown()).optional().describe('Backend-specific options'),
+    options: z.record(z.string(), z.unknown()).optional().describe('Backend-specific options'),
 });
 
 // Memory database - minimal configuration

--- a/packages/tools-builtins/package.json
+++ b/packages/tools-builtins/package.json
@@ -25,7 +25,7 @@
         "@dexto/agent-config": "workspace:*",
         "@dexto/core": "workspace:*",
         "undici": "^7.24.6",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/tools-builtins/src/implementations/ask-user-tool.test.ts
+++ b/packages/tools-builtins/src/implementations/ask-user-tool.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ToolExecutionContext } from '@dexto/core';
+import { createAskUserTool } from './ask-user-tool.js';
+
+describe('createAskUserTool', () => {
+    it('accepts boolean property schemas and leaves them untouched during title enrichment', async () => {
+        const tool = createAskUserTool();
+        const getElicitationData = vi.fn().mockResolvedValue({ ok: true });
+        const context = {
+            services: {
+                approval: {
+                    getElicitationData,
+                },
+            },
+        } as unknown as ToolExecutionContext;
+
+        const input = tool.inputSchema.parse({
+            question: 'Collect profile settings',
+            schema: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
+                    },
+                    ignored: true,
+                },
+                required: ['name'],
+            },
+        });
+
+        await tool.execute(input, context);
+
+        expect(getElicitationData).toHaveBeenCalledWith({
+            prompt: 'Collect profile settings',
+            schema: {
+                type: 'object',
+                properties: {
+                    name: {
+                        type: 'string',
+                        title: 'Name',
+                    },
+                    ignored: true,
+                },
+                required: ['name'],
+            },
+            serverName: 'Dexto Agent',
+        });
+    });
+});

--- a/packages/tools-builtins/src/implementations/ask-user-tool.ts
+++ b/packages/tools-builtins/src/implementations/ask-user-tool.ts
@@ -12,7 +12,7 @@ const AskUserInputSchema = z
         schema: z
             .object({
                 type: z.literal('object'),
-                properties: z.record(z.string(), z.record(z.unknown())),
+                properties: z.record(z.string(), z.record(z.string(), z.unknown())),
                 required: z.array(z.string()).optional(),
             })
             .passthrough()

--- a/packages/tools-builtins/src/implementations/ask-user-tool.ts
+++ b/packages/tools-builtins/src/implementations/ask-user-tool.ts
@@ -12,7 +12,12 @@ const AskUserInputSchema = z
         schema: z
             .object({
                 type: z.literal('object'),
-                properties: z.record(z.string(), z.record(z.string(), z.unknown())),
+                // JSON Schema properties can be object schemas or boolean schemas.
+                // enrichSchemaTitles and parseElicitationSchema both skip non-object entries safely.
+                properties: z.record(
+                    z.string(),
+                    z.union([z.boolean(), z.record(z.string(), z.unknown())])
+                ),
                 required: z.array(z.string()).optional(),
             })
             .passthrough()

--- a/packages/tools-builtins/src/implementations/http-request-tool.ts
+++ b/packages/tools-builtins/src/implementations/http-request-tool.ts
@@ -21,15 +21,15 @@ const HttpRequestInputSchema = z
             .default('GET')
             .describe('HTTP method to use'),
         headers: z
-            .record(z.string())
+            .record(z.string(), z.string())
             .optional()
             .describe('Optional request headers (string values only)'),
         query: z
-            .record(z.string())
+            .record(z.string(), z.string())
             .optional()
             .describe('Optional query parameters to append to the URL'),
         body: z
-            .union([z.string(), z.record(z.unknown()), z.array(z.unknown())])
+            .union([z.string(), z.record(z.string(), z.unknown()), z.array(z.unknown())])
             .optional()
             .describe('Optional request body (string or JSON-serializable value)'),
         timeoutMs: z

--- a/packages/tools-builtins/src/implementations/invoke-skill-tool.ts
+++ b/packages/tools-builtins/src/implementations/invoke-skill-tool.ts
@@ -16,7 +16,10 @@ const InvokeSkillInputSchema = z
             .describe(
                 'The name of the skill to invoke (e.g., "plugin-name:skill-name" or "skill-name")'
             ),
-        args: z.record(z.string()).optional().describe('Optional arguments to pass to the skill'),
+        args: z
+            .record(z.string(), z.string())
+            .optional()
+            .describe('Optional arguments to pass to the skill'),
         taskContext: z
             .string()
             .optional()

--- a/packages/tools-filesystem/package.json
+++ b/packages/tools-filesystem/package.json
@@ -28,7 +28,7 @@
         "diff": "^8.0.3",
         "glob": "^12.0.0",
         "safe-regex": "^2.1.1",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "@types/diff": "^5.2.3",

--- a/packages/tools-lifecycle/package.json
+++ b/packages/tools-lifecycle/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@dexto/agent-config": "workspace:*",
         "@dexto/core": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/tools-plan/package.json
+++ b/packages/tools-plan/package.json
@@ -26,7 +26,7 @@
         "@dexto/agent-config": "workspace:*",
         "@dexto/core": "workspace:*",
         "diff": "^8.0.3",
-        "zod": "^3.24.1"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "@types/diff": "^7.0.0",

--- a/packages/tools-process/package.json
+++ b/packages/tools-process/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@dexto/agent-config": "workspace:*",
         "@dexto/core": "workspace:*",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/tools-process/src/tool-factory-config.ts
+++ b/packages/tools-process/src/tool-factory-config.ts
@@ -79,7 +79,7 @@ export const ProcessToolsConfigSchema = z
             .default(DEFAULT_BLOCKED_COMMANDS)
             .describe('Blocked command patterns (applies to all security levels)'),
         environment: z
-            .record(z.string())
+            .record(z.string(), z.string())
             .default(DEFAULT_ENVIRONMENT)
             .describe('Custom environment variables to set for command execution'),
     })

--- a/packages/tools-scheduler/package.json
+++ b/packages/tools-scheduler/package.json
@@ -36,7 +36,7 @@
         "@dexto/core": "workspace:*",
         "cron-parser": "^4.9.0",
         "node-cron": "^4.2.1",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/tools-scheduler/src/schemas.ts
+++ b/packages/tools-scheduler/src/schemas.ts
@@ -69,7 +69,10 @@ export const CreateScheduleInputSchema = z
             ),
         timezone: z.string().optional().describe('Optional timezone (defaults to config timezone)'),
         enabled: z.boolean().default(true).describe('Whether schedule is enabled'),
-        metadata: z.record(z.unknown()).optional().describe('Optional metadata for the task'),
+        metadata: z
+            .record(z.string(), z.unknown())
+            .optional()
+            .describe('Optional metadata for the task'),
         workspacePath: z
             .string()
             .optional()
@@ -122,7 +125,7 @@ const UpdateScheduleFieldsSchema = z
             .describe('Updated instruction - what should happen when this schedule triggers'),
         timezone: z.string().optional().describe('Updated timezone'),
         enabled: z.boolean().optional().describe('Updated enabled state'),
-        metadata: z.record(z.unknown()).optional().describe('Updated metadata'),
+        metadata: z.record(z.string(), z.unknown()).optional().describe('Updated metadata'),
         workspacePath: z
             .string()
             .optional()

--- a/packages/tools-todo/package.json
+++ b/packages/tools-todo/package.json
@@ -26,7 +26,7 @@
         "@dexto/agent-config": "workspace:*",
         "@dexto/core": "workspace:*",
         "nanoid": "^5.0.9",
-        "zod": "^3.25.0"
+        "zod": "^4.3.6"
     },
     "devDependencies": {
         "tsup": "^8.0.0",

--- a/packages/webui/components/AgentEditor/FormEditorTabs.tsx
+++ b/packages/webui/components/AgentEditor/FormEditorTabs.tsx
@@ -307,7 +307,11 @@ function ModelTab({ config, onChange, errors }: TabProps) {
                             >
                                 <Input
                                     type="number"
-                                    value={config.llm?.maxOutputTokens ?? ''}
+                                    value={
+                                        typeof config.llm?.maxOutputTokens === 'number'
+                                            ? config.llm.maxOutputTokens
+                                            : ''
+                                    }
                                     onChange={(e) =>
                                         updateLLM({
                                             maxOutputTokens: e.target.value

--- a/packages/webui/components/AgentEditor/form-sections/LLMConfigSection.tsx
+++ b/packages/webui/components/AgentEditor/form-sections/LLMConfigSection.tsx
@@ -47,6 +47,13 @@ export function LLMConfigSection({
         onChange({ ...value, [field]: newValue });
     };
 
+    const maxIterationsValue = typeof value.maxIterations === 'number' ? value.maxIterations : '';
+    const temperatureValue = typeof value.temperature === 'number' ? value.temperature : '';
+    const maxInputTokensValue =
+        typeof value.maxInputTokens === 'number' ? value.maxInputTokens : '';
+    const maxOutputTokensValue =
+        typeof value.maxOutputTokens === 'number' ? value.maxOutputTokens : '';
+
     return (
         <Collapsible
             title="LLM Configuration"
@@ -175,7 +182,7 @@ export function LLMConfigSection({
                     <Input
                         id="maxIterations"
                         type="number"
-                        value={value.maxIterations !== undefined ? value.maxIterations : ''}
+                        value={maxIterationsValue}
                         onChange={(e) => {
                             const val = e.target.value;
                             if (val === '') {
@@ -229,7 +236,7 @@ export function LLMConfigSection({
                     <Input
                         id="temperature"
                         type="number"
-                        value={value.temperature !== undefined ? value.temperature : ''}
+                        value={temperatureValue}
                         onChange={(e) =>
                             handleChange(
                                 'temperature',
@@ -259,7 +266,7 @@ export function LLMConfigSection({
                         <Input
                             id="maxInputTokens"
                             type="number"
-                            value={value.maxInputTokens || ''}
+                            value={maxInputTokensValue}
                             onChange={(e) =>
                                 handleChange(
                                     'maxInputTokens',
@@ -286,7 +293,7 @@ export function LLMConfigSection({
                         <Input
                             id="maxOutputTokens"
                             type="number"
-                            value={value.maxOutputTokens || ''}
+                            value={maxOutputTokensValue}
                             onChange={(e) =>
                                 handleChange(
                                     'maxOutputTokens',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,7 +113,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.28.0(zod@3.25.76)
+        version: 1.28.0(zod@4.3.6)
 
   packages/agent-config:
     dependencies:
@@ -124,8 +124,8 @@ importers:
         specifier: workspace:*
         version: link:../storage
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.13.5
@@ -149,8 +149,8 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^22.13.5
@@ -208,7 +208,7 @@ importers:
         version: link:../tui
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.28.0(zod@3.25.76)
+        version: 1.28.0(zod@4.3.6)
       '@opentelemetry/core':
         specifier: ^1.28.0
         version: 1.30.1(@opentelemetry/api@1.9.0)
@@ -285,8 +285,8 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/ws':
         specifier: ^8.5.11
@@ -321,40 +321,40 @@ importers:
     dependencies:
       '@ai-sdk/amazon-bedrock':
         specifier: ^3.0.71
-        version: 3.0.73(zod@3.25.76)
+        version: 3.0.73(zod@4.3.6)
       '@ai-sdk/anthropic':
         specifier: ^2.0.65
-        version: 2.0.65(zod@3.25.76)
+        version: 2.0.65(zod@4.3.6)
       '@ai-sdk/cohere':
         specifier: ^2.0.0
-        version: 2.0.22(zod@3.25.76)
+        version: 2.0.22(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^2.0.0
-        version: 2.0.52(zod@3.25.76)
+        version: 2.0.52(zod@4.3.6)
       '@ai-sdk/google-vertex':
         specifier: ^3.0.94
-        version: 3.0.97(zod@3.25.76)
+        version: 3.0.97(zod@4.3.6)
       '@ai-sdk/groq':
         specifier: ^2.0.0
-        version: 2.0.34(zod@3.25.76)
+        version: 2.0.34(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^2.0.0
-        version: 2.0.89(zod@3.25.76)
+        version: 2.0.89(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^1.0.30
-        version: 1.0.30(zod@3.25.76)
+        version: 1.0.30(zod@4.3.6)
       '@ai-sdk/provider':
         specifier: ^2.0.0
         version: 2.0.1
       '@ai-sdk/xai':
         specifier: ^2.0.0
-        version: 2.0.44(zod@3.25.76)
+        version: 2.0.44(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.28.0(zod@3.25.76)
+        version: 1.28.0(zod@4.3.6)
       '@openrouter/ai-sdk-provider':
         specifier: ^1.5.4
-        version: 1.5.4(ai@5.0.118(zod@3.25.76))(zod@3.25.76)
+        version: 1.5.4(ai@5.0.118(zod@4.3.6))(zod@4.3.6)
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
@@ -369,7 +369,7 @@ importers:
         version: 0.55.0(@opentelemetry/api@1.9.0)
       ai:
         specifier: ^5.0.0
-        version: 5.0.118(zod@3.25.76)
+        version: 5.0.118(zod@4.3.6)
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -406,9 +406,6 @@ importers:
       yaml:
         specifier: ^2.8.3
         version: 2.8.3
-      zod-to-json-schema:
-        specifier: ^3.24.6
-        version: 3.24.6(zod@3.25.76)
     devDependencies:
       '@opentelemetry/instrumentation-http':
         specifier: ^0.210.0
@@ -435,8 +432,8 @@ importers:
         specifier: ^7.0.15
         version: 7.0.15
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/image-bundler:
     dependencies:
@@ -502,8 +499,8 @@ importers:
         specifier: workspace:*
         version: link:../tools-todo
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -527,8 +524,8 @@ importers:
         specifier: workspace:*
         version: link:../image-local
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -543,8 +540,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -586,11 +583,11 @@ importers:
         specifier: 1.19.13
         version: 1.19.13(hono@4.12.12)
       '@hono/zod-openapi':
-        specifier: ^0.19.1
-        version: 0.19.10(hono@4.12.12)(zod@3.25.76)
+        specifier: ^1.3.0
+        version: 1.3.0(hono@4.12.12)(zod@4.3.6)
       '@modelcontextprotocol/sdk':
         specifier: ^1.25.2
-        version: 1.28.0(zod@3.25.76)
+        version: 1.28.0(zod@4.3.6)
       hono:
         specifier: ^4.12.12
         version: 4.12.12
@@ -605,8 +602,8 @@ importers:
         specifier: ^8.5.11
         version: 8.18.1
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
 
   packages/storage:
     dependencies:
@@ -623,8 +620,8 @@ importers:
         specifier: ^8.15.4
         version: 8.16.3
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -645,8 +642,8 @@ importers:
         specifier: ^7.24.6
         version: 7.24.6
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -673,8 +670,8 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/diff':
         specifier: ^5.2.3
@@ -698,8 +695,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -723,8 +720,8 @@ importers:
         specifier: ^8.0.3
         version: 8.0.3
       zod:
-        specifier: ^3.24.1
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/diff':
         specifier: ^7.0.0
@@ -754,8 +751,8 @@ importers:
         specifier: workspace:*
         version: link:../core
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -779,8 +776,8 @@ importers:
         specifier: ^4.2.1
         version: 4.2.1
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -801,8 +798,8 @@ importers:
         specifier: ^5.0.9
         version: 5.1.6
       zod:
-        specifier: ^3.25.0
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       tsup:
         specifier: ^8.0.0
@@ -897,7 +894,7 @@ importers:
         version: link:../storage
       '@mcp-ui/client':
         specifier: ^5.14.1
-        version: 5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)
+        version: 5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@4.3.6)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.53.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -1134,10 +1131,10 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@asteasolutions/zod-to-openapi@7.3.4':
-    resolution: {integrity: sha512-/2rThQ5zPi9OzVwes6U7lK1+Yvug0iXu25olp7S0XsYmOqnyMfxH7gdSQjn/+DSOHRg7wnotwGJSyL+fBKdnEA==}
+  '@asteasolutions/zod-to-openapi@8.5.0':
+    resolution: {integrity: sha512-SABbKiObg5dLRiTFnqiW1WWwGcg1BJfmHtT2asIBnBHg6Smy/Ms2KHc650+JI4Hw7lSkdiNebEGXpwoxfben8Q==}
     peerDependencies:
-      zod: ^3.20.2
+      zod: ^4.0.0
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -2170,15 +2167,15 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/zod-openapi@0.19.10':
-    resolution: {integrity: sha512-dpoS6DenvoJyvxtQ7Kd633FRZ/Qf74+4+o9s+zZI8pEqnbjdF/DtxIib08WDpCaWabMEJOL5TXpMgNEZvb7hpA==}
+  '@hono/zod-openapi@1.3.0':
+    resolution: {integrity: sha512-loDVevfMaaNa0slskhpMcqjSdidVXba2QJwNVmnS5Dp6L8AqSgtjJxWGJfRZtosyzYOb5gx4ZzXNCe+QhwY7xw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       hono: '>=4.3.6'
-      zod: '>=3.0.0'
+      zod: ^4.0.0
 
-  '@hono/zod-validator@0.7.4':
-    resolution: {integrity: sha512-biKGn3BRJVaftZlIPMyK+HCe/UHAjJ6sH0UyXe3+v0OcgVr9xfImDROTJFLtn9e3XEEAHGZIM9U6evu85abm8Q==}
+  '@hono/zod-validator@0.7.6':
+    resolution: {integrity: sha512-Io1B6d011Gj1KknV4rXYz4le5+5EubcWEU/speUjuw9XMMIaP3n78yXLhjd2A3PXaXaUwEAluOiAyLqhBEJgsw==}
     peerDependencies:
       hono: '>=3.9.0'
       zod: ^3.25.0 || ^4.0.0
@@ -7144,11 +7141,6 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
-  zod-to-json-schema@3.24.6:
-    resolution: {integrity: sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==}
-    peerDependencies:
-      zod: ^3.24.1
-
   zod-to-json-schema@3.25.1:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
@@ -7160,8 +7152,8 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
@@ -7186,100 +7178,100 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/amazon-bedrock@3.0.73(zod@3.25.76)':
+  '@ai-sdk/amazon-bedrock@3.0.73(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.57(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.57(zod@4.3.6)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
       '@smithy/eventstream-codec': 4.2.7
       '@smithy/util-utf8': 4.2.0
       aws4fetch: 1.0.20
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@ai-sdk/anthropic@2.0.57(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.57(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/anthropic@2.0.65(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.65(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.21(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.21(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/cohere@2.0.22(zod@3.25.76)':
+  '@ai-sdk/cohere@2.0.22(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/gateway@2.0.24(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.24(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
       '@vercel/oidc': 3.0.5
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@ai-sdk/google-vertex@3.0.97(zod@3.25.76)':
+  '@ai-sdk/google-vertex@3.0.97(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.57(zod@3.25.76)
-      '@ai-sdk/google': 2.0.52(zod@3.25.76)
+      '@ai-sdk/anthropic': 2.0.57(zod@4.3.6)
+      '@ai-sdk/google': 2.0.52(zod@4.3.6)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
       google-auth-library: 10.5.0
-      zod: 3.25.76
+      zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/google@2.0.52(zod@3.25.76)':
+  '@ai-sdk/google@2.0.52(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/groq@2.0.34(zod@3.25.76)':
+  '@ai-sdk/groq@2.0.34(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/openai-compatible@1.0.30(zod@3.25.76)':
+  '@ai-sdk/openai-compatible@1.0.30(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/openai@2.0.89(zod@3.25.76)':
+  '@ai-sdk/openai@2.0.89(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
-  '@ai-sdk/provider-utils@3.0.20(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.20(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@ai-sdk/provider-utils@3.0.21(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.21(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@ai-sdk/provider@2.0.1':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/xai@2.0.44(zod@3.25.76)':
+  '@ai-sdk/xai@2.0.44(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/openai-compatible': 1.0.30(zod@3.25.76)
+      '@ai-sdk/openai-compatible': 1.0.30(zod@4.3.6)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
+      zod: 4.3.6
 
   '@alcalzone/ansi-tokenize@0.2.2':
     dependencies:
@@ -7293,10 +7285,10 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
 
-  '@asteasolutions/zod-to-openapi@7.3.4(zod@3.25.76)':
+  '@asteasolutions/zod-to-openapi@8.5.0(zod@4.3.6)':
     dependencies:
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -8079,18 +8071,18 @@ snapshots:
     dependencies:
       hono: 4.12.12
 
-  '@hono/zod-openapi@0.19.10(hono@4.12.12)(zod@3.25.76)':
+  '@hono/zod-openapi@1.3.0(hono@4.12.12)(zod@4.3.6)':
     dependencies:
-      '@asteasolutions/zod-to-openapi': 7.3.4(zod@3.25.76)
-      '@hono/zod-validator': 0.7.4(hono@4.12.12)(zod@3.25.76)
+      '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.3.6)
+      '@hono/zod-validator': 0.7.6(hono@4.12.12)(zod@4.3.6)
       hono: 4.12.12
       openapi3-ts: 4.5.0
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@hono/zod-validator@0.7.4(hono@4.12.12)(zod@3.25.76)':
+  '@hono/zod-validator@0.7.6(hono@4.12.12)(zod@4.3.6)':
     dependencies:
       hono: 4.12.12
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@humanfs/core@0.19.1': {}
 
@@ -8210,9 +8202,9 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-ui/client@5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@3.25.76)':
+  '@mcp-ui/client@5.14.1(@preact/signals-core@1.12.1)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(zod@4.3.6)':
     dependencies:
-      '@modelcontextprotocol/sdk': 1.28.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.28.0(zod@4.3.6)
       '@quilted/threads': 3.3.1(@preact/signals-core@1.12.1)
       '@r2wc/react-to-web-component': 2.1.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@remote-dom/core': 1.10.1(@preact/signals-core@1.12.1)
@@ -8226,7 +8218,7 @@ snapshots:
       - supports-color
       - zod
 
-  '@modelcontextprotocol/sdk@1.28.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.28.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.11(hono@4.12.9)
       ajv: 8.18.0
@@ -8243,8 +8235,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -8273,15 +8265,15 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@openrouter/ai-sdk-provider@1.5.4(ai@5.0.118(zod@3.25.76))(zod@3.25.76)':
+  '@openrouter/ai-sdk-provider@1.5.4(ai@5.0.118(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@openrouter/sdk': 0.1.27
-      ai: 5.0.118(zod@3.25.76)
-      zod: 3.25.76
+      ai: 5.0.118(zod@4.3.6)
+      zod: 4.3.6
 
   '@openrouter/sdk@0.1.27':
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
   '@opentelemetry/api-logs@0.210.0':
     dependencies:
@@ -9655,14 +9647,6 @@ snapshots:
     optionalDependencies:
       vite: 7.1.4(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.3)
 
-  '@vitest/mocker@3.2.4(vite@7.1.4(@types/node@22.19.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.18
-    optionalDependencies:
-      vite: 7.1.4(@types/node@22.19.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.3)
-
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -9758,13 +9742,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.118(zod@3.25.76):
+  ai@5.0.118(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 2.0.24(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.24(zod@4.3.6)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.20(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.3.6
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -10470,8 +10454,8 @@ snapshots:
       '@babel/parser': 7.28.3
       eslint: 9.34.0(jiti@2.5.1)
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.3.6
+      zod-validation-error: 4.0.2(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -13453,7 +13437,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@22.19.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.1.4(@types/node@20.19.11)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -13610,19 +13594,15 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.76):
+  zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod-to-json-schema@3.25.1(zod@3.25.76):
+  zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  zod-validation-error@4.0.2(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
+  zod@4.3.6: {}
 
   zustand@5.0.8(@types/react@19.1.12)(immer@10.2.0)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
       '@types/node':
         specifier: ^22.13.5
         version: 22.19.0
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/agent-management:
     dependencies:


### PR DESCRIPTION
## Summary
- upgrade the workspace to Zod 4 and update `@hono/zod-openapi` for compatibility
- replace deprecated Zod 3 patterns with Zod 4 APIs across core, server, CLI, TUI, and WebUI
- switch the Zod-to-JSON-Schema path to native `z.toJSONSchema()` and keep the JSON-Schema-to-Zod adapter for MCP tool aggregation
- add regression coverage for YAML parsing, env expansion, and nested default behavior
- regenerate the OpenAPI artifact after the schema changes

## Validation
- `pnpm exec vitest run packages/agent-config/src/schemas/agent-config.test.ts packages/core/src/systemPrompt/schemas.test.ts packages/core/src/mcp/schemas.test.ts packages/core/src/llm/schemas.test.ts packages/core/src/tools/schemas.test.ts packages/core/src/utils/result.test.ts`
- `./scripts/quality-checks.sh`

Closes #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Upgraded Zod v3 → v4 across packages and added a YAML parser to dev dependencies.

* **Validation Improvements**
  * Tightened many schemas to require string keys and stricter header/metadata types; error reporting now uses Zod v4 issues for clearer messages.

* **Compatibility**
  * YAML parsing and environment-variable expansion preserved; defaults maintained.

* **Internal Improvements**
  * Switched to Zod’s native JSON Schema conversion.

* **Bug Fixes**
  * Numeric form inputs now correctly preserve zero values.

* **Tests**
  * Expanded tests for YAML, schema conversion, and validation message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->