### PR TITLE
fix(core): make session history updates append-only

### DIFF
--- a/.changeset/session-history-append-updates.md
+++ b/.changeset/session-history-append-updates.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Persist session message updates append-only to avoid truncating history during rehydration.

--- a/packages/core/src/session/history/database.test.ts
+++ b/packages/core/src/session/history/database.test.ts
@@ -106,4 +106,27 @@ describe('DatabaseHistoryProvider error mapping', () => {
         });
         expect(db.delete).not.toHaveBeenCalled();
     });
+
+    test('flush failure does not overwrite newer pending updates', async () => {
+        const originalMessage = createTextMessage('assistant-1', 'partial');
+        const failedMessage = createTextMessage('assistant-1', 'in flight');
+        const newerMessage = createTextMessage('assistant-1', 'complete');
+        db.getRange.mockResolvedValue([originalMessage]);
+        db.append.mockImplementationOnce(async () => {
+            await provider.updateMessage(newerMessage);
+            throw new Error('append failed');
+        });
+
+        await provider.updateMessage(failedMessage);
+        await expect(provider.flush()).rejects.toMatchObject({
+            code: SessionErrorCode.SESSION_STORAGE_FAILED,
+        });
+
+        db.append.mockResolvedValue(undefined);
+        await provider.flush();
+
+        expect(db.append).toHaveBeenNthCalledWith(1, `messages:${sessionId}`, failedMessage);
+        expect(db.append).toHaveBeenNthCalledWith(2, `messages:${sessionId}`, newerMessage);
+        expect(db.delete).not.toHaveBeenCalled();
+    });
 });

--- a/packages/core/src/session/history/database.test.ts
+++ b/packages/core/src/session/history/database.test.ts
@@ -4,12 +4,18 @@ import type { Database } from '../../storage/types.js';
 import { SessionErrorCode } from '../error-codes.js';
 import { ErrorScope, ErrorType } from '../../errors/types.js';
 import { createMockLogger } from '../../logger/v2/test-utils.js';
+import type { InternalMessage } from '../../context/types.js';
 
 describe('DatabaseHistoryProvider error mapping', () => {
     let db: Mocked<Database>;
     let provider: DatabaseHistoryProvider;
     const sessionId = 's-1';
     const mockLogger = createMockLogger();
+    const createTextMessage = (id: string, content: string): InternalMessage => ({
+        id,
+        role: 'user',
+        content: [{ type: 'text', text: content }],
+    });
 
     beforeEach(() => {
         db = {
@@ -60,5 +66,44 @@ describe('DatabaseHistoryProvider error mapping', () => {
             type: ErrorType.SYSTEM,
             context: expect.objectContaining({ sessionId }),
         });
+    });
+
+    test('getHistory keeps the latest stored version when message IDs repeat', async () => {
+        const originalAssistant = createTextMessage('assistant-1', 'partial');
+        const userMessage = createTextMessage('user-1', 'next');
+        const updatedAssistant = createTextMessage('assistant-1', 'complete');
+        db.getRange.mockResolvedValue([originalAssistant, userMessage, updatedAssistant]);
+
+        await expect(provider.getHistory()).resolves.toEqual([updatedAssistant, userMessage]);
+        expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    test('updateMessage appends the new version without deleting existing history', async () => {
+        const originalMessage = createTextMessage('assistant-1', 'partial');
+        const updatedMessage = createTextMessage('assistant-1', 'complete');
+        db.getRange.mockResolvedValue([originalMessage]);
+
+        await provider.updateMessage(updatedMessage);
+        await provider.flush();
+
+        expect(db.append).toHaveBeenCalledWith(`messages:${sessionId}`, updatedMessage);
+        expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    test('flush maps backend append errors without deleting history', async () => {
+        const originalMessage = createTextMessage('assistant-1', 'partial');
+        const updatedMessage = createTextMessage('assistant-1', 'complete');
+        db.getRange.mockResolvedValue([originalMessage]);
+        db.append.mockRejectedValue(new Error('append failed'));
+
+        await provider.updateMessage(updatedMessage);
+
+        await expect(provider.flush()).rejects.toMatchObject({
+            code: SessionErrorCode.SESSION_STORAGE_FAILED,
+            scope: ErrorScope.SESSION,
+            type: ErrorType.SYSTEM,
+            context: expect.objectContaining({ sessionId }),
+        });
+        expect(db.delete).not.toHaveBeenCalled();
     });
 });

--- a/packages/core/src/session/history/database.ts
+++ b/packages/core/src/session/history/database.ts
@@ -206,6 +206,7 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
 
         this.cancelPendingFlush();
 
+        // Drain updates that arrive while flushPendingUpdates() awaits.
         while (this.pendingUpdates.size > 0) {
             this.flushPromise = this.flushPendingUpdates();
             try {
@@ -225,13 +226,15 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
             `DatabaseHistoryProvider: FLUSH UPDATES key=${key} count=${updates.length} ids=[${updates.map((m) => m.id).join(',')}]`
         );
 
+        let failedIndex = updates.length;
         try {
-            for (const message of updates) {
+            for (const [index, message] of updates.entries()) {
+                failedIndex = index;
                 await this.database.append(key, message);
             }
         } catch (error) {
-            for (const message of updates) {
-                if (message.id) {
+            for (const message of updates.slice(failedIndex)) {
+                if (message.id && !this.pendingUpdates.has(message.id)) {
                     this.pendingUpdates.set(message.id, message);
                 }
             }

--- a/packages/core/src/session/history/database.ts
+++ b/packages/core/src/session/history/database.ts
@@ -13,7 +13,7 @@ import type { ConversationHistoryProvider } from './types.js';
  * - getHistory(): Returns cached messages after first load (eliminates repeated DB reads)
  * - saveMessage(): Updates cache AND writes to DB immediately (new messages are critical)
  * - updateMessage(): Updates cache immediately, debounces DB writes (batches rapid updates)
- * - flush(): Forces all pending updates to DB (called at turn boundaries)
+ * - flush(): Appends the latest pending updates to DB (called at turn boundaries)
  * - clearHistory(): Clears cache and DB immediately
  *
  * Durability guarantees:
@@ -26,7 +26,7 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
 
     // Cache state
     private cache: InternalMessage[] | null = null;
-    private dirty = false;
+    private pendingUpdates = new Map<string, InternalMessage>();
     private flushTimer: ReturnType<typeof setTimeout> | null = null;
     private flushPromise: Promise<void> | null = null;
 
@@ -55,30 +55,28 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
                     );
                 }
 
-                // Deduplicate messages by ID (keep first occurrence to preserve order)
-                const seen = new Set<string>();
+                // Deduplicate message updates by ID: keep the latest version in the original slot.
+                const seenIndexes = new Map<string, number>();
                 this.cache = [];
                 let duplicateCount = 0;
 
                 for (const msg of rawMessages) {
-                    if (msg.id && seen.has(msg.id)) {
+                    const seenIndex = msg.id ? seenIndexes.get(msg.id) : undefined;
+                    if (seenIndex !== undefined) {
                         duplicateCount++;
-                        continue; // Skip duplicate
+                        this.cache[seenIndex] = msg;
+                        continue;
                     }
                     if (msg.id) {
-                        seen.add(msg.id);
+                        seenIndexes.set(msg.id, this.cache.length);
                     }
                     this.cache.push(msg);
                 }
 
-                // Log and self-heal if duplicates found (indicates prior data corruption)
                 if (duplicateCount > 0) {
                     this.logger.warn(
-                        `DatabaseHistoryProvider: Found ${duplicateCount} duplicate messages for session ${this.sessionId}, deduped to ${this.cache.length}`
+                        `DatabaseHistoryProvider: Found ${duplicateCount} duplicate message updates for session ${this.sessionId}, deduped to ${this.cache.length}`
                     );
-                    // Mark dirty to rewrite clean data on next flush
-                    this.dirty = true;
-                    this.scheduleFlush();
                 } else {
                     this.logger.debug(
                         `DatabaseHistoryProvider: Loaded ${this.cache.length} messages for session ${this.sessionId}`
@@ -155,12 +153,14 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
         }
 
         // Update cache immediately (fast, in-memory)
-        const index = this.cache!.findIndex((m) => m.id === message.id);
+        const cache = this.cache;
+        if (cache === null) {
+            return;
+        }
+        const index = cache.findIndex((m) => m.id === message.id);
         if (index !== -1) {
-            this.cache![index] = message;
-            this.dirty = true;
-
-            // Schedule debounced flush
+            cache[index] = message;
+            this.pendingUpdates.set(message.id, message);
             this.scheduleFlush();
 
             this.logger.debug(
@@ -179,7 +179,7 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
 
         // Clear cache
         this.cache = [];
-        this.dirty = false;
+        this.pendingUpdates.clear();
 
         // Clear DB
         const key = this.getMessagesKey();
@@ -199,107 +199,66 @@ export class DatabaseHistoryProvider implements ConversationHistoryProvider {
         }
     }
 
-    /**
-     * Flush any pending updates to the database.
-     * Should be called at turn boundaries to ensure durability.
-     */
     async flush(): Promise<void> {
-        // If a flush is already in progress, wait for it
         if (this.flushPromise) {
             await this.flushPromise;
-            return;
         }
 
-        // Cancel any scheduled flush since we're flushing now
         this.cancelPendingFlush();
 
-        // Nothing to flush
-        if (!this.dirty || !this.cache) {
-            return;
-        }
-
-        // Perform the flush
-        this.flushPromise = this.doFlush();
-        try {
-            await this.flushPromise;
-        } finally {
-            this.flushPromise = null;
+        while (this.pendingUpdates.size > 0) {
+            this.flushPromise = this.flushPendingUpdates();
+            try {
+                await this.flushPromise;
+            } finally {
+                this.flushPromise = null;
+            }
         }
     }
 
-    /**
-     * Internal flush implementation.
-     * Writes entire cache to DB (delete + re-append all).
-     */
-    private async doFlush(): Promise<void> {
-        if (!this.dirty || !this.cache) {
-            return;
-        }
-
+    private async flushPendingUpdates(): Promise<void> {
         const key = this.getMessagesKey();
-
-        // Take a snapshot of cache to avoid race conditions with concurrent saveMessage() calls.
-        // If saveMessage() is called during flush, it will append to the live cache AND write to DB.
-        // By iterating over a snapshot, we avoid re-appending messages that were already written.
-        const snapshot = [...this.cache];
-        const messageCount = snapshot.length;
+        const updates = [...this.pendingUpdates.values()];
+        this.pendingUpdates.clear();
 
         this.logger.debug(
-            `DatabaseHistoryProvider: FLUSH START key=${key} snapshotSize=${messageCount} ids=[${snapshot.map((m) => m.id).join(',')}]`
+            `DatabaseHistoryProvider: FLUSH UPDATES key=${key} count=${updates.length} ids=[${updates.map((m) => m.id).join(',')}]`
         );
 
         try {
-            // Atomic replace: delete all + re-append from snapshot
-            await this.database.delete(key);
-            this.logger.debug(`DatabaseHistoryProvider: FLUSH DELETED key=${key}`);
-
-            for (const msg of snapshot) {
-                await this.database.append(key, msg);
-            }
-            this.logger.debug(
-                `DatabaseHistoryProvider: FLUSH REAPPENDED key=${key} count=${messageCount}`
-            );
-
-            // Only clear dirty if no new updates were scheduled during flush.
-            // If flushTimer exists, updateMessage() was called during the flush,
-            // so keep dirty=true to ensure the scheduled flush persists those updates.
-            if (!this.flushTimer) {
-                this.dirty = false;
+            for (const message of updates) {
+                await this.database.append(key, message);
             }
         } catch (error) {
+            for (const message of updates) {
+                if (message.id) {
+                    this.pendingUpdates.set(message.id, message);
+                }
+            }
             this.logger.error(
-                `DatabaseHistoryProvider: Error flushing messages for session ${this.sessionId}: ${error instanceof Error ? error.message : String(error)}`
+                `DatabaseHistoryProvider: Error flushing message updates for session ${this.sessionId}: ${error instanceof Error ? error.message : String(error)}`
             );
             throw SessionError.storageFailed(
                 this.sessionId,
-                'flush messages',
+                'flush message updates',
                 error instanceof Error ? error.message : String(error)
             );
         }
     }
 
-    /**
-     * Schedule a debounced flush.
-     * Batches rapid updateMessage() calls into a single DB write.
-     */
     private scheduleFlush(): void {
-        // Already scheduled
         if (this.flushTimer) {
             return;
         }
 
         this.flushTimer = setTimeout(() => {
             this.flushTimer = null;
-            // Use flush() instead of doFlush() to respect flushPromise concurrency guard
             this.flush().catch(() => {
-                // Error already logged in doFlush
+                // Error already logged in flushPendingUpdates.
             });
         }, DatabaseHistoryProvider.FLUSH_DELAY_MS);
     }
 
-    /**
-     * Cancel any pending scheduled flush.
-     */
     private cancelPendingFlush(): void {
         if (this.flushTimer) {
             clearTimeout(this.flushTimer);


### PR DESCRIPTION
## Summary
- stop `DatabaseHistoryProvider` from flushing message updates via `delete(messages:<session>)` plus full rewrite
- persist updated messages append-only and rehydrate duplicate message IDs by keeping the latest version in the original slot
- add regression coverage for duplicate rehydration, append-only update flushing, append failure mapping, and in-flight newer-update retry behavior

## Persistence Model
This intentionally changes the physical storage model for message updates. A streamed or otherwise updated assistant/tool message keeps the same logical `message.id`, and each persisted update appends a newer physical record with that same id. On rehydration, `getHistory()` collapses repeated ids and returns one logical message, keeping the latest stored version in the original message position.

That means raw storage can contain multiple rows/list entries for the same message id. This is expected. It is the tradeoff that avoids the previous destructive `delete all -> rewrite cache` flush, which could truncate the entire session if the process restarted, the cache was stale, or another runtime read while the list had been deleted. New messages remain write-through; updates remain debounced, but they no longer make already-persisted history disappear.

This is a durability-first fix. If duplicate physical update records become material for very long streaming sessions, the follow-up should be safe compaction, preferably transactional or backend-aware, rather than returning to destructive rewrite during normal update flushes.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm test packages/core/src/session/history/database.test.ts`
- `pnpm --filter @dexto/core lint`
- `pnpm exec prettier --check packages/core/src/session/history/database.ts packages/core/src/session/history/database.test.ts .changeset/session-history-append-updates.md`
- `pnpm test packages/core/src/session/session-manager.integration.test.ts -- -t "chat history survives session expiry"`
- `pnpm build:server`
- `pnpm exec vitest run packages/server/src/hono/__tests__/api.integration.test.ts -t "GET /api/sessions/:id/history returns session history"`
- custom Hono/server smoke: create session over HTTP, update one assistant message through the real `ContextManager`, confirm raw storage has two physical records with the same logical id, end the in-memory session, then fetch `/api/sessions/:id/history` and verify one logical message with latest content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session message history is now preserved during rehydration by switching to append-only persistence for message updates, preventing loss of prior messages.

* **Tests**
  * Added tests covering message-versioning, persistence behavior, error handling for append failures, and ensuring newer updates aren’t overwritten by older failed writes.

* **Chores**
  * Published a patch changeset to release the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->