### PR TITLE
Instrument core agent loop with OTel spans

### DIFF
--- a/.changeset/quiet-clouds-trace.md
+++ b/.changeset/quiet-clouds-trace.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Add OpenTelemetry spans around core turn preparation so hosted runtimes can diagnose agent-loop latency.

--- a/packages/core/src/agent/DextoAgent.lifecycle.test.ts
+++ b/packages/core/src/agent/DextoAgent.lifecycle.test.ts
@@ -232,11 +232,24 @@ describe('DextoAgent Lifecycle Management', () => {
                     },
                 ]),
             });
+            mockGenerateSessionTitle.mockResolvedValueOnce({
+                title: 'Generated title',
+                usage: {
+                    inputTokens: 9,
+                    outputTokens: 2,
+                    totalTokens: 11,
+                },
+            });
 
             await agent.start();
 
             await expect(agent.generateSessionTitleDetails('session-123')).resolves.toEqual({
                 source: 'llm',
+                tokenUsage: {
+                    inputTokens: 9,
+                    outputTokens: 2,
+                    totalTokens: 11,
+                },
                 title: 'Generated title',
             });
             await expect(agent.generateSessionTitle('session-123')).resolves.toBe(

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -87,7 +87,11 @@ import type { CompactionStrategy } from '../context/compaction/types.js';
 import { SearchService } from '../search/index.js';
 import type { SearchOptions, SearchResponse, SessionSearchResponse } from '../search/index.js';
 import { safeStringify } from '../utils/safe-stringify.js';
-import { deriveHeuristicTitle, generateSessionTitle } from '../session/title-generator.js';
+import {
+    deriveHeuristicTitle,
+    generateSessionTitle,
+    type GenerateSessionTitleTokenUsage,
+} from '../session/title-generator.js';
 import type { ApprovalHandler } from '../approval/types.js';
 import type { DextoAgentOptions } from './agent-options.js';
 import type { WorkspaceManager } from '../workspace/manager.js';
@@ -121,6 +125,7 @@ export interface SessionTitleGenerationDetails {
     source: SessionTitleSource;
     reason?: string;
     timedOut?: boolean;
+    tokenUsage?: GenerateSessionTitleTokenUsage;
 }
 
 /**
@@ -1874,6 +1879,7 @@ export class DextoAgent {
                 const details = {
                     ...(result.error !== undefined && { reason: result.error }),
                     ...(result.timedOut !== undefined && { timedOut: result.timedOut }),
+                    ...(result.usage !== undefined && { tokenUsage: result.usage }),
                     source: 'heuristic',
                     title,
                 } satisfies SessionTitleGenerationDetails;
@@ -1893,6 +1899,7 @@ export class DextoAgent {
         return {
             source: 'llm',
             title,
+            ...(result.usage !== undefined && { tokenUsage: result.usage }),
         };
     }
 

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -8,6 +8,7 @@ import type { WorkspaceContext } from '../workspace/types.js';
 import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
 import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 import type { HostRuntimeContext } from '../runtime/index.js';
+import type { LLMProviderErrorDetails } from '../llm/executor/provider-error.js';
 
 /**
  * LLM finish reason - why the LLM stopped generating
@@ -578,6 +579,8 @@ interface SessionEventMapBase {
         error: Error;
         context?: string;
         recoverable?: boolean;
+        /** Structured provider/API error details when the error came from the model transport. */
+        details?: LLMProviderErrorDetails;
         /** Tool call ID if error occurred during tool execution */
         toolCallId?: string;
     };

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -102,6 +102,9 @@ export type { AgentEventMap, SessionEventMap } from './events/index.js';
 export type { ToolCallMetadata } from './tools/tool-call-metadata.js';
 export type { HostRuntimeContext, HostRuntimeIds } from './runtime/host-runtime.js';
 
+// Telemetry utilities (used by Cloudflare Worker-hosted runtimes)
+export { Telemetry, recordOperationSpan } from './telemetry/index.js';
+
 // LLM registry types (used by client-sdk package)
 export type { ModelInfo, ProviderInfo } from '@dexto/llm';
 export type { SupportedFileType } from '@dexto/llm';

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -102,8 +102,9 @@ export type { AgentEventMap, SessionEventMap } from './events/index.js';
 export type { ToolCallMetadata } from './tools/tool-call-metadata.js';
 export type { HostRuntimeContext, HostRuntimeIds } from './runtime/host-runtime.js';
 
-// Telemetry utilities (used by Cloudflare Worker-hosted runtimes)
-export { Telemetry, recordOperationSpan } from './telemetry/index.js';
+// Telemetry utilities (used by browser and Worker-hosted runtimes)
+export { Telemetry } from './telemetry/browser.js';
+export { recordOperationSpan, type OperationSpanOptions } from './telemetry/operation-span.js';
 
 // LLM registry types (used by client-sdk package)
 export type { ModelInfo, ProviderInfo } from '@dexto/llm';

--- a/packages/core/src/llm/executor/provider-error.test.ts
+++ b/packages/core/src/llm/executor/provider-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { APICallError } from 'ai';
+import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
+import { LLMErrorCode } from '../error-codes.js';
+import { mapProviderError } from './provider-error.js';
+
+describe('mapProviderError', () => {
+    it('does not classify generic OpenRouter 400 responses as invalid schema errors', () => {
+        const error = new APICallError({
+            message: 'Bad Request',
+            statusCode: 400,
+            responseHeaders: {},
+            responseBody: JSON.stringify({
+                error: {
+                    code: 400,
+                    message: 'Provider returned error',
+                },
+            }),
+            url: 'https://openrouter.ai/api/v1/chat/completions',
+            requestBodyValues: {},
+            isRetryable: false,
+        });
+
+        const mapped = mapProviderError({
+            error,
+            provider: 'openrouter',
+            model: 'openai/gpt-5.4-mini',
+            sessionId: 'session-1',
+        });
+
+        expect(mapped).toBeInstanceOf(DextoRuntimeError);
+        expect(mapped).toMatchObject({
+            code: LLMErrorCode.GENERATION_FAILED,
+            context: expect.objectContaining({
+                model: 'openai/gpt-5.4-mini',
+                openRouterErrorCode: 400,
+                provider: 'openrouter',
+                sessionId: 'session-1',
+                statusCode: 400,
+            }),
+        });
+    });
+
+    it('wraps plain provider failures in the typed LLM error pipeline', () => {
+        const mapped = mapProviderError({
+            error: new Error('Plain provider failure'),
+            provider: 'openai',
+            model: 'gpt-4.1',
+            sessionId: 'session-2',
+        });
+
+        expect(mapped).toBeInstanceOf(DextoRuntimeError);
+        expect(mapped).toMatchObject({
+            code: LLMErrorCode.GENERATION_FAILED,
+            message: 'Plain provider failure',
+            context: expect.objectContaining({
+                model: 'gpt-4.1',
+                provider: 'openai',
+                sessionId: 'session-2',
+            }),
+        });
+    });
+});

--- a/packages/core/src/llm/executor/provider-error.ts
+++ b/packages/core/src/llm/executor/provider-error.ts
@@ -127,6 +127,41 @@ function providerMessage(details: LLMProviderErrorDetails, fallback: string): st
     );
 }
 
+function messageFromUnknown(value: unknown): string {
+    return value instanceof Error ? value.message : String(value);
+}
+
+function isInvalidSchemaMessage(message: string): boolean {
+    return (
+        message.includes('Invalid schema for function') ||
+        message.includes('invalid_function_parameters') ||
+        message.includes('schema must have type')
+    );
+}
+
+function readNumericField(value: unknown, field: string): number | undefined {
+    if (!isRecord(value)) return undefined;
+    const fieldValue = value[field];
+    return typeof fieldValue === 'number' && Number.isFinite(fieldValue) ? fieldValue : undefined;
+}
+
+function extractBalance(value: unknown): number | undefined {
+    if (!isRecord(value)) return undefined;
+
+    const direct =
+        readNumericField(value, 'balance') ??
+        readNumericField(value, 'balanceUsd') ??
+        readNumericField(value, 'creditsUsd');
+    if (direct !== undefined) return direct;
+
+    for (const nested of Object.values(value)) {
+        const balance = extractBalance(nested);
+        if (balance !== undefined) return balance;
+    }
+
+    return undefined;
+}
+
 function errorTypeForStatus(status: number | undefined): ErrorType {
     if (status === 402) return ErrorType.PAYMENT_REQUIRED;
     if (status === 403) return ErrorType.FORBIDDEN;
@@ -190,7 +225,17 @@ export function mapProviderError(input: MapProviderErrorInput): Error {
     if (input.error instanceof DextoRuntimeError) return input.error;
 
     if (!APICallError.isInstance?.(input.error)) {
-        return input.error instanceof Error ? input.error : new Error(String(input.error));
+        const message = messageFromUnknown(input.error);
+        if (isInvalidSchemaMessage(message)) {
+            return new DextoRuntimeError(
+                LLMErrorCode.REQUEST_INVALID_SCHEMA,
+                ErrorScope.LLM,
+                ErrorType.USER,
+                message,
+                buildContext(input, extractProviderErrorDetails(input))
+            );
+        }
+        return input.error instanceof Error ? input.error : new Error(message);
     }
 
     const details = extractProviderErrorDetails(input);
@@ -198,6 +243,23 @@ export function mapProviderError(input: MapProviderErrorInput): Error {
     const message = providerMessage(details, input.error.message);
     const code = errorCodeForStatus(status, details);
     const type = errorTypeForStatus(status);
+
+    if (status === 402) {
+        const balance = extractBalance(parseJsonObject(details.responseBody));
+        return new DextoRuntimeError(
+            code,
+            ErrorScope.LLM,
+            type,
+            `Insufficient Dexto credits. Balance: ${
+                balance === undefined ? 'low' : `$${balance.toFixed(2)}`
+            }`,
+            {
+                ...buildContext(input, details),
+                ...(balance === undefined ? {} : { balance }),
+            },
+            'Run `dexto billing` to check your balance'
+        );
+    }
 
     return new DextoRuntimeError(
         code,

--- a/packages/core/src/llm/executor/provider-error.ts
+++ b/packages/core/src/llm/executor/provider-error.ts
@@ -1,0 +1,209 @@
+import { APICallError } from 'ai';
+import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
+import { ErrorScope, ErrorType } from '../../errors/types.js';
+import { LLMErrorCode } from '../error-codes.js';
+
+export type LLMProviderErrorDetails = {
+    provider?: string;
+    model?: string;
+    statusCode?: number;
+    retryAfter?: number;
+    responseBody?: string;
+    openRouterErrorCode?: string | number;
+    openRouterErrorMessage?: string;
+    openRouterProviderName?: string;
+    openRouterProviderRaw?: unknown;
+    openRouterProviderRawMessage?: string;
+    openRouterProviderRawParam?: string;
+    openRouterProviderRawCode?: string | number;
+    openRouterPreviousErrorCount?: number;
+    url?: string;
+    isRetryable?: boolean;
+};
+
+export type MapProviderErrorInput = {
+    error: unknown;
+    provider: string;
+    model: string;
+    sessionId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+    if (isRecord(value)) return value;
+    if (typeof value !== 'string') return null;
+    try {
+        const parsed: unknown = JSON.parse(value);
+        return isRecord(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+function readScalar(value: unknown): string | number | boolean | undefined {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        return value;
+    }
+    return undefined;
+}
+
+function readStringOrNumber(value: unknown): string | number | undefined {
+    return typeof value === 'string' || typeof value === 'number' ? value : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readRetryAfter(headers: Record<string, string> | undefined): number | undefined {
+    const retryAfter = headers?.['retry-after'];
+    if (retryAfter === undefined) return undefined;
+    const value = Number(retryAfter);
+    return Number.isFinite(value) ? value : undefined;
+}
+
+function stringifyBody(value: unknown): string | undefined {
+    if (typeof value === 'string') return value;
+    if (value === undefined || value === null) return undefined;
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
+}
+
+function readErrorEnvelope(body: Record<string, unknown> | null): Record<string, unknown> | null {
+    const error = body?.error;
+    return isRecord(error) ? error : null;
+}
+
+function addOpenRouterDetails(details: LLMProviderErrorDetails, responseBody: string): void {
+    const body = parseJsonObject(responseBody);
+    const errorEnvelope = readErrorEnvelope(body);
+    if (errorEnvelope === null) return;
+
+    const code = readStringOrNumber(errorEnvelope.code);
+    if (code !== undefined) details.openRouterErrorCode = code;
+
+    const message = readString(errorEnvelope.message);
+    if (message !== undefined) details.openRouterErrorMessage = message;
+
+    const metadata = isRecord(errorEnvelope.metadata) ? errorEnvelope.metadata : null;
+    if (metadata === null) return;
+
+    const providerName = readString(metadata.provider_name);
+    if (providerName !== undefined) details.openRouterProviderName = providerName;
+
+    if (Reflect.has(metadata, 'raw')) {
+        details.openRouterProviderRaw = metadata.raw;
+    }
+
+    const rawObject = parseJsonObject(metadata.raw);
+    const rawError = readErrorEnvelope(rawObject);
+    const rawMessage = readString(rawError?.message);
+    if (rawMessage !== undefined) details.openRouterProviderRawMessage = rawMessage;
+
+    const rawParam = readString(rawError?.param);
+    if (rawParam !== undefined) details.openRouterProviderRawParam = rawParam;
+
+    const rawCode = readStringOrNumber(rawError?.code);
+    if (rawCode !== undefined) details.openRouterProviderRawCode = rawCode;
+
+    const previousErrors = metadata.previous_errors;
+    if (Array.isArray(previousErrors)) {
+        details.openRouterPreviousErrorCount = previousErrors.length;
+    }
+}
+
+function providerMessage(details: LLMProviderErrorDetails, fallback: string): string {
+    return (
+        details.openRouterProviderRawMessage ??
+        details.openRouterErrorMessage ??
+        details.responseBody ??
+        fallback
+    );
+}
+
+function errorTypeForStatus(status: number | undefined): ErrorType {
+    if (status === 402) return ErrorType.PAYMENT_REQUIRED;
+    if (status === 403) return ErrorType.FORBIDDEN;
+    if (status === 408) return ErrorType.TIMEOUT;
+    if (status === 429) return ErrorType.RATE_LIMIT;
+    if (status !== undefined && status >= 400 && status < 500) return ErrorType.USER;
+    return ErrorType.THIRD_PARTY;
+}
+
+function errorCodeForStatus(
+    status: number | undefined,
+    details: LLMProviderErrorDetails
+): LLMErrorCode {
+    if (status === 402) return LLMErrorCode.INSUFFICIENT_CREDITS;
+    if (status === 429) return LLMErrorCode.RATE_LIMIT_EXCEEDED;
+    if (
+        status === 400 &&
+        (details.openRouterProviderRawCode === 'invalid_function_parameters' ||
+            details.openRouterErrorCode === 400)
+    ) {
+        return LLMErrorCode.REQUEST_INVALID_SCHEMA;
+    }
+    return LLMErrorCode.GENERATION_FAILED;
+}
+
+function buildContext(input: MapProviderErrorInput, details: LLMProviderErrorDetails) {
+    return {
+        ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+        provider: input.provider,
+        model: input.model,
+        ...details,
+    };
+}
+
+export function extractProviderErrorDetails(input: MapProviderErrorInput): LLMProviderErrorDetails {
+    const details: LLMProviderErrorDetails = {
+        provider: input.provider,
+        model: input.model,
+    };
+
+    if (!APICallError.isInstance?.(input.error)) return details;
+
+    const responseHeaders = (input.error.responseHeaders || {}) as Record<string, string>;
+    const responseBody = stringifyBody(input.error.responseBody);
+
+    if (input.error.statusCode !== undefined) details.statusCode = input.error.statusCode;
+    const retryAfter = readRetryAfter(responseHeaders);
+    if (retryAfter !== undefined) details.retryAfter = retryAfter;
+    if (responseBody !== undefined) details.responseBody = responseBody;
+    if (input.error.url !== undefined) details.url = input.error.url;
+    details.isRetryable = input.error.isRetryable;
+
+    if (responseBody !== undefined) {
+        addOpenRouterDetails(details, responseBody);
+    }
+
+    return details;
+}
+
+export function mapProviderError(input: MapProviderErrorInput): Error {
+    if (input.error instanceof DextoRuntimeError) return input.error;
+
+    if (!APICallError.isInstance?.(input.error)) {
+        return input.error instanceof Error ? input.error : new Error(String(input.error));
+    }
+
+    const details = extractProviderErrorDetails(input);
+    const status = input.error.statusCode;
+    const message = providerMessage(details, input.error.message);
+    const code = errorCodeForStatus(status, details);
+    const type = errorTypeForStatus(status);
+
+    return new DextoRuntimeError(
+        code,
+        ErrorScope.LLM,
+        type,
+        status === undefined ? message : `Provider error ${status}: ${message}`,
+        buildContext(input, details)
+    );
+}

--- a/packages/core/src/llm/executor/provider-error.ts
+++ b/packages/core/src/llm/executor/provider-error.ts
@@ -43,13 +43,6 @@ function parseJsonObject(value: unknown): Record<string, unknown> | null {
     }
 }
 
-function readScalar(value: unknown): string | number | boolean | undefined {
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-        return value;
-    }
-    return undefined;
-}
-
 function readStringOrNumber(value: unknown): string | number | undefined {
     return typeof value === 'string' || typeof value === 'number' ? value : undefined;
 }
@@ -180,7 +173,7 @@ function errorCodeForStatus(
     if (
         status === 400 &&
         (details.openRouterProviderRawCode === 'invalid_function_parameters' ||
-            details.openRouterErrorCode === 400)
+            isInvalidSchemaMessage(providerMessage(details, '')))
     ) {
         return LLMErrorCode.REQUEST_INVALID_SCHEMA;
     }
@@ -235,7 +228,13 @@ export function mapProviderError(input: MapProviderErrorInput): Error {
                 buildContext(input, extractProviderErrorDetails(input))
             );
         }
-        return input.error instanceof Error ? input.error : new Error(message);
+        return new DextoRuntimeError(
+            LLMErrorCode.GENERATION_FAILED,
+            ErrorScope.LLM,
+            ErrorType.THIRD_PARTY,
+            message,
+            buildContext(input, extractProviderErrorDetails(input))
+        );
     }
 
     const details = extractProviderErrorDetails(input);

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -1062,13 +1062,23 @@ describe('StreamProcessor', () => {
             const testError = new Error('Test error');
             const events = [{ type: 'error', error: testError }];
 
-            await expect(processor.process(() => createMockStream(events) as never)).rejects.toBe(
-                testError
-            );
+            await expect(
+                processor.process(() => createMockStream(events) as never)
+            ).rejects.toMatchObject({
+                code: 'llm_generation_failed',
+                message: 'Test error',
+                context: expect.objectContaining({
+                    model: 'gpt-4',
+                    provider: 'openai',
+                }),
+            });
             expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
                 name: 'llm:error',
                 payload: {
-                    error: testError,
+                    error: {
+                        code: 'llm_generation_failed',
+                        message: 'Test error',
+                    },
                     context: 'StreamProcessor',
                     recoverable: false,
                 },
@@ -1227,9 +1237,16 @@ describe('StreamProcessor', () => {
                 { type: 'error', error: testError },
             ];
 
-            await expect(processor.process(() => createMockStream(events) as never)).rejects.toBe(
-                testError
-            );
+            await expect(
+                processor.process(() => createMockStream(events) as never)
+            ).rejects.toMatchObject({
+                code: 'llm_generation_failed',
+                message: 'Test error',
+                context: expect.objectContaining({
+                    model: 'gpt-4',
+                    provider: 'openai',
+                }),
+            });
 
             expect(mocks.contextManager.addToolCall).toHaveBeenCalledWith(expect.any(String), {
                 id: 'call-1',
@@ -1253,7 +1270,10 @@ describe('StreamProcessor', () => {
             expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
                 name: 'llm:error',
                 payload: {
-                    error: testError,
+                    error: {
+                        code: 'llm_generation_failed',
+                        message: 'Test error',
+                    },
                     context: 'StreamProcessor',
                     recoverable: false,
                 },
@@ -1296,9 +1316,16 @@ describe('StreamProcessor', () => {
                 { type: 'error', error: testError },
             ];
 
-            await expect(processor.process(() => createMockStream(events) as never)).rejects.toBe(
-                testError
-            );
+            await expect(
+                processor.process(() => createMockStream(events) as never)
+            ).rejects.toMatchObject({
+                code: 'llm_generation_failed',
+                message: 'Model stream failed',
+                context: expect.objectContaining({
+                    model: 'gpt-4',
+                    provider: 'openai',
+                }),
+            });
 
             expect(mocks.contextManager.addToolResult).toHaveBeenCalledTimes(2);
             expect(mocks.contextManager.addToolResult).toHaveBeenNthCalledWith(

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -1093,11 +1093,50 @@ describe('StreamProcessor', () => {
             ).rejects.toMatchObject({
                 message: 'String error message',
             });
-            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
+            const errorEvents = mocks.emittedEvents.filter((e) => e.name === 'llm:error');
+            expect(errorEvents).toHaveLength(1);
+            expect(errorEvents[0]).toMatchObject({
                 name: 'llm:error',
                 payload: {
                     context: 'StreamProcessor',
                     recoverable: false,
+                },
+            });
+        });
+
+        test('classifies OpenAI-compatible schema string stream errors', async () => {
+            const mocks = createMocks();
+            const processor = new StreamProcessor(
+                mocks.contextManager,
+                mocks.eventBus,
+                mocks.abortController.signal,
+                mocks.config,
+                mocks.logger,
+                true
+            );
+
+            await expect(
+                processor.process(
+                    () =>
+                        createMockStream([
+                            {
+                                type: 'error',
+                                error: "Invalid schema for function 'dexto_apps': schema must have type 'object'",
+                            },
+                        ]) as never
+                )
+            ).rejects.toMatchObject({
+                code: 'llm_request_invalid_schema',
+                message: expect.stringContaining("Invalid schema for function 'dexto_apps'"),
+            });
+
+            const errorEvents = mocks.emittedEvents.filter((e) => e.name === 'llm:error');
+            expect(errorEvents).toHaveLength(1);
+            expect(errorEvents[0]).toMatchObject({
+                payload: {
+                    error: {
+                        code: 'llm_request_invalid_schema',
+                    },
                 },
             });
         });

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { APICallError } from 'ai';
 import { StreamProcessor } from './stream-processor.js';
 import type { StreamProcessorConfig } from './stream-processor.js';
 import type { ContextManager } from '../../context/manager.js';
@@ -1047,7 +1048,7 @@ describe('StreamProcessor', () => {
     });
 
     describe('Error Event Handling', () => {
-        test('throws Error objects from fatal stream events', async () => {
+        test('throws Error objects from fatal stream events and emits llm:error', async () => {
             const mocks = createMocks();
             const processor = new StreamProcessor(
                 mocks.contextManager,
@@ -1064,10 +1065,17 @@ describe('StreamProcessor', () => {
             await expect(processor.process(() => createMockStream(events) as never)).rejects.toBe(
                 testError
             );
-            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toBeUndefined();
+            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
+                name: 'llm:error',
+                payload: {
+                    error: testError,
+                    context: 'StreamProcessor',
+                    recoverable: false,
+                },
+            });
         });
 
-        test('wraps non-Error fatal stream events before throwing', async () => {
+        test('wraps non-Error fatal stream events before throwing and emits llm:error', async () => {
             const mocks = createMocks();
             const processor = new StreamProcessor(
                 mocks.contextManager,
@@ -1085,7 +1093,77 @@ describe('StreamProcessor', () => {
             ).rejects.toMatchObject({
                 message: 'String error message',
             });
-            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toBeUndefined();
+            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
+                name: 'llm:error',
+                payload: {
+                    context: 'StreamProcessor',
+                    recoverable: false,
+                },
+            });
+        });
+
+        test('extracts OpenRouter provider metadata from API stream errors', async () => {
+            const mocks = createMocks();
+            mocks.config.provider = 'openrouter';
+            mocks.config.model = 'openai/gpt-5.4-mini';
+            const processor = new StreamProcessor(
+                mocks.contextManager,
+                mocks.eventBus,
+                mocks.abortController.signal,
+                mocks.config,
+                mocks.logger,
+                true
+            );
+            const responseBody = JSON.stringify({
+                error: {
+                    code: 400,
+                    message: 'Provider returned error',
+                    metadata: {
+                        provider_name: 'OpenAI',
+                        raw: {
+                            error: {
+                                code: 'invalid_function_parameters',
+                                message:
+                                    "Invalid schema for function 'dexto_apps': schema must have type 'object'",
+                                param: 'tools[23].parameters',
+                            },
+                        },
+                        previous_errors: [{}],
+                    },
+                },
+            });
+            const apiError = new APICallError({
+                message: 'Bad Request',
+                statusCode: 400,
+                responseHeaders: {},
+                responseBody,
+                url: 'https://openrouter.ai/api/v1/chat/completions',
+                requestBodyValues: {},
+                isRetryable: false,
+            });
+
+            await expect(
+                processor.process(
+                    () => createMockStream([{ type: 'error', error: apiError }]) as never
+                )
+            ).rejects.toMatchObject({
+                code: 'llm_request_invalid_schema',
+                message: expect.stringContaining("Invalid schema for function 'dexto_apps'"),
+            });
+            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
+                payload: {
+                    details: {
+                        model: 'openai/gpt-5.4-mini',
+                        openRouterProviderName: 'OpenAI',
+                        openRouterProviderRawCode: 'invalid_function_parameters',
+                        openRouterProviderRawMessage:
+                            "Invalid schema for function 'dexto_apps': schema must have type 'object'",
+                        openRouterProviderRawParam: 'tools[23].parameters',
+                        provider: 'openrouter',
+                        statusCode: 400,
+                    },
+                },
+            });
         });
 
         test('persists failed tool results before throwing fatal stream errors', async () => {
@@ -1133,7 +1211,14 @@ describe('StreamProcessor', () => {
                 }),
                 undefined
             );
-            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toBeUndefined();
+            expect(mocks.emittedEvents.find((e) => e.name === 'llm:error')).toMatchObject({
+                name: 'llm:error',
+                payload: {
+                    error: testError,
+                    context: 'StreamProcessor',
+                    recoverable: false,
+                },
+            });
 
             const toolResultEvent = mocks.emittedEvents.find((e) => e.name === 'llm:tool-result');
             expect(toolResultEvent?.payload).toMatchObject({

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -94,6 +94,8 @@ export class StreamProcessor {
      * @param config Provider/model configuration
      * @param logger Logger instance
      * @param streaming If true, emits llm:chunk events. Default true.
+     * @param emitFatalErrors If true, emits terminal llm:error events. TurnExecutor owns
+     * terminal run errors and disables this to avoid duplicate events.
      */
     constructor(
         private contextManager: ContextManager,
@@ -101,7 +103,8 @@ export class StreamProcessor {
         private abortSignal: AbortSignal,
         private config: StreamProcessorConfig,
         logger: Logger,
-        private streaming: boolean = true
+        private streaming: boolean = true,
+        private emitFatalErrors: boolean = true
     ) {
         this.logger = logger.createChild(DextoLogComponent.EXECUTOR);
         this.usageScopeId = config.usageScopeId;
@@ -406,17 +409,7 @@ export class StreamProcessor {
                             model: this.config.model,
                         });
                         await this.persistFailedToolResults(err.message);
-                        this.eventBus.emit('llm:error', {
-                            error: err,
-                            context: 'StreamProcessor',
-                            recoverable: false,
-                            details: extractProviderErrorDetails({
-                                error: event.error,
-                                provider: this.config.provider,
-                                model: this.config.model,
-                            }),
-                        });
-                        throw err;
+                        throw event.error;
                     }
 
                     case 'abort': {
@@ -498,16 +491,23 @@ export class StreamProcessor {
                 provider: this.config.provider,
                 model: this.config.model,
             });
-            this.eventBus.emit('llm:error', {
-                error: mappedError,
-                context: 'StreamProcessor',
-                recoverable: false,
-                details: extractProviderErrorDetails({
-                    error,
-                    provider: this.config.provider,
-                    model: this.config.model,
-                }),
-            });
+            if (!this.emitFatalErrors) {
+                this.logger.error('Stream processing failed', { error: mappedError });
+                throw error;
+            }
+
+            if (this.emitFatalErrors) {
+                this.eventBus.emit('llm:error', {
+                    error: mappedError,
+                    context: 'StreamProcessor',
+                    recoverable: false,
+                    details: extractProviderErrorDetails({
+                        error,
+                        provider: this.config.provider,
+                        model: this.config.model,
+                    }),
+                });
+            }
             this.logger.error('Stream processing failed', { error: mappedError });
             throw mappedError;
         }

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -9,6 +9,7 @@ import type { ModelToolCall } from './types.js';
 import { getUsagePricingMetadata } from '../usage-metadata.js';
 import type { TokenUsageCostBreakdown } from '@dexto/llm';
 import type { LLMProvider, LLMPricingStatus, ReasoningVariant, TokenUsage } from '@dexto/llm';
+import { extractProviderErrorDetails, mapProviderError } from './provider-error.js';
 
 type UsageLike = {
     inputTokens?: number | null | undefined;
@@ -399,11 +400,22 @@ export class StreamProcessor {
                     }
 
                     case 'error': {
-                        const err =
-                            event.error instanceof Error
-                                ? event.error
-                                : new Error(String(event.error));
+                        const err = mapProviderError({
+                            error: event.error,
+                            provider: this.config.provider,
+                            model: this.config.model,
+                        });
                         await this.persistFailedToolResults(err.message);
+                        this.eventBus.emit('llm:error', {
+                            error: err,
+                            context: 'StreamProcessor',
+                            recoverable: false,
+                            details: extractProviderErrorDetails({
+                                error: event.error,
+                                provider: this.config.provider,
+                                model: this.config.model,
+                            }),
+                        });
                         throw err;
                     }
 
@@ -481,8 +493,23 @@ export class StreamProcessor {
             }
 
             // Non-abort errors are real failures
-            this.logger.error('Stream processing failed', { error });
-            throw error;
+            const mappedError = mapProviderError({
+                error,
+                provider: this.config.provider,
+                model: this.config.model,
+            });
+            this.eventBus.emit('llm:error', {
+                error: mappedError,
+                context: 'StreamProcessor',
+                recoverable: false,
+                details: extractProviderErrorDetails({
+                    error,
+                    provider: this.config.provider,
+                    model: this.config.model,
+                }),
+            });
+            this.logger.error('Stream processing failed', { error: mappedError });
+            throw mappedError;
         }
 
         return {

--- a/packages/core/src/llm/executor/turn-executor.integration.test.ts
+++ b/packages/core/src/llm/executor/turn-executor.integration.test.ts
@@ -3269,7 +3269,9 @@ describe('TurnExecutor Integration Tests', () => {
                 );
 
             const retryingHandler = vi.fn();
+            const errorHandler = vi.fn();
             sessionEventBus.on('llm:retrying', retryingHandler);
+            sessionEventBus.on('llm:error', errorHandler);
 
             await contextManager.addUserMessage([{ type: 'text', text: 'Hello' }]);
 
@@ -3278,6 +3280,41 @@ describe('TurnExecutor Integration Tests', () => {
             expect(result.text).toBe('Recovered');
             expect(streamText).toHaveBeenCalledTimes(2);
             expect(retryingHandler).toHaveBeenCalledTimes(1);
+            expect(errorHandler).not.toHaveBeenCalled();
+        });
+
+        it('emits one llm:error for terminal async stream failures', async () => {
+            const streamError = apiCallError({
+                message: 'Bad request',
+                statusCode: 400,
+                isRetryable: false,
+            });
+
+            vi.mocked(streamText).mockImplementation(
+                () =>
+                    ({
+                        fullStream: (async function* () {
+                            yield { type: 'error', error: streamError };
+                        })(),
+                    }) as unknown as ReturnType<typeof streamText>
+            );
+
+            const errorHandler = vi.fn();
+            sessionEventBus.on('llm:error', errorHandler);
+
+            await contextManager.addUserMessage([{ type: 'text', text: 'Hello' }]);
+
+            await expect(executor.execute({ mcpManager }, true)).rejects.toMatchObject({
+                code: 'llm_generation_failed',
+            });
+
+            expect(errorHandler).toHaveBeenCalledTimes(1);
+            expect(errorHandler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    context: 'TurnExecutor',
+                    recoverable: false,
+                })
+            );
         });
 
         it('does not retry once a failed stream has changed conversation history', async () => {
@@ -3365,6 +3402,39 @@ describe('TurnExecutor Integration Tests', () => {
             await expect(executor.execute({ mcpManager }, true)).rejects.toMatchObject({
                 code: 'llm_rate_limit_exceeded',
                 type: 'rate_limit',
+            });
+        });
+
+        it('should preserve Dexto billing recovery guidance for 402 provider errors', async () => {
+            const { APICallError } = await import('ai');
+            const billingError = new APICallError({
+                message: 'Insufficient credits',
+                statusCode: 402,
+                responseHeaders: {},
+                responseBody: JSON.stringify({
+                    error: {
+                        message: 'Insufficient credits',
+                        metadata: {
+                            balance: 0.37,
+                        },
+                    },
+                }),
+                url: 'https://api.dexto.ai/v1/chat/completions',
+                requestBodyValues: {},
+                isRetryable: false,
+            });
+
+            vi.mocked(streamText).mockImplementation(() => {
+                throw billingError;
+            });
+
+            await contextManager.addUserMessage([{ type: 'text', text: 'Hello' }]);
+
+            await expect(executor.execute({ mcpManager }, true)).rejects.toMatchObject({
+                code: 'llm_insufficient_credits',
+                message: 'Insufficient Dexto credits. Balance: $0.37',
+                recovery: 'Run `dexto billing` to check your balance',
+                type: 'payment_required',
             });
         });
     });

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -51,9 +51,10 @@ import type { JSONSchema7 } from 'json-schema';
 import type { MessageQueueService } from '../../session/message-queue.js';
 import type { StreamProcessorConfig } from './stream-processor.js';
 import type { CoalescedMessage } from '../../session/types.js';
-import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
-import { ErrorScope, ErrorType } from '../../errors/types.js';
-import { LLMErrorCode } from '../error-codes.js';
+import {
+    extractProviderErrorDetails,
+    mapProviderError as mapCoreProviderError,
+} from './provider-error.js';
 import { toError } from '../../utils/error-conversion.js';
 import type { CompactionStrategy } from '../../context/compaction/types.js';
 import type { ModelLimits } from '../../context/compaction/overflow.js';
@@ -888,6 +889,12 @@ export class TurnExecutor {
             error: mappedError,
             context: 'TurnExecutor',
             recoverable: false,
+            details: extractProviderErrorDetails({
+                error,
+                provider: this.llmContext.provider,
+                model: this.llmContext.model,
+                sessionId: this.sessionId,
+            }),
         });
 
         await this.contextManager.flush();
@@ -2079,92 +2086,12 @@ export class TurnExecutor {
      * Map provider errors to DextoRuntimeError.
      */
     private mapProviderError(err: unknown): Error {
-        if (APICallError.isInstance?.(err)) {
-            const status = err.statusCode;
-            const headers = (err.responseHeaders || {}) as Record<string, string>;
-            const retryAfter = headers['retry-after'] ? Number(headers['retry-after']) : undefined;
-            const body =
-                typeof err.responseBody === 'string'
-                    ? err.responseBody
-                    : JSON.stringify(err.responseBody ?? '');
-
-            if (status === 402) {
-                // Dexto gateway returns 402 with INSUFFICIENT_CREDITS when balance is low
-                // Try to extract balance from response body
-                let balance: number | undefined;
-                try {
-                    const parsed = JSON.parse(body);
-                    // Format: { error: { code: 'INSUFFICIENT_CREDITS', message: '...Balance: $X.XX...' } }
-                    const msg = parsed?.error?.message || '';
-                    const match = msg.match(/Balance:\s*\$?([\d.]+)/i);
-                    if (match) {
-                        balance = parseFloat(match[1]);
-                    }
-                } catch {
-                    // Ignore parse errors
-                }
-                return new DextoRuntimeError(
-                    LLMErrorCode.INSUFFICIENT_CREDITS,
-                    ErrorScope.LLM,
-                    ErrorType.PAYMENT_REQUIRED,
-                    `Insufficient Dexto credits${balance !== undefined ? `. Balance: $${balance.toFixed(2)}` : ''}`,
-                    {
-                        sessionId: this.sessionId,
-                        provider: this.llmContext.provider,
-                        model: this.llmContext.model,
-                        status,
-                        balance,
-                        body,
-                    },
-                    'Run `dexto billing` to check your balance'
-                );
-            }
-            if (status === 429) {
-                return new DextoRuntimeError(
-                    LLMErrorCode.RATE_LIMIT_EXCEEDED,
-                    ErrorScope.LLM,
-                    ErrorType.RATE_LIMIT,
-                    `Rate limit exceeded${body ? ` - ${body}` : ''}`,
-                    {
-                        sessionId: this.sessionId,
-                        provider: this.llmContext.provider,
-                        model: this.llmContext.model,
-                        status,
-                        retryAfter,
-                        body,
-                    }
-                );
-            }
-            if (status === 408) {
-                return new DextoRuntimeError(
-                    LLMErrorCode.GENERATION_FAILED,
-                    ErrorScope.LLM,
-                    ErrorType.TIMEOUT,
-                    `Provider timed out${body ? ` - ${body}` : ''}`,
-                    {
-                        sessionId: this.sessionId,
-                        provider: this.llmContext.provider,
-                        model: this.llmContext.model,
-                        status,
-                        body,
-                    }
-                );
-            }
-            return new DextoRuntimeError(
-                LLMErrorCode.GENERATION_FAILED,
-                ErrorScope.LLM,
-                ErrorType.THIRD_PARTY,
-                `Provider error ${status}${body ? ` - ${body}` : ''}`,
-                {
-                    sessionId: this.sessionId,
-                    provider: this.llmContext.provider,
-                    model: this.llmContext.model,
-                    status,
-                    body,
-                }
-            );
-        }
-
-        return toError(err, this.logger);
+        if (!APICallError.isInstance?.(err)) return toError(err, this.logger);
+        return mapCoreProviderError({
+            error: err,
+            provider: this.llmContext.provider,
+            model: this.llmContext.model,
+            sessionId: this.sessionId,
+        });
     }
 }

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -1262,7 +1262,8 @@ export class TurnExecutor {
             this.stepAbortController.signal,
             this.getStreamProcessorConfig(request.estimatedInputTokens, request.reasoning),
             this.logger,
-            request.streaming
+            request.streaming,
+            false
         );
 
         return streamProcessor.process(() =>

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -2225,7 +2225,6 @@ export class TurnExecutor {
      * Map provider errors to DextoRuntimeError.
      */
     private mapProviderError(err: unknown): Error {
-        if (!APICallError.isInstance?.(err)) return toError(err, this.logger);
         return mapCoreProviderError({
             error: err,
             provider: this.llmContext.provider,

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -47,6 +47,7 @@ import type { SessionEventBus, LLMFinishReason } from '../../events/index.js';
 import type { ResourceManager } from '../../resources/index.js';
 import { DynamicContributorContext } from '../../systemPrompt/types.js';
 import type { JSONSchema7 } from 'json-schema';
+import { recordOperationSpan } from '../../telemetry/operation-span.js';
 
 import type { MessageQueueService } from '../../session/message-queue.js';
 import type { StreamProcessorConfig } from './stream-processor.js';
@@ -639,11 +640,20 @@ export class TurnExecutor {
                 this.currentModelStepId = `in-memory-model-step-${stepCount}`;
                 modelStepPreparing = true;
                 try {
-                    preparedModelRequest = await this.prepareNextModelRequest({
-                        contributorContext,
-                        supportsTools: turn.supportsTools,
-                        streaming: options.streaming,
-                    });
+                    preparedModelRequest = await recordOperationSpan(
+                        {
+                            name: 'turn.prepare_model_step',
+                            componentName: 'TurnExecutor',
+                            attributes: { 'turn.step_count': stepCount },
+                        },
+                        () =>
+                            this.prepareNextModelRequest({
+                                contributorContext,
+                                supportsTools: turn.supportsTools,
+                                streaming: options.streaming,
+                            }),
+                        this.logger
+                    );
                 } catch (error) {
                     currentStepScope[Symbol.dispose]();
                     currentStepScope = null;
@@ -670,11 +680,20 @@ export class TurnExecutor {
                         }
                         currentStepScope = this.startModelStepScope();
                         this.currentModelStepId = `in-memory-model-step-${stepCount}`;
-                        preparedModelRequest = await this.prepareNextModelRequest({
-                            contributorContext,
-                            supportsTools: turn.supportsTools,
-                            streaming: options.streaming,
-                        });
+                        preparedModelRequest = await recordOperationSpan(
+                            {
+                                name: 'turn.prepare_model_step',
+                                componentName: 'TurnExecutor',
+                                attributes: { 'turn.step_count': stepCount },
+                            },
+                            () =>
+                                this.prepareNextModelRequest({
+                                    contributorContext,
+                                    supportsTools: turn.supportsTools,
+                                    streaming: options.streaming,
+                                }),
+                            this.logger
+                        );
                     }
                     const modelStepRequest = preparedModelRequest;
                     if (currentStepScope === null || modelStepRequest === null) {
@@ -1145,43 +1164,150 @@ export class TurnExecutor {
         // Prune old tool outputs before compaction, so pruning can avoid unnecessary compaction.
         await this.pruneOldToolOutputs();
 
-        let prepared = await this.contextManager.getFormattedMessagesForLLM(
-            input.contributorContext,
-            this.llmContext
+        let systemPrompt = await recordOperationSpan(
+            {
+                name: 'system_prompt.build',
+                componentName: 'TurnExecutor',
+                attributes: {
+                    'llm.model': this.llmContext.model,
+                    'llm.provider': this.llmContext.provider,
+                },
+            },
+            () => this.contextManager.getSystemPrompt(input.contributorContext),
+            this.logger
+        );
+
+        let { preparedHistory, formattedMessages } = await recordOperationSpan(
+            {
+                name: 'context.build_messages',
+                componentName: 'TurnExecutor',
+                attributes: {
+                    'llm.model': this.llmContext.model,
+                    'llm.provider': this.llmContext.provider,
+                },
+            },
+            async () => {
+                const preparedHistory = (await this.contextManager.prepareHistory())
+                    .preparedHistory;
+                const formattedMessages = await this.contextManager.getFormattedMessages(
+                    input.contributorContext,
+                    this.llmContext,
+                    systemPrompt,
+                    preparedHistory
+                );
+                return { preparedHistory, formattedMessages };
+            },
+            this.logger
         );
 
         const toolDefinitions = input.supportsTools
-            ? this.toolManager.filterToolsForSession(
-                  await this.toolManager.getAllTools(),
-                  this.sessionId
+            ? await recordOperationSpan(
+                  {
+                      name: 'tools.list',
+                      componentName: 'TurnExecutor',
+                      attributes: { 'tools.supports': input.supportsTools },
+                      resultAttributes: (tools) => ({ 'tools.count': Object.keys(tools).length }),
+                  },
+                  async () =>
+                      this.toolManager.filterToolsForSession(
+                          await this.toolManager.getAllTools(),
+                          this.sessionId
+                      ),
+                  this.logger
               )
             : {};
 
-        let estimatedInputTokens = await this.contextManager.getEstimatedNextInputTokens(
-            prepared.systemPrompt,
-            prepared.preparedHistory,
-            toolDefinitions
+        let estimatedInputTokens = await recordOperationSpan(
+            {
+                name: 'context.token_estimate',
+                componentName: 'TurnExecutor',
+                attributes: { 'tools.count': Object.keys(toolDefinitions).length },
+                resultAttributes: (tokens) => ({ 'context.estimated_input_tokens': tokens }),
+            },
+            () =>
+                this.contextManager.getEstimatedNextInputTokens(
+                    systemPrompt,
+                    preparedHistory,
+                    toolDefinitions
+                ),
+            this.logger
         );
 
         if (this.shouldCompact(estimatedInputTokens)) {
             this.logger.debug(
                 `Pre-check: estimated ${estimatedInputTokens} tokens exceeds threshold, compacting`
             );
-            const didCompact = await this.compactContext(
-                estimatedInputTokens,
-                input.contributorContext,
-                toolDefinitions
+            const didCompact = await recordOperationSpan(
+                {
+                    name: 'context.compact',
+                    componentName: 'TurnExecutor',
+                    attributes: { 'context.estimated_input_tokens': estimatedInputTokens },
+                },
+                () =>
+                    this.compactContext(
+                        estimatedInputTokens,
+                        input.contributorContext,
+                        toolDefinitions
+                    ),
+                this.logger
             );
 
             if (didCompact) {
-                prepared = await this.contextManager.getFormattedMessagesForLLM(
-                    input.contributorContext,
-                    this.llmContext
+                systemPrompt = await recordOperationSpan(
+                    {
+                        name: 'system_prompt.build',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            'context.after_compaction': true,
+                            'llm.model': this.llmContext.model,
+                            'llm.provider': this.llmContext.provider,
+                        },
+                    },
+                    () => this.contextManager.getSystemPrompt(input.contributorContext),
+                    this.logger
                 );
-                estimatedInputTokens = await this.contextManager.getEstimatedNextInputTokens(
-                    prepared.systemPrompt,
-                    prepared.preparedHistory,
-                    toolDefinitions
+                ({ preparedHistory, formattedMessages } = await recordOperationSpan(
+                    {
+                        name: 'context.build_messages',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            'context.after_compaction': true,
+                            'llm.model': this.llmContext.model,
+                            'llm.provider': this.llmContext.provider,
+                        },
+                    },
+                    async () => {
+                        const preparedHistory = (await this.contextManager.prepareHistory())
+                            .preparedHistory;
+                        const formattedMessages = await this.contextManager.getFormattedMessages(
+                            input.contributorContext,
+                            this.llmContext,
+                            systemPrompt,
+                            preparedHistory
+                        );
+                        return { preparedHistory, formattedMessages };
+                    },
+                    this.logger
+                ));
+                estimatedInputTokens = await recordOperationSpan(
+                    {
+                        name: 'context.token_estimate',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            'context.after_compaction': true,
+                            'tools.count': Object.keys(toolDefinitions).length,
+                        },
+                        resultAttributes: (tokens) => ({
+                            'context.estimated_input_tokens': tokens,
+                        }),
+                    },
+                    () =>
+                        this.contextManager.getEstimatedNextInputTokens(
+                            systemPrompt,
+                            preparedHistory,
+                            toolDefinitions
+                        ),
+                    this.logger
                 );
                 this.logger.debug(
                     `Post-compaction: recomputed estimate is ${estimatedInputTokens} tokens`
@@ -1189,11 +1315,23 @@ export class TurnExecutor {
             }
         }
 
-        const providerOptions = buildProviderOptions({
-            provider: this.llmContext.provider,
-            model: this.llmContext.model,
-            reasoning: this.config.reasoning,
-        });
+        const providerOptions = await recordOperationSpan(
+            {
+                name: 'llm.request_setup',
+                componentName: 'TurnExecutor',
+                attributes: {
+                    'llm.model': this.llmContext.model,
+                    'llm.provider': this.llmContext.provider,
+                },
+            },
+            () =>
+                buildProviderOptions({
+                    provider: this.llmContext.provider,
+                    model: this.llmContext.model,
+                    reasoning: this.config.reasoning,
+                }),
+            this.logger
+        );
 
         // Debug log for verifying reasoning + provider options are actually being sent.
         // (Avoids logging headers/body; providerOptions captures the effective request knobs.)
@@ -1218,7 +1356,7 @@ export class TurnExecutor {
                 : undefined;
 
         return {
-            messages: prepared.formattedMessages,
+            messages: formattedMessages,
             tools: input.supportsTools ? createModelToolDefinitions(toolDefinitions) : {},
             toolDefinitions,
             estimatedInputTokens,

--- a/packages/core/src/session/title-generator.test.ts
+++ b/packages/core/src/session/title-generator.test.ts
@@ -28,6 +28,12 @@ vi.mock('../llm/services/factory.js', () => ({
     createVercelModel: mocks.createVercelModel,
 }));
 
+const defaultUsage = {
+    inputTokens: 11,
+    outputTokens: 3,
+    totalTokens: 14,
+};
+
 describe('generateSessionTitle', () => {
     const logger = createMockLogger();
     const llmConfig = LLMConfigSchema.parse({
@@ -41,20 +47,38 @@ describe('generateSessionTitle', () => {
     beforeEach(() => {
         vi.resetAllMocks();
         mocks.createVercelModel.mockReturnValue(createMockModel('default-model'));
-        mocks.generateText.mockResolvedValue({ text: 'Default title' });
+        mocks.generateText.mockResolvedValue({ text: 'Default title', totalUsage: defaultUsage });
     });
 
     test('passes a host-provided languageModelFactory through to direct text generation', async () => {
         const hostedModel = createMockModel('hosted-model');
         const languageModelFactory = vi.fn(() => hostedModel);
-        mocks.generateText.mockResolvedValue({ text: 'Hosted transport title' });
+        mocks.generateText.mockResolvedValue({
+            text: 'Hosted transport title',
+            totalUsage: {
+                cachedInputTokens: 4,
+                inputTokens: 22,
+                outputTokens: 5,
+                reasoningTokens: 1,
+                totalTokens: 28,
+            },
+        });
 
         const result = await generateSessionTitle(llmConfig, 'help me debug this session', logger, {
             languageModelFactory,
             providerContext: { sessionId: 'session-123', clientSource: 'web' },
         });
 
-        expect(result).toEqual({ title: 'Hosted transport title' });
+        expect(result).toEqual({
+            title: 'Hosted transport title',
+            usage: {
+                cachedInputTokens: 4,
+                inputTokens: 22,
+                outputTokens: 5,
+                reasoningTokens: 1,
+                totalTokens: 28,
+            },
+        });
         expect(languageModelFactory).toHaveBeenCalledWith({
             config: llmConfig,
             context: { sessionId: 'session-123', clientSource: 'web' },
@@ -75,7 +99,10 @@ describe('generateSessionTitle', () => {
 
         const result = await generateSessionTitle(llmConfig, 'generate a title', logger);
 
-        expect(result).toEqual({ title: 'Default title' });
+        expect(result).toEqual({
+            title: 'Default title',
+            usage: defaultUsage,
+        });
         expect(mocks.createVercelModel).toHaveBeenCalledWith(llmConfig, {});
         expect(mocks.generateText).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -83,5 +110,27 @@ describe('generateSessionTitle', () => {
                 prompt: expect.stringContaining('generate a title'),
             })
         );
+    });
+
+    test('returns usage details when the LLM output cannot be used as a title', async () => {
+        mocks.generateText.mockResolvedValue({
+            text: ' ',
+            totalUsage: {
+                inputTokens: 7,
+                outputTokens: 0,
+                totalTokens: 7,
+            },
+        });
+
+        const result = await generateSessionTitle(llmConfig, 'generate a title', logger);
+
+        expect(result).toEqual({
+            error: 'LLM returned empty title',
+            usage: {
+                inputTokens: 7,
+                outputTokens: 0,
+                totalTokens: 7,
+            },
+        });
     });
 });

--- a/packages/core/src/session/title-generator.ts
+++ b/packages/core/src/session/title-generator.ts
@@ -2,12 +2,21 @@ import type { ValidatedLLMConfig } from '../llm/schemas.js';
 import type { Logger } from '../logger/v2/types.js';
 import type { DextoProviderContext, LanguageModelFactory } from '../llm/services/types.js';
 import { createVercelModel } from '../llm/services/factory.js';
-import { generateText } from 'ai';
+import { generateText, type LanguageModelUsage } from 'ai';
+
+export interface GenerateSessionTitleTokenUsage {
+    cachedInputTokens?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    reasoningTokens?: number;
+    totalTokens?: number;
+}
 
 export interface GenerateSessionTitleResult {
     title?: string;
     error?: string;
     timedOut?: boolean;
+    usage?: GenerateSessionTitleTokenUsage;
 }
 
 /**
@@ -57,9 +66,12 @@ export async function generateSessionTitle(
 
         const processed = postProcessTitle(result.text);
         if (!processed) {
-            return { error: 'LLM returned empty title' };
+            return {
+                error: 'LLM returned empty title',
+                usage: toSessionTitleTokenUsage(result.totalUsage),
+            };
         }
-        return { title: processed };
+        return { title: processed, usage: toSessionTitleTokenUsage(result.totalUsage) };
     } catch (error) {
         if (controller?.signal.aborted) {
             return { timedOut: true, error: 'Timed out while waiting for LLM response' };
@@ -70,6 +82,26 @@ export async function generateSessionTitle(
         if (timer) {
             clearTimeout(timer);
         }
+    }
+}
+
+function toSessionTitleTokenUsage(usage: LanguageModelUsage): GenerateSessionTitleTokenUsage {
+    const tokenUsage: GenerateSessionTitleTokenUsage = {};
+    copyTokenUsageNumber(tokenUsage, 'cachedInputTokens', usage.cachedInputTokens);
+    copyTokenUsageNumber(tokenUsage, 'inputTokens', usage.inputTokens);
+    copyTokenUsageNumber(tokenUsage, 'outputTokens', usage.outputTokens);
+    copyTokenUsageNumber(tokenUsage, 'reasoningTokens', usage.reasoningTokens);
+    copyTokenUsageNumber(tokenUsage, 'totalTokens', usage.totalTokens);
+    return tokenUsage;
+}
+
+function copyTokenUsageNumber(
+    target: GenerateSessionTitleTokenUsage,
+    key: keyof GenerateSessionTitleTokenUsage,
+    value: number | undefined
+): void {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        target[key] = value;
     }
 }
 

--- a/packages/core/src/systemPrompt/contributors.ts
+++ b/packages/core/src/systemPrompt/contributors.ts
@@ -6,6 +6,7 @@ import { SystemPromptError } from './errors.js';
 import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 import type { MemoryManager } from '../memory/index.js';
 import type { SkillManager } from '../skills/index.js';
+import { recordOperationSpan } from '../telemetry/operation-span.js';
 
 export class StaticContributor implements SystemPromptContributor {
     constructor(
@@ -256,7 +257,15 @@ export class SkillsContributor implements SystemPromptContributor {
 
     async getContent(_context: DynamicContributorContext): Promise<string> {
         try {
-            const skills = await this.skillManager.list();
+            const skills = await recordOperationSpan(
+                {
+                    name: 'skills.list',
+                    componentName: 'SkillsContributor',
+                    resultAttributes: (skills) => ({ 'skills.count': skills.length }),
+                },
+                () => this.skillManager.list(),
+                this.logger
+            );
             if (skills.length === 0) {
                 return '';
             }

--- a/packages/core/src/telemetry/browser.ts
+++ b/packages/core/src/telemetry/browser.ts
@@ -15,12 +15,31 @@ type TelemetryInstanceOptions = {
     shutdown?: TelemetryShutdownHandler | undefined;
 };
 
+export type BrowserTelemetryInstance = Pick<
+    Telemetry,
+    'forceFlush' | 'isInitialized' | 'name' | 'shutdown' | 'tracer'
+>;
+
+function isGlobalTelemetryLike(value: unknown): value is BrowserTelemetryInstance {
+    if (typeof value !== 'object' || value === null) {
+        return false;
+    }
+
+    return (
+        typeof Reflect.get(value, 'forceFlush') === 'function' &&
+        typeof Reflect.get(value, 'isInitialized') === 'function' &&
+        typeof Reflect.get(value, 'name') === 'string' &&
+        typeof Reflect.get(value, 'shutdown') === 'function' &&
+        Reflect.get(value, 'tracer') !== undefined
+    );
+}
+
 export class Telemetry {
     public tracer: Tracer;
     name: string;
     private _isInitialized: boolean;
     private _shutdownHandler?: TelemetryShutdownHandler | undefined;
-    private static _initPromise?: Promise<Telemetry> | undefined;
+    private static _initPromise?: Promise<BrowserTelemetryInstance> | undefined;
 
     private constructor(config: OtelConfiguration, options: TelemetryInstanceOptions) {
         const serviceName = config.serviceName ?? 'dexto-service';
@@ -32,7 +51,9 @@ export class Telemetry {
         this._isInitialized = options.initialized;
     }
 
-    static async registerGlobal(options: TelemetryRegistrationOptions = {}): Promise<Telemetry> {
+    static async registerGlobal(
+        options: TelemetryRegistrationOptions = {}
+    ): Promise<BrowserTelemetryInstance> {
         const existing = Telemetry.getGlobalInstance();
         if (existing !== undefined) {
             return existing;
@@ -63,7 +84,7 @@ export class Telemetry {
         return trace.getActiveSpan();
     }
 
-    static get(): Telemetry {
+    static get(): BrowserTelemetryInstance {
         const telemetry = Telemetry.getGlobalInstance();
         if (telemetry === undefined) {
             throw new Error('Telemetry not initialized. Call Telemetry.registerGlobal() first.');
@@ -124,9 +145,9 @@ export class Telemetry {
         }
     }
 
-    private static getGlobalInstance(): Telemetry | undefined {
+    private static getGlobalInstance(): BrowserTelemetryInstance | undefined {
         const telemetry = Reflect.get(globalThis, '__TELEMETRY__');
-        return telemetry instanceof Telemetry ? telemetry : undefined;
+        return isGlobalTelemetryLike(telemetry) ? telemetry : undefined;
     }
 
     private static setGlobalInstance(telemetry: Telemetry | undefined): void {

--- a/packages/core/src/telemetry/browser.ts
+++ b/packages/core/src/telemetry/browser.ts
@@ -1,0 +1,139 @@
+import { context as otlpContext, propagation, trace } from '@opentelemetry/api';
+import type { BaggageEntry, Context, Tracer } from '@opentelemetry/api';
+import type { OtelConfiguration } from './schemas.js';
+
+export type TelemetryShutdownHandler = () => Promise<void>;
+
+export type TelemetryRegistrationOptions = {
+    config?: OtelConfiguration | undefined;
+    initialized?: boolean | undefined;
+    shutdown?: TelemetryShutdownHandler | undefined;
+};
+
+type TelemetryInstanceOptions = {
+    initialized: boolean;
+    shutdown?: TelemetryShutdownHandler | undefined;
+};
+
+export class Telemetry {
+    public tracer: Tracer;
+    name: string;
+    private _isInitialized: boolean;
+    private _shutdownHandler?: TelemetryShutdownHandler | undefined;
+    private static _initPromise?: Promise<Telemetry> | undefined;
+
+    private constructor(config: OtelConfiguration, options: TelemetryInstanceOptions) {
+        const serviceName = config.serviceName ?? 'dexto-service';
+        const tracerName = config.tracerName ?? serviceName;
+
+        this.name = serviceName;
+        this.tracer = trace.getTracer(tracerName);
+        this._shutdownHandler = options.shutdown;
+        this._isInitialized = options.initialized;
+    }
+
+    static async registerGlobal(options: TelemetryRegistrationOptions = {}): Promise<Telemetry> {
+        const existing = Telemetry.getGlobalInstance();
+        if (existing !== undefined) {
+            return existing;
+        }
+
+        if (Telemetry._initPromise !== undefined) {
+            return Telemetry._initPromise;
+        }
+
+        Telemetry._initPromise = Promise.resolve().then(() => {
+            const current = Telemetry.getGlobalInstance();
+            if (current !== undefined) {
+                return current;
+            }
+
+            const telemetry = new Telemetry(options.config ?? {}, {
+                initialized: options.initialized ?? true,
+                ...(options.shutdown !== undefined && { shutdown: options.shutdown }),
+            });
+            Telemetry.setGlobalInstance(telemetry);
+            return telemetry;
+        });
+
+        return Telemetry._initPromise;
+    }
+
+    static getActiveSpan() {
+        return trace.getActiveSpan();
+    }
+
+    static get(): Telemetry {
+        const telemetry = Telemetry.getGlobalInstance();
+        if (telemetry === undefined) {
+            throw new Error('Telemetry not initialized. Call Telemetry.registerGlobal() first.');
+        }
+        return telemetry;
+    }
+
+    static hasGlobalInstance(): boolean {
+        return Telemetry.getGlobalInstance() !== undefined;
+    }
+
+    static async shutdownGlobal(): Promise<void> {
+        const telemetry = Telemetry.getGlobalInstance();
+        if (telemetry !== undefined) {
+            await telemetry.shutdown();
+        }
+        Telemetry.setGlobalInstance(undefined);
+        Telemetry._initPromise = undefined;
+    }
+
+    static setBaggage(baggage: Record<string, BaggageEntry>, ctx: Context = otlpContext.active()) {
+        const currentBaggage = Object.fromEntries(
+            propagation.getBaggage(ctx)?.getAllEntries() ?? []
+        );
+        return propagation.setBaggage(
+            ctx,
+            propagation.createBaggage({
+                ...currentBaggage,
+                ...baggage,
+            })
+        );
+    }
+
+    static withContext<T>(ctx: Context, fn: () => T): T {
+        return otlpContext.with(ctx, fn);
+    }
+
+    public isInitialized(): boolean {
+        return this._isInitialized;
+    }
+
+    public async forceFlush(): Promise<void> {
+        const provider = trace.getTracerProvider();
+        const forceFlush = Reflect.get(provider, 'forceFlush');
+        if (typeof forceFlush === 'function') {
+            await Reflect.apply(forceFlush, provider, []);
+        }
+    }
+
+    public async shutdown(): Promise<void> {
+        try {
+            await this._shutdownHandler?.();
+        } finally {
+            this._isInitialized = false;
+            this._shutdownHandler = undefined;
+            Telemetry.setGlobalInstance(undefined);
+            Telemetry._initPromise = undefined;
+        }
+    }
+
+    private static getGlobalInstance(): Telemetry | undefined {
+        const telemetry = Reflect.get(globalThis, '__TELEMETRY__');
+        return telemetry instanceof Telemetry ? telemetry : undefined;
+    }
+
+    private static setGlobalInstance(telemetry: Telemetry | undefined): void {
+        if (telemetry === undefined) {
+            Reflect.deleteProperty(globalThis, '__TELEMETRY__');
+            return;
+        }
+        Reflect.set(globalThis, '__TELEMETRY__', telemetry);
+    }
+}

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -5,3 +5,4 @@ export {
 } from './telemetry.js';
 export { OtelConfigurationSchema } from './schemas.js';
 export type { OtelConfiguration } from './schemas.js';
+export { recordOperationSpan, type OperationSpanOptions } from './operation-span.js';

--- a/packages/core/src/telemetry/operation-span.test.ts
+++ b/packages/core/src/telemetry/operation-span.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SpanStatusCode, trace } from '@opentelemetry/api';
+import {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+import { recordOperationSpan } from './operation-span.js';
+
+describe('recordOperationSpan', () => {
+    let exporter: InMemorySpanExporter;
+    let provider: BasicTracerProvider | undefined;
+
+    beforeEach(() => {
+        exporter = new InMemorySpanExporter();
+        provider = new BasicTracerProvider();
+        provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+        provider.register();
+    });
+
+    afterEach(async () => {
+        if (provider !== undefined) {
+            await provider.shutdown();
+            provider = undefined;
+        }
+        trace.disable();
+    });
+
+    it('records a real OpenTelemetry span with stable attributes', async () => {
+        await expect(
+            recordOperationSpan(
+                {
+                    name: 'skills.list',
+                    componentName: 'SkillsContributor',
+                    attributes: { 'tools.supports': true },
+                    resultAttributes: (skills: string[]) => ({ 'skills.count': skills.length }),
+                    skipIfNoTelemetry: false,
+                },
+                async () => ['alpha', 'beta']
+            )
+        ).resolves.toEqual(['alpha', 'beta']);
+
+        const span = exporter.getFinishedSpans().find((span) => span.name === 'skills.list');
+
+        expect(span?.attributes).toEqual(
+            expect.objectContaining({
+                componentName: 'SkillsContributor',
+                'skills.count': 2,
+                'tools.supports': true,
+            })
+        );
+    });
+
+    it('does not fail the operation when result attribute extraction fails', async () => {
+        await expect(
+            recordOperationSpan(
+                {
+                    name: 'context.token_estimate',
+                    resultAttributes: () => {
+                        throw new Error('attribute bug');
+                    },
+                    skipIfNoTelemetry: false,
+                },
+                () => 42
+            )
+        ).resolves.toBe(42);
+
+        const span = exporter
+            .getFinishedSpans()
+            .find((span) => span.name === 'context.token_estimate');
+
+        expect(span?.status.code).toBe(SpanStatusCode.OK);
+    });
+});

--- a/packages/core/src/telemetry/operation-span.ts
+++ b/packages/core/src/telemetry/operation-span.ts
@@ -1,0 +1,75 @@
+import { context, SpanKind, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Span } from '@opentelemetry/api';
+import type { Logger } from '../logger/v2/types.js';
+import { addBaggageAttributesToSpan, hasActiveTelemetry } from './utils.js';
+
+type OperationSpanAttributes = Record<string, string | number | boolean>;
+
+export type OperationSpanOptions<T> = {
+    attributes?: OperationSpanAttributes;
+    componentName?: string;
+    name: string;
+    resultAttributes?: (result: T) => OperationSpanAttributes | undefined;
+    skipIfNoTelemetry?: boolean;
+    tracerName?: string;
+};
+
+export async function recordOperationSpan<T>(
+    options: OperationSpanOptions<T>,
+    operation: () => T | Promise<T>,
+    logger?: Logger
+): Promise<T> {
+    const skipIfNoTelemetry = options.skipIfNoTelemetry ?? true;
+
+    if (skipIfNoTelemetry && !hasActiveTelemetry(logger)) {
+        return operation();
+    }
+
+    const span = trace
+        .getTracer(options.tracerName ?? 'dexto')
+        .startSpan(options.name, { kind: SpanKind.INTERNAL });
+    const spanContext = trace.setSpan(context.active(), span);
+
+    addBaggageAttributesToSpan(span, spanContext, logger);
+    if (options.componentName !== undefined) {
+        span.setAttribute('componentName', options.componentName);
+    }
+    setOperationSpanAttributes(span, options.attributes);
+
+    try {
+        const result = await context.with(spanContext, operation);
+        try {
+            setOperationSpanAttributes(span, options.resultAttributes?.(result));
+        } catch (error) {
+            logger?.debug('Failed to set OpenTelemetry result attributes', {
+                error: error instanceof Error ? error.message : String(error),
+                span: options.name,
+            });
+        }
+        span.setStatus({ code: SpanStatusCode.OK });
+        return result;
+    } catch (error) {
+        if (error instanceof Error) {
+            span.recordException(error);
+            span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+        } else {
+            span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+        }
+        throw error;
+    } finally {
+        span.end();
+    }
+}
+
+function setOperationSpanAttributes(
+    span: Pick<Span, 'setAttribute'> | undefined,
+    attributes: OperationSpanAttributes | undefined
+): void {
+    if (span === undefined || attributes === undefined) {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(attributes)) {
+        span.setAttribute(key, value);
+    }
+}

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -1,6 +1,8 @@
 import { context as otlpContext, trace, propagation } from '@opentelemetry/api';
 import type { Tracer, Context, BaggageEntry } from '@opentelemetry/api';
 import type { OtelConfiguration } from './schemas.js';
+import { TelemetryError } from './errors.js';
+import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 
 // Type definitions for dynamically imported modules
 type NodeSDKType = import('@opentelemetry/sdk-node').NodeSDK;
@@ -20,14 +22,6 @@ type TelemetryInstanceOptions = {
     sdk?: NodeSDKType | undefined;
     shutdown?: TelemetryShutdownHandler | undefined;
 };
-
-async function getTelemetryErrorFactory(): Promise<typeof import('./errors.js').TelemetryError> {
-    return (await import('./errors.js')).TelemetryError;
-}
-
-function isDextoRuntimeError(error: unknown): boolean {
-    return error instanceof Error && error.name === 'DextoRuntimeError';
-}
 
 // Add type declaration for global namespace
 declare global {
@@ -80,7 +74,6 @@ export class Telemetry {
                 } catch (err) {
                     const error = err as NodeJS.ErrnoException;
                     if (error.code === 'ERR_MODULE_NOT_FOUND') {
-                        const TelemetryError = await getTelemetryErrorFactory();
                         throw TelemetryError.exporterDependencyNotInstalled(
                             'grpc',
                             '@opentelemetry/exporter-trace-otlp-grpc'
@@ -102,7 +95,6 @@ export class Telemetry {
             } catch (err) {
                 const error = err as NodeJS.ErrnoException;
                 if (error.code === 'ERR_MODULE_NOT_FOUND') {
-                    const TelemetryError = await getTelemetryErrorFactory();
                     throw TelemetryError.exporterDependencyNotInstalled(
                         'http',
                         '@opentelemetry/exporter-trace-otlp-http'
@@ -181,7 +173,6 @@ export class Telemetry {
                         } catch (importError) {
                             const err = importError as NodeJS.ErrnoException;
                             if (err.code === 'ERR_MODULE_NOT_FOUND') {
-                                const TelemetryError = await getTelemetryErrorFactory();
                                 throw TelemetryError.dependencyNotInstalled([
                                     '@opentelemetry/sdk-node',
                                     '@opentelemetry/instrumentation-http',
@@ -252,10 +243,9 @@ export class Telemetry {
             // Clear init promise so subsequent calls can retry
             Telemetry._initPromise = undefined;
             // Re-throw typed errors as-is, wrap unknown errors
-            if (isDextoRuntimeError(error)) {
+            if (error instanceof DextoRuntimeError) {
                 throw error;
             }
-            const TelemetryError = await getTelemetryErrorFactory();
             throw TelemetryError.initializationFailed(
                 error instanceof Error ? error.message : String(error),
                 error
@@ -291,10 +281,9 @@ export class Telemetry {
             return await Telemetry._initPromise;
         } catch (error) {
             Telemetry._initPromise = undefined;
-            if (isDextoRuntimeError(error)) {
+            if (error instanceof DextoRuntimeError) {
                 throw error;
             }
-            const TelemetryError = await getTelemetryErrorFactory();
             throw TelemetryError.initializationFailed(
                 error instanceof Error ? error.message : String(error),
                 error
@@ -314,9 +303,7 @@ export class Telemetry {
      */
     static get(): Telemetry {
         if (!globalThis.__TELEMETRY__) {
-            throw new Error(
-                'Telemetry not initialized. Call Telemetry.init() or Telemetry.registerGlobal() first.'
-            );
+            throw TelemetryError.notInitialized();
         }
         return globalThis.__TELEMETRY__;
     }

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -1,7 +1,6 @@
 import { context as otlpContext, trace, propagation } from '@opentelemetry/api';
 import type { Tracer, Context, BaggageEntry } from '@opentelemetry/api';
 import type { OtelConfiguration } from './schemas.js';
-import { logger } from '../logger/logger.js';
 import { TelemetryError } from './errors.js';
 import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 
@@ -395,7 +394,7 @@ export class Telemetry {
             // Don't throw - log warning and continue with cleanup
             // Telemetry is observability infrastructure, not core functionality
             const errorMsg = error instanceof Error ? error.message : String(error);
-            logger.warn(`Telemetry shutdown failed to flush spans (non-blocking): ${errorMsg}`);
+            console.warn(`Telemetry shutdown failed to flush spans (non-blocking): ${errorMsg}`);
         } finally {
             this.cleanupAfterShutdown();
         }
@@ -407,7 +406,7 @@ export class Telemetry {
         globalThis.__TELEMETRY__ = undefined;
 
         // Cleanup signal handlers to prevent leaks
-        if (Telemetry._signalHandlers) {
+        if (Telemetry._signalHandlers && typeof process !== 'undefined') {
             process.off('SIGTERM', Telemetry._signalHandlers.sigterm);
             process.off('SIGINT', Telemetry._signalHandlers.sigint);
             Telemetry._signalHandlers = undefined;

--- a/packages/core/src/telemetry/telemetry.ts
+++ b/packages/core/src/telemetry/telemetry.ts
@@ -1,8 +1,6 @@
 import { context as otlpContext, trace, propagation } from '@opentelemetry/api';
 import type { Tracer, Context, BaggageEntry } from '@opentelemetry/api';
 import type { OtelConfiguration } from './schemas.js';
-import { TelemetryError } from './errors.js';
-import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 
 // Type definitions for dynamically imported modules
 type NodeSDKType = import('@opentelemetry/sdk-node').NodeSDK;
@@ -22,6 +20,14 @@ type TelemetryInstanceOptions = {
     sdk?: NodeSDKType | undefined;
     shutdown?: TelemetryShutdownHandler | undefined;
 };
+
+async function getTelemetryErrorFactory(): Promise<typeof import('./errors.js').TelemetryError> {
+    return (await import('./errors.js')).TelemetryError;
+}
+
+function isDextoRuntimeError(error: unknown): boolean {
+    return error instanceof Error && error.name === 'DextoRuntimeError';
+}
 
 // Add type declaration for global namespace
 declare global {
@@ -74,6 +80,7 @@ export class Telemetry {
                 } catch (err) {
                     const error = err as NodeJS.ErrnoException;
                     if (error.code === 'ERR_MODULE_NOT_FOUND') {
+                        const TelemetryError = await getTelemetryErrorFactory();
                         throw TelemetryError.exporterDependencyNotInstalled(
                             'grpc',
                             '@opentelemetry/exporter-trace-otlp-grpc'
@@ -95,6 +102,7 @@ export class Telemetry {
             } catch (err) {
                 const error = err as NodeJS.ErrnoException;
                 if (error.code === 'ERR_MODULE_NOT_FOUND') {
+                    const TelemetryError = await getTelemetryErrorFactory();
                     throw TelemetryError.exporterDependencyNotInstalled(
                         'http',
                         '@opentelemetry/exporter-trace-otlp-http'
@@ -173,6 +181,7 @@ export class Telemetry {
                         } catch (importError) {
                             const err = importError as NodeJS.ErrnoException;
                             if (err.code === 'ERR_MODULE_NOT_FOUND') {
+                                const TelemetryError = await getTelemetryErrorFactory();
                                 throw TelemetryError.dependencyNotInstalled([
                                     '@opentelemetry/sdk-node',
                                     '@opentelemetry/instrumentation-http',
@@ -243,9 +252,10 @@ export class Telemetry {
             // Clear init promise so subsequent calls can retry
             Telemetry._initPromise = undefined;
             // Re-throw typed errors as-is, wrap unknown errors
-            if (error instanceof DextoRuntimeError) {
+            if (isDextoRuntimeError(error)) {
                 throw error;
             }
+            const TelemetryError = await getTelemetryErrorFactory();
             throw TelemetryError.initializationFailed(
                 error instanceof Error ? error.message : String(error),
                 error
@@ -281,9 +291,10 @@ export class Telemetry {
             return await Telemetry._initPromise;
         } catch (error) {
             Telemetry._initPromise = undefined;
-            if (error instanceof DextoRuntimeError) {
+            if (isDextoRuntimeError(error)) {
                 throw error;
             }
+            const TelemetryError = await getTelemetryErrorFactory();
             throw TelemetryError.initializationFailed(
                 error instanceof Error ? error.message : String(error),
                 error
@@ -303,7 +314,9 @@ export class Telemetry {
      */
     static get(): Telemetry {
         if (!globalThis.__TELEMETRY__) {
-            throw TelemetryError.notInitialized();
+            throw new Error(
+                'Telemetry not initialized. Call Telemetry.init() or Telemetry.registerGlobal() first.'
+            );
         }
         return globalThis.__TELEMETRY__;
     }

--- a/packages/core/src/telemetry/utils.ts
+++ b/packages/core/src/telemetry/utils.ts
@@ -1,23 +1,26 @@
 import { propagation } from '@opentelemetry/api';
 import type { Context, Span } from '@opentelemetry/api';
-import { Telemetry } from './telemetry.js';
 import type { Logger } from '../logger/v2/types.js';
 import { getHostRuntimeAttributes, getHostRuntimeContextFromBaggage } from '../runtime/index.js';
+
+function getGlobalTelemetryInitialized(): boolean {
+    const telemetry = Reflect.get(globalThis, '__TELEMETRY__');
+    if (typeof telemetry !== 'object' || telemetry === null) {
+        return false;
+    }
+
+    const isInitialized = Reflect.get(telemetry, 'isInitialized');
+    return (
+        typeof isInitialized === 'function' && Reflect.apply(isInitialized, telemetry, []) === true
+    );
+}
 
 // Helper function to check if telemetry is active
 export function hasActiveTelemetry(logger?: Logger): boolean {
     logger?.silly('hasActiveTelemetry called.');
-    try {
-        const telemetryInstance = Telemetry.get();
-        const isActive = telemetryInstance.isInitialized();
-        logger?.silly(`hasActiveTelemetry: Telemetry is initialized: ${isActive}`);
-        return isActive;
-    } catch (error) {
-        logger?.silly(
-            `hasActiveTelemetry: Telemetry not active or initialized. Error: ${error instanceof Error ? error.message : String(error)}`
-        );
-        return false;
-    }
+    const isActive = getGlobalTelemetryInitialized();
+    logger?.silly(`hasActiveTelemetry: Telemetry is initialized: ${isActive}`);
+    return isActive;
 }
 
 /**

--- a/packages/core/src/tools/tool-call-metadata.test.ts
+++ b/packages/core/src/tools/tool-call-metadata.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { wrapToolParametersSchema } from './tool-call-metadata.js';
+
+describe('wrapToolParametersSchema', () => {
+    it('does not narrow a union property when only one branch has enum constraints', () => {
+        const schema = wrapToolParametersSchema({
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        format: { const: 'email' },
+                    },
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        format: { type: 'string' },
+                    },
+                },
+            ],
+        });
+
+        expect(schema.properties?.format).toEqual({});
+        expect(schema.properties).toHaveProperty('__meta');
+    });
+
+    it('merges enum constraints when every union branch constrains the property', () => {
+        const schema = wrapToolParametersSchema({
+            anyOf: [
+                {
+                    type: 'object',
+                    properties: {
+                        format: { const: 'email' },
+                    },
+                },
+                {
+                    type: 'object',
+                    properties: {
+                        format: { enum: ['sms', 'email'] },
+                    },
+                },
+            ],
+        });
+
+        expect(schema.properties?.format).toEqual({ enum: ['email', 'sms'] });
+    });
+});

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -36,19 +36,50 @@ const META_SCHEMA: JSONSchema7 = {
 
 const META_KEY = '__meta';
 
-export function wrapToolParametersSchema(parameters: JSONSchema7): JSONSchema7 {
-    if (parameters.type !== 'object' || !parameters.properties) {
+function hasObjectAlternative(parameters: JSONSchema7): boolean {
+    const alternatives = parameters.oneOf ?? parameters.anyOf;
+    return (
+        Array.isArray(alternatives) &&
+        alternatives.some(
+            (alternative) =>
+                alternative !== true && alternative !== false && alternative.type === 'object'
+        )
+    );
+}
+
+function normalizeToolParametersSchema(parameters: JSONSchema7): JSONSchema7 {
+    if (parameters.type === 'object') {
         return parameters;
     }
 
-    if (META_KEY in parameters.properties) {
-        return parameters;
+    if (hasObjectAlternative(parameters)) {
+        return {
+            ...parameters,
+            type: 'object',
+        };
     }
 
     return {
-        ...parameters,
+        type: 'object',
+        additionalProperties: true,
+    };
+}
+
+export function wrapToolParametersSchema(parameters: JSONSchema7): JSONSchema7 {
+    const normalized = normalizeToolParametersSchema(parameters);
+
+    if (!normalized.properties) {
+        return normalized;
+    }
+
+    if (META_KEY in normalized.properties) {
+        return normalized;
+    }
+
+    return {
+        ...normalized,
         properties: {
-            ...parameters.properties,
+            ...normalized.properties,
             [META_KEY]: META_SCHEMA,
         },
     };

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -1,4 +1,6 @@
 import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7Definition } from 'json-schema';
+import type { JSONSchema7Type } from 'json-schema';
 
 export type ToolCallMetadata = Record<string, unknown> & {
     runInBackground?: boolean;
@@ -35,28 +37,141 @@ const META_SCHEMA: JSONSchema7 = {
 };
 
 const META_KEY = '__meta';
+const FORBIDDEN_TOP_LEVEL_SCHEMA_KEYS = ['oneOf', 'anyOf', 'allOf', 'enum', 'not'] as const;
 
-function hasObjectAlternative(parameters: JSONSchema7): boolean {
+function hasForbiddenTopLevelSchemaKey(parameters: JSONSchema7): boolean {
+    return FORBIDDEN_TOP_LEVEL_SCHEMA_KEYS.some((key) => key in parameters);
+}
+
+function readObjectAlternatives(parameters: JSONSchema7): JSONSchema7[] {
     const alternatives = parameters.oneOf ?? parameters.anyOf;
-    return (
-        Array.isArray(alternatives) &&
-        alternatives.some(
-            (alternative) =>
-                alternative !== true && alternative !== false && alternative.type === 'object'
-        )
+    if (!Array.isArray(alternatives)) {
+        return [];
+    }
+
+    return alternatives.filter(
+        (alternative): alternative is JSONSchema7 =>
+            alternative !== true && alternative !== false && alternative.type === 'object'
     );
 }
 
+function readRequiredPropertyNames(schema: JSONSchema7): Set<string> {
+    return new Set(
+        Array.isArray(schema.required)
+            ? schema.required.filter((propertyName) => typeof propertyName === 'string')
+            : []
+    );
+}
+
+function intersectRequiredProperties(alternatives: JSONSchema7[]): string[] | undefined {
+    if (alternatives.length === 0) {
+        return undefined;
+    }
+
+    const requiredSets = alternatives.map(readRequiredPropertyNames);
+    const first = requiredSets[0];
+    if (first === undefined) {
+        return undefined;
+    }
+    const rest = requiredSets.slice(1);
+    const required = [...first].filter((propertyName) =>
+        rest.every((requiredProperties) => requiredProperties.has(propertyName))
+    );
+
+    return required.length === 0 ? undefined : required;
+}
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+    return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function mergeEnumValues(values: JSONSchema7Type[]): JSONSchema7Type[] {
+    const merged: JSONSchema7Type[] = [];
+
+    for (const value of values) {
+        if (!merged.some((existing) => valuesEqual(existing, value))) {
+            merged.push(value);
+        }
+    }
+
+    return merged;
+}
+
+function readEnumValues(schema: JSONSchema7): JSONSchema7Type[] | undefined {
+    if (schema.const !== undefined) {
+        return [schema.const];
+    }
+
+    return Array.isArray(schema.enum) ? schema.enum : undefined;
+}
+
+function mergePropertySchema(
+    current: JSONSchema7Definition | undefined,
+    next: JSONSchema7Definition
+): JSONSchema7Definition {
+    if (current === undefined || current === false) {
+        return next;
+    }
+
+    if (current === true || next === true) {
+        return {};
+    }
+
+    if (next === false) {
+        return current;
+    }
+
+    if (valuesEqual(current, next)) {
+        return current;
+    }
+
+    const enumValues = [...(readEnumValues(current) ?? []), ...(readEnumValues(next) ?? [])];
+    if (enumValues.length > 0) {
+        return { enum: mergeEnumValues(enumValues) };
+    }
+
+    if (current.type !== undefined && valuesEqual(current.type, next.type)) {
+        return { type: current.type };
+    }
+
+    return {};
+}
+
+function flattenObjectUnionSchema(parameters: JSONSchema7): JSONSchema7 | undefined {
+    const alternatives = readObjectAlternatives(parameters);
+    if (alternatives.length === 0) {
+        return undefined;
+    }
+
+    const properties: NonNullable<JSONSchema7['properties']> = {};
+    const required = intersectRequiredProperties(alternatives);
+    for (const alternative of alternatives) {
+        const alternativeProperties = alternative.properties ?? {};
+        for (const [propertyName, propertySchema] of Object.entries(alternativeProperties)) {
+            properties[propertyName] = mergePropertySchema(
+                properties[propertyName],
+                propertySchema
+            );
+        }
+    }
+
+    return {
+        ...(parameters.description === undefined ? {} : { description: parameters.description }),
+        type: 'object',
+        properties,
+        ...(required === undefined ? {} : { required }),
+        additionalProperties: true,
+    };
+}
+
 function normalizeToolParametersSchema(parameters: JSONSchema7): JSONSchema7 {
-    if (parameters.type === 'object') {
+    if (parameters.type === 'object' && !hasForbiddenTopLevelSchemaKey(parameters)) {
         return parameters;
     }
 
-    if (hasObjectAlternative(parameters)) {
-        return {
-            ...parameters,
-            type: 'object',
-        };
+    const flattened = flattenObjectUnionSchema(parameters);
+    if (flattened !== undefined) {
+        return flattened;
     }
 
     return {

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -125,9 +125,10 @@ function mergePropertySchema(
         return current;
     }
 
-    const enumValues = [...(readEnumValues(current) ?? []), ...(readEnumValues(next) ?? [])];
-    if (enumValues.length > 0) {
-        return { enum: mergeEnumValues(enumValues) };
+    const currentEnum = readEnumValues(current);
+    const nextEnum = readEnumValues(next);
+    if (currentEnum !== undefined && nextEnum !== undefined) {
+        return { enum: mergeEnumValues([...currentEnum, ...nextEnum]) };
     }
 
     if (current.type !== undefined && valuesEqual(current.type, next.type)) {

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -3591,6 +3591,73 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             expect(getDescription).toHaveBeenCalledTimes(1);
         });
 
+        it('exports discriminated-union local tool schemas with an object root', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                mockAgentEventBus,
+                { alwaysAllow: [] },
+                [
+                    defineTool({
+                        id: 'multi_action',
+                        description: 'Multi-action tool',
+                        inputSchema: z.discriminatedUnion('action', [
+                            z.object({ action: z.literal('list') }),
+                            z.object({ action: z.literal('open'), id: z.string() }),
+                        ]),
+                        execute: vi.fn(),
+                    }),
+                ],
+                mockLogger
+            );
+
+            const tools = await toolManager.getAllTools();
+
+            expect(tools['multi_action']?.parameters).toMatchObject({
+                type: 'object',
+                oneOf: expect.any(Array),
+            });
+        });
+
+        it('normalizes non-object MCP tool parameters to an object root', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({
+                legacy: {
+                    name: 'legacy',
+                    description: 'Legacy MCP tool',
+                    parameters: {
+                        oneOf: [
+                            {
+                                type: 'object',
+                                properties: { action: { const: 'open' } },
+                            },
+                        ],
+                    },
+                },
+            });
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                mockAgentEventBus,
+                { alwaysAllow: [] },
+                [],
+                mockLogger
+            );
+
+            const tools = await toolManager.getAllTools();
+
+            expect(tools['mcp--legacy']?.parameters).toMatchObject({
+                type: 'object',
+                oneOf: expect.any(Array),
+            });
+        });
+
         it('should cache tool discovery results', async () => {
             const tools = {
                 test_tool: { name: 'test_tool', description: 'Test', parameters: {} },

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -3591,7 +3591,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             expect(getDescription).toHaveBeenCalledTimes(1);
         });
 
-        it('exports discriminated-union local tool schemas with an object root', async () => {
+        it('exports discriminated-union local tool schemas with a provider-safe object root', async () => {
             mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
 
             const toolManager = createToolManager(
@@ -3617,13 +3617,22 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
 
             const tools = await toolManager.getAllTools();
 
-            expect(tools['multi_action']?.parameters).toMatchObject({
-                type: 'object',
-                oneOf: expect.any(Array),
-            });
+            expect(tools['multi_action']?.parameters).toEqual(
+                expect.objectContaining({
+                    additionalProperties: true,
+                    properties: expect.objectContaining({
+                        __meta: expect.any(Object),
+                        action: { enum: ['list', 'open'] },
+                        id: { type: 'string' },
+                    }),
+                    required: ['action'],
+                    type: 'object',
+                })
+            );
+            expect(tools['multi_action']?.parameters).not.toHaveProperty('oneOf');
         });
 
-        it('normalizes non-object MCP tool parameters to an object root', async () => {
+        it('normalizes non-object MCP tool parameters to a provider-safe object root', async () => {
             mockMcpManager.getAllTools = vi.fn().mockResolvedValue({
                 legacy: {
                     name: 'legacy',
@@ -3633,6 +3642,15 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                             {
                                 type: 'object',
                                 properties: { action: { const: 'open' } },
+                                required: ['action'],
+                            },
+                            {
+                                type: 'object',
+                                properties: {
+                                    action: { const: 'list' },
+                                    limit: { type: 'number' },
+                                },
+                                required: ['action'],
                             },
                         ],
                     },
@@ -3652,9 +3670,48 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
 
             const tools = await toolManager.getAllTools();
 
-            expect(tools['mcp--legacy']?.parameters).toMatchObject({
+            expect(tools['mcp--legacy']?.parameters).toEqual(
+                expect.objectContaining({
+                    additionalProperties: true,
+                    properties: expect.objectContaining({
+                        __meta: expect.any(Object),
+                        action: { enum: ['open', 'list'] },
+                        limit: { type: 'number' },
+                    }),
+                    required: ['action'],
+                    type: 'object',
+                })
+            );
+            expect(tools['mcp--legacy']?.parameters).not.toHaveProperty('oneOf');
+        });
+
+        it('falls back when MCP tool parameters cannot be flattened to an object schema', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({
+                legacy: {
+                    name: 'legacy',
+                    description: 'Legacy MCP tool',
+                    parameters: {
+                        type: 'string',
+                    },
+                },
+            });
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                mockAgentEventBus,
+                { alwaysAllow: [] },
+                [],
+                mockLogger
+            );
+
+            const tools = await toolManager.getAllTools();
+
+            expect(tools['mcp--legacy']?.parameters).toEqual({
+                additionalProperties: true,
                 type: 'object',
-                oneOf: expect.any(Array),
             });
         });
 


### PR DESCRIPTION
## Summary
- Add `recordOperationSpan` to capture focused OpenTelemetry spans around core turn preparation, context building, tool listing, compaction, and request setup.
- Instrument skill listing and turn model-step preparation so hosted runtimes can diagnose latency inside core operations.
- Export telemetry helpers from the browser-safe core entrypoint for Worker-hosted consumers.

## Test plan
- `pnpm vitest run packages/core/src/telemetry/operation-span.test.ts`
- `pnpm typecheck:core`
- `pnpm -C packages/core lint` (passes with one pre-existing warning in `provider-error.ts`)
- `pnpm build:core`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session title generation now returns token-usage metrics.
  * Browser-friendly telemetry API and an operation-span helper are exposed.

* **Improvements**
  * Provider/LLM errors now include structured details (provider, model, status, parsed metadata).
  * Core turn preparation is wrapped with operation-level telemetry spans.
  * Tool parameter schemas are normalized for broader provider compatibility.
  * Stream processing and retries emit richer error context and recovery guidance (e.g., billing).

* **Tests**
  * Expanded tests cover usage reporting, error mapping, stream failures, and schema normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->