### PR TITLE
fix(cli): remove unused --no-inject-preferences flag causing Zod error

### DIFF
--- a/.changeset/tough-camels-chew.md
+++ b/.changeset/tough-camels-chew.md
@@ -1,0 +1,5 @@
+---
+'@dexto/cli': patch
+---
+
+fix: remove unused --no-inject-preferences flag from agents install

--- a/packages/cli/src/cli/commands/agents/install.ts
+++ b/packages/cli/src/cli/commands/agents/install.ts
@@ -15,6 +15,7 @@ const InstallCommandSchema = z
         agents: z.array(z.string().min(1, 'Agent name cannot be empty')),
         all: z.boolean().default(false),
         force: z.boolean().default(false),
+        injectPreferences: z.boolean().default(true),
     })
     .strict();
 

--- a/packages/cli/src/cli/commands/agents/install.ts
+++ b/packages/cli/src/cli/commands/agents/install.ts
@@ -15,7 +15,6 @@ const InstallCommandSchema = z
         agents: z.array(z.string().min(1, 'Agent name cannot be empty')),
         all: z.boolean().default(false),
         force: z.boolean().default(false),
-        injectPreferences: z.boolean().default(true),
     })
     .strict();
 

--- a/packages/cli/src/cli/commands/agents/register.ts
+++ b/packages/cli/src/cli/commands/agents/register.ts
@@ -16,10 +16,6 @@ export function registerAgentsCommand({ program }: AgentsCommandRegisterContext)
         .command('install [agents...]')
         .description('Install agents from registry or custom YAML files/directories')
         .option('--all', 'Install all available agents from registry')
-        .option(
-            '--no-inject-preferences',
-            'Skip injecting global preferences into installed agents'
-        )
         .option('--force', 'Force reinstall even if agent is already installed')
         .addHelpText(
             'after',


### PR DESCRIPTION
## Bug Description
The `dexto agents install` command was failing with a Zod 'unrecognized_keys' error for `injectPreferences`.

## Root Cause
Commander.js automatically includes boolean flags in the options object. The `--no-inject-preferences` flag was registered in `register.ts`, but the `InstallCommandSchema` used `.strict()` and did not include this field.

## Changes
- Removed the unused `--no-inject-preferences` flag from `register.ts` as it was dead code not wired into the installation flow.

Resolves #761