### PR TITLE
fix(core): preserve mixed media tool results

### DIFF
--- a/.changeset/little-apples-feel.md
+++ b/.changeset/little-apples-feel.md
@@ -25,4 +25,4 @@
 
 Add media-aware filesystem reads and resource-backed multimodal handling.
 
-This expands supported file type capabilities for audio, video, and document inputs, preserves resource references for history and UI rehydration, and updates prompt/session handling to project multimodal content more reliably across core, server, and WebUI flows.
+This expands supported file type capabilities for audio, video, and document inputs, preserves resource references for history and UI rehydration, and updates prompt/session handling to project multimodal content more reliably across core, server, and WebUI flows. Tool results with mixed text and media are now formatted as structured content parts instead of stringifying media objects into prompt text.

--- a/.changeset/little-apples-feel.md
+++ b/.changeset/little-apples-feel.md
@@ -25,4 +25,4 @@
 
 Add media-aware filesystem reads and resource-backed multimodal handling.
 
-This expands supported file type capabilities for audio, video, and document inputs, preserves resource references for history and UI rehydration, and updates prompt/session handling to project multimodal content more reliably across core, server, and WebUI flows. Tool results with mixed text and media are now formatted as structured content parts instead of stringifying media objects into prompt text.
+This expands supported file type capabilities for audio, video, and document inputs, preserves resource references for history and UI rehydration, and updates prompt/session handling to project multimodal content more reliably across core, server, and WebUI flows.

--- a/.changeset/media-tool-results.md
+++ b/.changeset/media-tool-results.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Preserve mixed text and media tool results as structured content parts instead of stringifying media objects into prompt text, and keep tool-result media payloads base64-only for Vercel AI SDK compatibility.

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -218,6 +218,59 @@ describe('VercelMessageFormatter', () => {
             expect(toolCallPart).toBeDefined();
             expect(toolCallPart!.providerOptions).toEqual(toolProviderOptions);
         });
+
+        test('should preserve mixed text and media tool results as content parts', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    content: [{ type: 'text', text: 'Reading image' }],
+                    toolCalls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-1',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        { type: 'text', text: 'Attached image: blob:abc123' },
+                        { type: 'image', image: 'base64-image-data', mimeType: 'image/png' },
+                        { type: 'text', text: '[Stored resource_ref:blob:abc123]' },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+
+            const toolMessage = result.find((m) => m.role === 'tool');
+            expect(toolMessage).toBeDefined();
+
+            const content = toolMessage!.content as Array<{
+                type: string;
+                output: {
+                    type: string;
+                    value: Array<{ type: string; text?: string; data?: string }>;
+                };
+            }>;
+            const output = content[0]?.output;
+
+            expect(output?.type).toBe('content');
+            expect(output?.value).toEqual([
+                { type: 'text', text: 'Attached image: blob:abc123' },
+                { type: 'media', data: 'base64-image-data', mediaType: 'image/png' },
+                { type: 'text', text: '[Stored resource_ref:blob:abc123]' },
+            ]);
+        });
     });
 
     describe('Reasoning round-trip', () => {

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -271,6 +271,95 @@ describe('VercelMessageFormatter', () => {
                 { type: 'text', text: '[Stored resource_ref:blob:abc123]' },
             ]);
         });
+
+        test('should strip data URI prefixes from tool-result media data', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    content: [{ type: 'text', text: 'Reading image' }],
+                    toolCalls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-1',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        {
+                            type: 'image',
+                            image: 'data:image/png;base64,base64-image-data',
+                            mimeType: 'image/png',
+                        },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+            const toolMessage = result.find((m) => m.role === 'tool');
+            const content = toolMessage!.content as Array<{
+                output: { type: string; value: Array<{ type: string; data?: string }> };
+            }>;
+
+            expect(content[0]?.output.value).toEqual([
+                { type: 'media', data: 'base64-image-data', mediaType: 'image/png' },
+            ]);
+        });
+
+        test('should keep tool-result URL media as text references', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    content: [{ type: 'text', text: 'Reading image' }],
+                    toolCalls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-1',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        {
+                            type: 'image',
+                            image: 'https://example.com/image.png',
+                            mimeType: 'image/png',
+                        },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+            const toolMessage = result.find((m) => m.role === 'tool');
+            const content = toolMessage!.content as Array<{
+                output: { type: string; value: string };
+            }>;
+
+            expect(content[0]?.output).toEqual({
+                type: 'text',
+                value: 'Attached image: https://example.com/image.png',
+            });
+        });
     });
 
     describe('Reasoning round-trip', () => {

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -334,55 +334,54 @@ export class VercelMessageFormatter {
     private formatToolMessage(msg: ToolMessage): { content: ToolContent } {
         let toolResultPart: ToolResultPart;
         if (Array.isArray(msg.content)) {
-            if (msg.content[0]?.type === 'image') {
-                const imagePart = msg.content[0];
-                const imageDataBase64 = getImageData(imagePart, this.logger);
+            const content = msg.content
+                .map((part) => {
+                    if (part.type === 'text') {
+                        return { type: 'text' as const, text: part.text };
+                    }
+                    if (part.type === 'image') {
+                        return {
+                            type: 'media' as const,
+                            data: getImageData(part, this.logger),
+                            mediaType: part.mimeType || 'image/jpeg',
+                        };
+                    }
+                    if (part.type === 'file') {
+                        return {
+                            type: 'media' as const,
+                            data: getFileData(part, this.logger),
+                            mediaType: part.mimeType,
+                        };
+                    }
+                    if (part.type === 'resource') {
+                        return { type: 'text' as const, text: `${part.name}: ${part.uri}` };
+                    }
+                    return null;
+                })
+                .filter((part) => part !== null);
+
+            if (content.some((part) => part.type === 'media')) {
                 toolResultPart = {
                     type: 'tool-result',
                     toolCallId: msg.toolCallId,
                     toolName: msg.name,
                     output: {
                         type: 'content',
-                        value: [
-                            {
-                                type: 'media',
-                                data: imageDataBase64,
-                                mediaType: imagePart.mimeType || 'image/jpeg',
-                            },
-                        ],
-                    },
-                };
-            } else if (msg.content[0]?.type === 'file') {
-                const filePart = msg.content[0];
-                const fileDataBase64 = getFileData(filePart, this.logger);
-                toolResultPart = {
-                    type: 'tool-result',
-                    toolCallId: msg.toolCallId,
-                    toolName: msg.name,
-                    output: {
-                        type: 'content',
-                        value: [
-                            {
-                                type: 'media',
-                                data: fileDataBase64,
-                                mediaType: filePart.mimeType,
-                            },
-                        ],
+                        value: content,
                     },
                 };
             } else {
-                const textContent = Array.isArray(msg.content)
-                    ? msg.content
-                          .map((part) => (part.type === 'text' ? part.text : JSON.stringify(part)))
-                          .join('\n')
-                    : String(msg.content);
                 toolResultPart = {
                     type: 'tool-result',
                     toolCallId: msg.toolCallId,
                     toolName: msg.name,
                     output: {
                         type: 'text',
-                        value: textContent,
+                        value:
+                            content
+                                .filter((part) => part.type === 'text')
+                                .map((part) => part.text)
+                                .join('\n') || '[empty result]',
                     },
                 };
             }

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -1,7 +1,12 @@
 import type { ModelMessage, AssistantContent, ToolContent, ToolResultPart } from 'ai';
 import { LLMContext } from '../types.js';
 import type { InternalMessage, AssistantMessage, ToolMessage } from '../../context/types.js';
-import { getImageData, getFileData, filterMessagesByLLMCapabilities } from '../../context/utils.js';
+import {
+    getImageData,
+    getFileData,
+    filterMessagesByLLMCapabilities,
+    parseDataUri,
+} from '../../context/utils.js';
 import type { Logger } from '../../logger/v2/types.js';
 import { DextoLogComponent } from '../../logger/v2/types.js';
 
@@ -19,6 +24,17 @@ function toUrlIfString<T>(value: T): T | URL {
         }
     }
     return value;
+}
+
+function normalizeToolMediaData(data: string): string | null {
+    const dataUri = parseDataUri(data);
+    if (dataUri) return dataUri.base64;
+
+    if (/^https?:\/\//i.test(data) || data.startsWith('blob:') || data.startsWith('@blob:')) {
+        return null;
+    }
+
+    return data;
 }
 
 /**
@@ -340,16 +356,26 @@ export class VercelMessageFormatter {
                         return { type: 'text' as const, text: part.text };
                     }
                     if (part.type === 'image') {
+                        const data = getImageData(part, this.logger);
+                        const mediaData = normalizeToolMediaData(data);
+                        if (!mediaData) {
+                            return { type: 'text' as const, text: `Attached image: ${data}` };
+                        }
                         return {
                             type: 'media' as const,
-                            data: getImageData(part, this.logger),
+                            data: mediaData,
                             mediaType: part.mimeType || 'image/jpeg',
                         };
                     }
                     if (part.type === 'file') {
+                        const data = getFileData(part, this.logger);
+                        const mediaData = normalizeToolMediaData(data);
+                        if (!mediaData) {
+                            return { type: 'text' as const, text: `Attached file: ${data}` };
+                        }
                         return {
                             type: 'media' as const,
-                            data: getFileData(part, this.logger),
+                            data: mediaData,
                             mediaType: part.mimeType,
                         };
                     }


### PR DESCRIPTION
## Summary
- preserve mixed text/media tool results as structured content parts in the Vercel formatter
- avoid stringifying image/file content into tool-result text when media is preceded by text
- update the media changeset note for maintainers

## Validation
- pnpm exec vitest run packages/core/src/llm/formatters/vercel.test.ts
- pnpm --filter @dexto/core typecheck
- pnpm --filter @dexto/core lint
- pnpm --filter @dexto/core build

Note: an initial root `pnpm test -- packages/core/src/llm/formatters/vercel.test.ts` invocation ran broader repo tests and hit unrelated package entry/dist resolution failures; the targeted Vitest command above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool results containing mixed text and media content, now properly structuring all content elements instead of converting images to text references.
  * Media payloads in tool results are normalized to base64 format for enhanced compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->