### PR TITLE
fix: keep session history blob refs compact

### DIFF
--- a/.changeset/tidy-blobs-rest.md
+++ b/.changeset/tidy-blobs-rest.md
@@ -1,0 +1,7 @@
+---
+'@dexto/core': patch
+'@dexto/server': patch
+'dexto': patch
+---
+
+Keep session history blob references compact for API consumers and avoid rehydrating tool media into later model prompts.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/core/src/context/manager.test.ts
+++ b/packages/core/src/context/manager.test.ts
@@ -276,6 +276,58 @@ describe('ContextManager', () => {
                 { type: 'image', image: 'new-image-data', mimeType: 'image/png' },
             ]);
         });
+
+        it('should not rehydrate tool media for the LLM', async () => {
+            const formatter = createMockFormatter();
+            const resourceManager = {
+                read: vi.fn(async (uri: string) => {
+                    if (uri === 'blob:tool-image') {
+                        return {
+                            contents: [{ blob: 'tool-image-data', mimeType: 'image/png' }],
+                            _meta: { size: 4096, originalName: 'tool-image.png' },
+                        };
+                    }
+                    throw new Error(`Unexpected blob URI: ${uri}`);
+                }),
+                getBlobStore: vi.fn().mockReturnValue(createMockBlobStore()),
+            } as unknown as ResourceManager;
+
+            const contextManager = createContextManager({
+                formatter,
+                resourceManager,
+                llmConfig: {
+                    ...createMockLLMConfig(),
+                    allowedMediaTypes: ['image/*'],
+                } as ValidatedLLMConfig,
+            });
+
+            await contextManager.getFormattedMessages(
+                createMockContributorContext(),
+                { provider: 'openai', model: 'gpt-4' },
+                'System prompt',
+                [
+                    {
+                        role: 'tool',
+                        toolCallId: 'call-tool-image',
+                        name: 'read_media_file',
+                        success: true,
+                        content: [
+                            {
+                                type: 'image',
+                                image: '@blob:tool-image',
+                                mimeType: 'image/png',
+                            },
+                        ],
+                    } as InternalMessage,
+                ]
+            );
+
+            const formattedHistory = vi.mocked(formatter.format).mock
+                .calls[0]?.[0] as InternalMessage[];
+            expect(formattedHistory[0]?.content).toEqual([
+                { type: 'text', text: '[Image: tool-image.png (4 KB)]' },
+            ]);
+        });
     });
 
     describe('addAssistantMessage', () => {

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -1022,9 +1022,10 @@ export class ContextManager<TMessage = unknown> {
             );
         }
 
-        // Resolve blob references using resource manager with filtering
-        // Only user and tool messages can contain blob references (images, files)
-        // System and assistant messages have string-only content - no blob expansion needed
+        // Resolve blob references using resource manager with filtering.
+        // Only recent user media is rehydrated into model-visible binary parts.
+        // Tool media stays as compact resource text so large tool outputs cannot
+        // balloon the prompt on later turns.
         this.logger.debug('Resolving blob references in message history before formatting');
         const retainedMediaMessageIndexes = new Set<number>();
         let retainedMediaMessages = 0;
@@ -1033,7 +1034,8 @@ export class ContextManager<TMessage = unknown> {
                 break;
             }
 
-            if (ContextManager.hasRetainableMedia(messageHistory[index]!)) {
+            const message = messageHistory[index]!;
+            if (isUserMessage(message) && ContextManager.hasRetainableMedia(message)) {
                 retainedMediaMessageIndexes.add(index);
                 retainedMediaMessages += 1;
             }
@@ -1062,7 +1064,7 @@ export class ContextManager<TMessage = unknown> {
                         this.resourceManager,
                         this.logger,
                         allowedMediaTypes,
-                        expandMatchingMedia
+                        false
                     );
                     return { ...message, content: expandedContent };
                 }

--- a/packages/server/src/hono/__tests__/api.integration.test.ts
+++ b/packages/server/src/hono/__tests__/api.integration.test.ts
@@ -533,7 +533,7 @@ describe('Hono API Integration Tests', () => {
             });
         });
 
-        it('GET /api/sessions/:id/history expands blob-backed media parts by default', async () => {
+        it('GET /api/sessions/:id/history preserves blob-backed media refs', async () => {
             if (!testServer) throw new Error('Test server not initialized');
             const sessionId = 'test-session-history-expanded-blobs';
 
@@ -583,7 +583,7 @@ describe('Hono API Integration Tests', () => {
             expect(history).toHaveLength(1);
             expect(history[0]?.content[0]).toEqual({
                 type: 'image',
-                image: 'iVBORw0KGgo=',
+                image: `@${storedBlob.uri}`,
                 mimeType: 'image/png',
             });
         });
@@ -641,7 +641,7 @@ describe('Hono API Integration Tests', () => {
                     mimeType: 'application/pdf',
                     filename: 'missing.pdf',
                 });
-                expect(readSpy).toHaveBeenCalledTimes(1);
+                expect(readSpy).not.toHaveBeenCalled();
             } finally {
                 readSpy.mockRestore();
             }

--- a/packages/server/src/hono/routes/sessions.ts
+++ b/packages/server/src/hono/routes/sessions.ts
@@ -711,7 +711,9 @@ export function createSessionsRouter(
             const agent = await getAgent(ctx);
             const { sessionId } = ctx.req.param();
             const metadata = await agent.getSessionMetadata(sessionId);
-            const history = await agent.getSessionHistory(sessionId);
+            const history = await agent.getSessionHistory(sessionId, {
+                expandBlobReferences: false,
+            });
             return ctx.json(
                 {
                     session: {
@@ -726,7 +728,9 @@ export function createSessionsRouter(
             const agent = await getAgent(ctx);
             const { sessionId } = ctx.req.param();
             const [history, isBusy] = await Promise.all([
-                agent.getSessionHistory(sessionId),
+                agent.getSessionHistory(sessionId, {
+                    expandBlobReferences: false,
+                }),
                 agent.isSessionBusy(sessionId),
             ]);
             // TODO: Improve type alignment between core and server schemas.


### PR DESCRIPTION
## Summary
- preserve blob-backed media refs in session history API responses instead of expanding them
- only rehydrate recent user media for model prompts; tool media stays compact text
- add regression coverage and a patch changeset for publishing

## Verification
- ./scripts/quality-checks.sh all all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes – v1.7.1

* **Bug Fixes**
  * Session history endpoints now preserve blob references instead of expanding them inline, improving API response efficiency.

* **Improvements**
  * Tool message media is no longer rehydrated in session history responses.

* **Documentation**
  * OpenAPI specification updated to version 1.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->