### PR TITLE
Instrument turn loop spans

### DIFF
--- a/.changeset/lemon-books-happen.md
+++ b/.changeset/lemon-books-happen.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Add turn-loop tracing spans around setup, model steps, tool calls, and next-step decisions.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -135,7 +135,6 @@
         }
     },
     "dependencies": {
-        "@dexto/llm": "workspace:*",
         "@ai-sdk/amazon-bedrock": "^3.0.71",
         "@ai-sdk/anthropic": "^2.0.65",
         "@ai-sdk/cohere": "^2.0.0",
@@ -146,6 +145,7 @@
         "@ai-sdk/openai-compatible": "^1.0.30",
         "@ai-sdk/provider": "^2.0.0",
         "@ai-sdk/xai": "^2.0.0",
+        "@dexto/llm": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.28.0",
         "@openrouter/ai-sdk-provider": "^1.5.4",
         "@opentelemetry/api": "^1.9.0",
@@ -160,6 +160,7 @@
         "yaml": "^2.8.3"
     },
     "devDependencies": {
+        "@opentelemetry/context-async-hooks": "^1.28.0",
         "@opentelemetry/instrumentation-http": "^0.210.0",
         "@opentelemetry/instrumentation-undici": "^0.20.0",
         "@opentelemetry/resources": "^1.28.0",

--- a/packages/core/src/llm/executor/turn-executor.integration.test.ts
+++ b/packages/core/src/llm/executor/turn-executor.integration.test.ts
@@ -1,4 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import { z } from 'zod';
 import { parseTurnDriverState, TurnExecutor, type TurnDriverState } from './turn-executor.js';
 import { ContextManager } from '../../context/manager.js';
@@ -132,6 +137,7 @@ vi.mock('@opentelemetry/api', async (importOriginal) => {
         ...actual,
         trace: {
             ...actual.trace,
+            getTracer: actual.trace.getTracer.bind(actual.trace),
             getActiveSpan: vi.fn(() => null),
         },
     };
@@ -427,6 +433,7 @@ describe('TurnExecutor Integration Tests', () => {
     });
 
     afterEach(async () => {
+        Reflect.deleteProperty(globalThis, '__TELEMETRY__');
         vi.restoreAllMocks();
         await stores.disconnect();
         logger.destroy();
@@ -1001,6 +1008,122 @@ describe('TurnExecutor Integration Tests', () => {
                 ]);
             } finally {
                 driver.dispose();
+            }
+        });
+
+        it('records turn loop spans for model steps and tool execution', async () => {
+            const exporter = new InMemorySpanExporter();
+            const provider = new BasicTracerProvider();
+            provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+            provider.register();
+            Reflect.set(globalThis, '__TELEMETRY__', { isInitialized: () => true });
+
+            const executeTool = vi.fn(async () => 'telemetry result');
+            toolManager.addTools([
+                defineTool({
+                    id: 'telemetry_tool',
+                    description: 'Telemetry tool',
+                    inputSchema: z.object({ value: z.string() }).strict(),
+                    execute: executeTool,
+                }),
+            ]);
+
+            vi.mocked(streamText)
+                .mockImplementationOnce(
+                    () =>
+                        createMockStream({
+                            finishReason: 'tool-calls',
+                            toolCalls: [
+                                {
+                                    toolCallId: 'call-telemetry',
+                                    toolName: 'telemetry_tool',
+                                    args: { value: 'one' },
+                                },
+                            ],
+                        }) as unknown as ReturnType<typeof streamText>
+                )
+                .mockImplementationOnce(
+                    () =>
+                        createMockStream({
+                            text: 'done',
+                            finishReason: 'stop',
+                        }) as unknown as ReturnType<typeof streamText>
+                );
+
+            try {
+                await contextManager.addUserMessage([{ type: 'text', text: 'Use tools' }]);
+                await expect(executor.execute({ mcpManager }, true)).resolves.toMatchObject({
+                    finishReason: 'stop',
+                    text: 'done',
+                });
+
+                const spans = exporter.getFinishedSpans();
+                const names = spans.map((span) => span.name);
+
+                expect(names).toEqual(
+                    expect.arrayContaining([
+                        'turn.run_model_step',
+                        'llm.stream',
+                        'turn.execute_tool_calls',
+                        'tool.prepare',
+                        'tool.execute',
+                        'tool.persist_result',
+                        'turn.decide_next_step',
+                    ])
+                );
+
+                const firstModelStep = spans.find(
+                    (span) =>
+                        span.name === 'turn.run_model_step' &&
+                        span.attributes['turn.step_count'] === 0
+                );
+                const stream = spans.find((span) => span.name === 'llm.stream');
+                const executeTools = spans.find((span) => span.name === 'turn.execute_tool_calls');
+                const toolExecute = spans.find((span) => span.name === 'tool.execute');
+
+                expect(firstModelStep?.attributes).toEqual(
+                    expect.objectContaining({
+                        'llm.finish_reason': 'tool-calls',
+                        'llm.model': 'gpt-4',
+                        'llm.provider': 'openai',
+                        'tool.count': 1,
+                        'turn.step_count': 0,
+                    })
+                );
+                expect(stream?.attributes).toEqual(
+                    expect.objectContaining({
+                        'llm.finish_reason': 'tool-calls',
+                        'tool.count': 1,
+                    })
+                );
+                expect(executeTools?.attributes).toEqual(
+                    expect.objectContaining({
+                        'tool.count': 1,
+                        'turn.step_count': 0,
+                    })
+                );
+                expect(toolExecute?.attributes).toEqual(
+                    expect.objectContaining({
+                        'tool.call_id': 'call-telemetry',
+                        'tool.name': 'telemetry_tool',
+                        'tool.success': true,
+                    })
+                );
+                expect(stream).toBeDefined();
+                expect(firstModelStep).toBeDefined();
+                expect(executeTools).toBeDefined();
+                expect(toolExecute).toBeDefined();
+                if (
+                    stream === undefined ||
+                    firstModelStep === undefined ||
+                    executeTools === undefined ||
+                    toolExecute === undefined
+                ) {
+                    throw new Error('Expected telemetry spans to be recorded.');
+                }
+            } finally {
+                Reflect.deleteProperty(globalThis, '__TELEMETRY__');
+                await provider.shutdown();
             }
         });
 

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -363,6 +363,12 @@ export type TurnDriver = {
     dispose(): void;
 };
 
+type TurnStepSpanAttributes = {
+    'turn.step_count': number;
+    'llm.model': string;
+    'llm.provider': string;
+};
+
 /**
  * Static cache for tool support validation.
  * Persists across TurnExecutor instances to avoid repeated validation calls.
@@ -644,7 +650,7 @@ export class TurnExecutor {
                         {
                             name: 'turn.prepare_model_step',
                             componentName: 'TurnExecutor',
-                            attributes: { 'turn.step_count': stepCount },
+                            attributes: this.createTurnStepSpanAttributes(stepCount),
                         },
                         () =>
                             this.prepareNextModelRequest({
@@ -684,7 +690,7 @@ export class TurnExecutor {
                             {
                                 name: 'turn.prepare_model_step',
                                 componentName: 'TurnExecutor',
-                                attributes: { 'turn.step_count': stepCount },
+                                attributes: this.createTurnStepSpanAttributes(stepCount),
                             },
                             () =>
                                 this.prepareNextModelRequest({
@@ -701,7 +707,20 @@ export class TurnExecutor {
                     }
                     this.logger.debug(`Step ${stepCount}: Starting`);
 
-                    const result = await this.runModelStepWithRetry(modelStepRequest);
+                    const result = await recordOperationSpan(
+                        {
+                            name: 'turn.run_model_step',
+                            componentName: 'TurnExecutor',
+                            attributes: this.createTurnStepSpanAttributes(stepCount),
+                            resultAttributes: (stepResult) => ({
+                                'llm.finish_reason': stepResult.finishReason,
+                                'llm.output_text_length': stepResult.text.length,
+                                'tool.count': stepResult.toolCalls.length,
+                            }),
+                        },
+                        () => this.runModelStepWithRetry(modelStepRequest),
+                        this.logger
+                    );
                     currentResult = result;
                     currentToolCallsExecuted = result.finishReason !== 'tool-calls';
                     preparedModelRequest = null;
@@ -745,7 +764,18 @@ export class TurnExecutor {
                     toolCallsRunning = true;
                     currentToolCallsExecuted = true;
                     try {
-                        await this.executeModelToolCalls(result.toolCalls);
+                        await recordOperationSpan(
+                            {
+                                name: 'turn.execute_tool_calls',
+                                componentName: 'TurnExecutor',
+                                attributes: {
+                                    ...this.createTurnStepSpanAttributes(stepCount),
+                                    'tool.count': result.toolCalls.length,
+                                },
+                            },
+                            () => this.executeModelToolCalls(result.toolCalls),
+                            this.logger
+                        );
                     } catch (error) {
                         currentToolCallsExecuted = false;
                         throw error;
@@ -766,7 +796,23 @@ export class TurnExecutor {
                 if (result.finishReason === 'tool-calls' && !currentToolCallsExecuted) {
                     throw new Error('Tool calls must finish before deciding the next model step');
                 }
-                const nextStep = await this.decideNextStep(result, stepCount);
+                const nextStep = await recordOperationSpan(
+                    {
+                        name: 'turn.decide_next_step',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            ...this.createTurnStepSpanAttributes(stepCount),
+                            'llm.finish_reason': result.finishReason,
+                            'tool.calls_executed': currentToolCallsExecuted,
+                        },
+                        resultAttributes: (decision) => ({
+                            'turn.next_action': decision.kind,
+                            'turn.next_step_count': decision.stepCount,
+                        }),
+                    },
+                    () => this.decideNextStep(result, stepCount),
+                    this.logger
+                );
                 stepCount = nextStep.stepCount;
                 currentResult = null;
                 currentToolCallsExecuted = false;
@@ -878,6 +924,14 @@ export class TurnExecutor {
             [Symbol.dispose]: () => {
                 this.externalSignal?.removeEventListener('abort', abortHandler);
             },
+        };
+    }
+
+    private createTurnStepSpanAttributes(stepCount: number): TurnStepSpanAttributes {
+        return {
+            'turn.step_count': stepCount,
+            'llm.model': this.llmContext.model,
+            'llm.provider': this.llmContext.provider,
         };
     }
 
@@ -1404,29 +1458,47 @@ export class TurnExecutor {
             false
         );
 
-        return streamProcessor.process(() =>
-            streamText({
-                model: this.model,
-                stopWhen: stepCountIs(1),
-                maxRetries: 0,
-                tools: request.tools,
-                abortSignal: this.stepAbortController.signal,
-                messages: request.messages,
-                ...(this.config.maxOutputTokens !== undefined && {
-                    maxOutputTokens: this.config.maxOutputTokens,
-                }),
-                ...(this.config.temperature !== undefined && {
-                    temperature: this.config.temperature,
-                }),
-                // Provider-specific options (caching, reasoning, etc.)
-                ...(request.providerOptions !== undefined && {
-                    providerOptions: request.providerOptions,
-                }),
-                // Log stream-level errors (tool errors, API errors during streaming)
-                onError: (error) => {
-                    this.logger.error('Stream error', { error });
+        return recordOperationSpan(
+            {
+                name: 'llm.stream',
+                componentName: 'TurnExecutor',
+                attributes: {
+                    'llm.model': this.llmContext.model,
+                    'llm.provider': this.llmContext.provider,
+                    'tools.count': Object.keys(request.toolDefinitions).length,
                 },
-            })
+                resultAttributes: (result) => ({
+                    'llm.finish_reason': result.finishReason,
+                    'llm.output_text_length': result.text.length,
+                    'tool.count': result.toolCalls.length,
+                }),
+            },
+            () =>
+                streamProcessor.process(() =>
+                    streamText({
+                        model: this.model,
+                        stopWhen: stepCountIs(1),
+                        maxRetries: 0,
+                        tools: request.tools,
+                        abortSignal: this.stepAbortController.signal,
+                        messages: request.messages,
+                        ...(this.config.maxOutputTokens !== undefined && {
+                            maxOutputTokens: this.config.maxOutputTokens,
+                        }),
+                        ...(this.config.temperature !== undefined && {
+                            temperature: this.config.temperature,
+                        }),
+                        // Provider-specific options (caching, reasoning, etc.)
+                        ...(request.providerOptions !== undefined && {
+                            providerOptions: request.providerOptions,
+                        }),
+                        // Log stream-level errors (tool errors, API errors during streaming)
+                        onError: (error) => {
+                            this.logger.error('Stream error', { error });
+                        },
+                    })
+                ),
+            this.logger
         );
     }
 
@@ -1530,11 +1602,42 @@ export class TurnExecutor {
         const preparedCalls: PreparedModelToolCall[] = [];
 
         for (const toolCall of toolCalls) {
-            preparedCalls.push(await this.prepareModelToolCall(toolCall));
+            preparedCalls.push(
+                await recordOperationSpan(
+                    {
+                        name: 'tool.prepare',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            'tool.call_id': toolCall.toolCallId,
+                            'tool.name': toolCall.toolName,
+                        },
+                        resultAttributes: (prepared) => ({ 'tool.prepare_kind': prepared.kind }),
+                    },
+                    () => this.prepareModelToolCall(toolCall),
+                    this.logger
+                )
+            );
         }
 
         const executionResults = await Promise.all(
-            preparedCalls.map((prepared) => this.executePreparedModelToolCall(prepared))
+            preparedCalls.map((prepared) =>
+                recordOperationSpan(
+                    {
+                        name: 'tool.execute',
+                        componentName: 'TurnExecutor',
+                        attributes: {
+                            'tool.call_id': prepared.toolCall.toolCallId,
+                            'tool.name': prepared.toolCall.toolName,
+                            'tool.prepare_kind': prepared.kind,
+                        },
+                        resultAttributes: (result) => ({
+                            'tool.success': this.isToolExecutionSuccessful(result),
+                        }),
+                    },
+                    () => this.executePreparedModelToolCall(prepared),
+                    this.logger
+                )
+            )
         );
         for (let index = 0; index < toolCalls.length; index += 1) {
             const toolCall = toolCalls[index];
@@ -1542,7 +1645,19 @@ export class TurnExecutor {
             if (toolCall === undefined || executionResult === undefined) {
                 throw new Error('Tool call result count must match emitted tool call count');
             }
-            await this.persistModelToolResult(toolCall, executionResult);
+            await recordOperationSpan(
+                {
+                    name: 'tool.persist_result',
+                    componentName: 'TurnExecutor',
+                    attributes: {
+                        'tool.call_id': toolCall.toolCallId,
+                        'tool.name': toolCall.toolName,
+                        'tool.success': this.isToolExecutionSuccessful(executionResult),
+                    },
+                },
+                () => this.persistModelToolResult(toolCall, executionResult),
+                this.logger
+            );
         }
     }
 

--- a/packages/core/src/llm/services/vercel.ts
+++ b/packages/core/src/llm/services/vercel.ts
@@ -23,6 +23,7 @@ import { ErrorScope, ErrorType } from '../../errors/types.js';
 import { LLMErrorCode } from '../error-codes.js';
 import type { ContentInput } from '../../agent/types.js';
 import type { AgentRunContext } from '../../runtime/run-context.js';
+import { recordOperationSpan } from '../../telemetry/operation-span.js';
 
 export function ensureRunContextMatchesServiceSession(
     serviceSessionId: string,
@@ -152,11 +153,39 @@ export class VercelLLMService {
     async createTurnDriver(options: CreateTurnDriverOptions = {}): Promise<TurnDriver> {
         const sessionId = ensureRunContextMatchesServiceSession(this.sessionId, options.runContext);
         const executor = this.createTurnExecutor(options.signal, options.runContext);
-        const contributorContext = await this.toolManager.buildContributorContext({ sessionId });
-        return executor.createDriver(contributorContext, {
-            streaming: options.streaming ?? true,
-            ...(options.state !== undefined ? { state: options.state } : {}),
-        });
+        const contributorContext = await recordOperationSpan(
+            {
+                name: 'llm.vercel.build_contributor_context',
+                attributes: {
+                    'session.id': sessionId,
+                },
+                resultAttributes: (context) => ({
+                    'tool.has_workspace_context': context.workspace !== null,
+                    'tool.has_environment_context': context.environment !== undefined,
+                    'tool.session_prompt_contributors':
+                        context.session?.systemPromptContributors?.length ?? 0,
+                }),
+            },
+            () => this.toolManager.buildContributorContext({ sessionId }),
+            this.logger
+        );
+        const streaming = options.streaming ?? true;
+        return recordOperationSpan(
+            {
+                name: 'llm.vercel.create_turn_executor_driver',
+                attributes: {
+                    'session.id': sessionId,
+                    'turn.streaming': streaming,
+                    'turn.resume': options.state !== undefined,
+                },
+            },
+            () =>
+                executor.createDriver(contributorContext, {
+                    streaming,
+                    ...(options.state !== undefined ? { state: options.state } : {}),
+                }),
+            this.logger
+        );
     }
 
     /**

--- a/packages/core/src/session/chat-session.test.ts
+++ b/packages/core/src/session/chat-session.test.ts
@@ -1,4 +1,11 @@
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { context as otelContext, trace } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
+import {
+    BasicTracerProvider,
+    InMemorySpanExporter,
+    SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
 import { ChatSession } from './chat-session.js';
 import { type ValidatedLLMConfig } from '../llm/schemas.js';
 import { LLMConfigSchema } from '../llm/schemas.js';
@@ -317,6 +324,8 @@ describe('ChatSession', () => {
         if (chatSession) {
             chatSession.dispose();
         }
+        Reflect.deleteProperty(globalThis, '__TELEMETRY__');
+        trace.disable();
     });
 
     describe('Session Identity and Lifecycle', () => {
@@ -650,6 +659,59 @@ describe('ChatSession', () => {
             mockServices.agentEventBus.emit.mockClear();
             chatSession.eventBus.emit('llm:thinking', {});
             expect(mockServices.agentEventBus.emit).not.toHaveBeenCalled();
+        });
+
+        test('records setup spans under the active trace parent', async () => {
+            const exporter = new InMemorySpanExporter();
+            const provider = new BasicTracerProvider();
+            const contextManager = new AsyncHooksContextManager().enable();
+            provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
+            provider.register({ contextManager });
+            Reflect.set(globalThis, '__TELEMETRY__', { isInitialized: () => true });
+
+            await chatSession.init();
+            mockLLMService.createTurnDriver.mockResolvedValue(createMockTurnDriver());
+
+            const parentSpan = trace.getTracer('test').startSpan('cloud.parent_turn');
+            try {
+                await otelContext.with(trace.setSpan(otelContext.active(), parentSpan), () =>
+                    chatSession.createTurnDriver({
+                        kind: 'start',
+                        content: 'hello',
+                    })
+                );
+
+                const spans = exporter.getFinishedSpans();
+                const parentContext = parentSpan.spanContext();
+                const setupSpans = spans.filter((span) =>
+                    [
+                        'chat_session.prepare_turn_input',
+                        'chat_session.add_user_message',
+                        'chat_session.create_llm_turn_driver',
+                    ].includes(span.name)
+                );
+
+                expect(setupSpans.map((span) => span.name)).toEqual([
+                    'chat_session.prepare_turn_input',
+                    'chat_session.add_user_message',
+                    'chat_session.create_llm_turn_driver',
+                ]);
+                expect(setupSpans).toHaveLength(3);
+                for (const span of setupSpans) {
+                    expect(span.spanContext().traceId).toBe(parentContext.traceId);
+                    expect(span).toHaveProperty('parentSpanId', parentContext.spanId);
+                    expect(span.attributes).toEqual(
+                        expect.objectContaining({
+                            'session.id': sessionId,
+                            'turn.kind': 'start',
+                        })
+                    );
+                }
+            } finally {
+                parentSpan.end();
+                await provider.shutdown();
+                contextManager.disable();
+            }
         });
 
         test('checkpoints through the session driver and resumes that state without a new user message', async () => {

--- a/packages/core/src/session/chat-session.ts
+++ b/packages/core/src/session/chat-session.ts
@@ -37,6 +37,7 @@ import type { VercelLLMService } from '../llm/services/vercel.js';
 import type { AgentRunContext } from '../runtime/run-context.js';
 import { SessionError } from './errors.js';
 import type { TurnDriver, TurnDriverState } from '../llm/executor/turn-executor.js';
+import { recordOperationSpan } from '../telemetry/operation-span.js';
 
 export type ChatSessionTurnDriverInput =
     | {
@@ -638,20 +639,50 @@ export class ChatSession {
 
         try {
             if (input.kind === 'start') {
-                const modifiedParts = await this.prepareTurnInput(
-                    input.content,
-                    signal,
-                    input.runContext
+                const modifiedParts = await recordOperationSpan(
+                    {
+                        name: 'chat_session.prepare_turn_input',
+                        attributes: {
+                            'session.id': this.id,
+                            'turn.kind': input.kind,
+                        },
+                    },
+                    () => this.prepareTurnInput(input.content, signal, input.runContext),
+                    this.logger
                 );
-                await this.llmService.getContextManager().addUserMessage(modifiedParts);
+                await recordOperationSpan(
+                    {
+                        name: 'chat_session.add_user_message',
+                        attributes: {
+                            'session.id': this.id,
+                            'turn.kind': input.kind,
+                            'message.parts': modifiedParts.length,
+                        },
+                    },
+                    () => this.llmService.getContextManager().addUserMessage(modifiedParts),
+                    this.logger
+                );
             }
 
-            const driver = await this.llmService.createTurnDriver({
-                signal,
-                streaming: input.streaming ?? true,
-                ...(input.runContext !== undefined && { runContext: input.runContext }),
-                ...(input.kind === 'resume' ? { state: input.state } : {}),
-            });
+            const streaming = input.streaming ?? true;
+            const driver = await recordOperationSpan(
+                {
+                    name: 'chat_session.create_llm_turn_driver',
+                    attributes: {
+                        'session.id': this.id,
+                        'turn.kind': input.kind,
+                        'turn.streaming': streaming,
+                    },
+                },
+                () =>
+                    this.llmService.createTurnDriver({
+                        signal,
+                        streaming,
+                        ...(input.runContext !== undefined && { runContext: input.runContext }),
+                        ...(input.kind === 'resume' ? { state: input.state } : {}),
+                    }),
+                this.logger
+            );
 
             return this.wrapTurnDriver(driver, signal, input.runContext, detachForwarders);
         } catch (error) {

--- a/packages/core/src/telemetry/decorators.ts
+++ b/packages/core/src/telemetry/decorators.ts
@@ -6,6 +6,7 @@ import {
     propagation,
     SpanOptions,
     type BaggageEntry,
+    type Span,
 } from '@opentelemetry/api';
 import type { Logger } from '../logger/v2/types.js';
 import { hasActiveTelemetry, getBaggageValues } from './utils.js';
@@ -56,18 +57,11 @@ export function withSpan(options: {
                 }
             }
 
-            // Start the span with optional kind
             const spanOptions: SpanOptions = {};
             if (spanKind !== undefined) {
                 spanOptions.kind = spanKind;
             }
-            const span = tracer.startSpan(spanName, spanOptions);
-            let ctx = trace.setSpan(context.active(), span);
-
-            // Record input arguments as span attributes (sanitized and truncated)
-            args.forEach((arg, index) => {
-                span.setAttribute(`${spanName}.argument.${index}`, safeStringify(arg, 8192));
-            });
+            let ctx = context.active();
 
             // Extract baggage values from the current context (may include values set by parent spans)
             const {
@@ -80,58 +74,65 @@ export function withSpan(options: {
                 hostRuntime,
             } = getBaggageValues(ctx);
 
-            // Add all baggage values to span attributes
-            // Set both direct attributes and baggage-prefixed versions for storage schema fallback
-            if (sessionId) {
-                span.setAttribute('sessionId', sessionId);
-                span.setAttribute('baggage.sessionId', sessionId); // Fallback for storage
-            }
-
-            if (requestId) {
-                span.setAttribute('http.request_id', requestId);
-                span.setAttribute('baggage.http.request_id', requestId);
-            }
-
-            if (threadId) {
-                span.setAttribute('threadId', threadId);
-                span.setAttribute('baggage.threadId', threadId);
-            }
-
-            if (resourceId) {
-                span.setAttribute('resourceId', resourceId);
-                span.setAttribute('baggage.resourceId', resourceId);
-            }
-
-            if (runId !== undefined) {
-                span.setAttribute('runId', String(runId));
-                span.setAttribute('baggage.runId', String(runId));
-            }
-
-            for (const [key, value] of Object.entries(getHostRuntimeAttributes(hostRuntime))) {
-                span.setAttribute(key, value);
-            }
-
             const inferredComponentName = options?.componentName;
             const effectiveHostRuntime = hostRuntime;
             const effectiveRunId = effectiveHostRuntime?.ids?.runId ?? runId;
 
-            if (componentName) {
-                span.setAttribute('componentName', componentName);
-                span.setAttribute('baggage.componentName', componentName);
-            } else if (inferredComponentName) {
-                span.setAttribute('componentName', inferredComponentName);
-            }
+            const applySpanAttributes = (span: Span) => {
+                // Record input arguments as span attributes (sanitized and truncated)
+                args.forEach((arg, index) => {
+                    span.setAttribute(`${spanName}.argument.${index}`, safeStringify(arg, 8192));
+                });
 
-            if (effectiveRunId !== undefined) {
-                span.setAttribute('runId', String(effectiveRunId));
-                span.setAttribute('baggage.runId', String(effectiveRunId));
-            }
+                // Add all baggage values to span attributes
+                // Set both direct attributes and baggage-prefixed versions for storage schema fallback
+                if (sessionId) {
+                    span.setAttribute('sessionId', sessionId);
+                    span.setAttribute('baggage.sessionId', sessionId); // Fallback for storage
+                }
 
-            for (const [key, value] of Object.entries(
-                getHostRuntimeAttributes(effectiveHostRuntime)
-            )) {
-                span.setAttribute(key, value);
-            }
+                if (requestId) {
+                    span.setAttribute('http.request_id', requestId);
+                    span.setAttribute('baggage.http.request_id', requestId);
+                }
+
+                if (threadId) {
+                    span.setAttribute('threadId', threadId);
+                    span.setAttribute('baggage.threadId', threadId);
+                }
+
+                if (resourceId) {
+                    span.setAttribute('resourceId', resourceId);
+                    span.setAttribute('baggage.resourceId', resourceId);
+                }
+
+                if (runId !== undefined) {
+                    span.setAttribute('runId', String(runId));
+                    span.setAttribute('baggage.runId', String(runId));
+                }
+
+                for (const [key, value] of Object.entries(getHostRuntimeAttributes(hostRuntime))) {
+                    span.setAttribute(key, value);
+                }
+
+                if (componentName) {
+                    span.setAttribute('componentName', componentName);
+                    span.setAttribute('baggage.componentName', componentName);
+                } else if (inferredComponentName) {
+                    span.setAttribute('componentName', inferredComponentName);
+                }
+
+                if (effectiveRunId !== undefined) {
+                    span.setAttribute('runId', String(effectiveRunId));
+                    span.setAttribute('baggage.runId', String(effectiveRunId));
+                }
+
+                for (const [key, value] of Object.entries(
+                    getHostRuntimeAttributes(effectiveHostRuntime)
+                )) {
+                    span.setAttribute(key, value);
+                }
+            };
 
             // Merge with existing baggage to preserve parent context values.
             const existingBaggage = propagation.getBaggage(ctx);
@@ -186,59 +187,62 @@ export function withSpan(options: {
                 ctx = propagation.setBaggage(ctx, propagation.createBaggage(baggageEntries));
             }
 
-            let result: unknown;
-            try {
-                // Call the original method within the context
-                result = context.with(ctx, () => originalMethod.apply(this, args));
+            return tracer.startActiveSpan(spanName, spanOptions, ctx, (span) => {
+                applySpanAttributes(span);
 
-                // Handle promises
-                if (result instanceof Promise) {
-                    return result
-                        .then((resolvedValue) => {
-                            span.setAttribute(
-                                `${spanName}.result`,
-                                safeStringify(resolvedValue, 8192)
-                            );
-                            return resolvedValue;
-                        })
-                        .catch((error) => {
-                            span.recordException(error);
-                            span.setStatus({
-                                code: SpanStatusCode.ERROR,
-                                message: error?.toString(),
+                let result: unknown;
+                try {
+                    result = originalMethod.apply(this, args);
+
+                    // Handle promises
+                    if (result instanceof Promise) {
+                        return result
+                            .then((resolvedValue) => {
+                                span.setAttribute(
+                                    `${spanName}.result`,
+                                    safeStringify(resolvedValue, 8192)
+                                );
+                                return resolvedValue;
+                            })
+                            .catch((error) => {
+                                span.recordException(error);
+                                span.setStatus({
+                                    code: SpanStatusCode.ERROR,
+                                    message: error?.toString(),
+                                });
+                                throw error;
+                            })
+                            .finally(() => {
+                                span.end();
                             });
-                            throw error;
-                        })
-                        .finally(() => {
-                            span.end();
-                        });
-                }
+                    }
 
-                // Record result for non-promise returns (sanitized and truncated)
-                span.setAttribute(`${spanName}.result`, safeStringify(result, 8192));
-                // Return regular results
-                return result;
-            } catch (error) {
-                // Try to use instance logger if available (DI pattern)
-                const logger = (this as any)?.logger as Logger | undefined;
-                logger?.error(
-                    `withSpan: Error in method '${methodName}': ${error instanceof Error ? error.message : String(error)}`,
-                    { error }
-                );
-                span.setStatus({
-                    code: SpanStatusCode.ERROR,
-                    message: error instanceof Error ? error.message : 'Unknown error',
-                });
-                if (error instanceof Error) {
-                    span.recordException(error);
+                    // Record result for non-promise returns (sanitized and truncated)
+                    span.setAttribute(`${spanName}.result`, safeStringify(result, 8192));
+                    // Return regular results
+                    return result;
+                } catch (error) {
+                    // Try to use instance logger if available (DI pattern)
+                    const logger = (this as any)?.logger as Logger | undefined;
+                    logger?.error(
+                        `withSpan: Error in method '${methodName}': ${error instanceof Error ? error.message : String(error)}`,
+                        { error }
+                    );
+                    span.setStatus({
+                        code: SpanStatusCode.ERROR,
+                        message: error instanceof Error ? error.message : 'Unknown error',
+                    });
+                    if (error instanceof Error) {
+                        span.recordException(error);
+                    }
+                    throw error;
+                } finally {
+                    // End span for non-promise returns
+                    if (!(result instanceof Promise)) {
+                        span.end();
+                    }
                 }
-                throw error;
-            } finally {
-                // End span for non-promise returns
-                if (!(result instanceof Promise)) {
-                    span.end();
-                }
-            }
+            });
         };
 
         return descriptor;

--- a/packages/core/src/telemetry/operation-span.test.ts
+++ b/packages/core/src/telemetry/operation-span.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { SpanStatusCode, trace } from '@opentelemetry/api';
+import { AsyncHooksContextManager } from '@opentelemetry/context-async-hooks';
 import {
     BasicTracerProvider,
     InMemorySpanExporter,
@@ -8,14 +9,16 @@ import {
 import { recordOperationSpan } from './operation-span.js';
 
 describe('recordOperationSpan', () => {
+    let contextManager: AsyncHooksContextManager | undefined;
     let exporter: InMemorySpanExporter;
     let provider: BasicTracerProvider | undefined;
 
     beforeEach(() => {
+        contextManager = new AsyncHooksContextManager().enable();
         exporter = new InMemorySpanExporter();
         provider = new BasicTracerProvider();
         provider.addSpanProcessor(new SimpleSpanProcessor(exporter));
-        provider.register();
+        provider.register({ contextManager });
     });
 
     afterEach(async () => {
@@ -23,6 +26,8 @@ describe('recordOperationSpan', () => {
             await provider.shutdown();
             provider = undefined;
         }
+        contextManager?.disable();
+        contextManager = undefined;
         trace.disable();
     });
 
@@ -70,5 +75,30 @@ describe('recordOperationSpan', () => {
             .find((span) => span.name === 'context.token_estimate');
 
         expect(span?.status.code).toBe(SpanStatusCode.OK);
+    });
+
+    it('keeps spans created inside the operation under the operation span', async () => {
+        await recordOperationSpan(
+            {
+                name: 'operation.parent',
+                skipIfNoTelemetry: false,
+            },
+            () =>
+                trace.getTracer('test').startActiveSpan('operation.child', (span) => {
+                    span.end();
+                    return 'ok';
+                })
+        );
+
+        const parent = exporter.getFinishedSpans().find((span) => span.name === 'operation.parent');
+        const child = exporter.getFinishedSpans().find((span) => span.name === 'operation.child');
+
+        expect(parent).toBeDefined();
+        expect(child).toBeDefined();
+        if (parent === undefined || child === undefined) {
+            throw new Error('Expected parent and child spans to be recorded.');
+        }
+        expect(child.spanContext().traceId).toBe(parent.spanContext().traceId);
+        expect(child).toHaveProperty('parentSpanId', parent.spanContext().spanId);
     });
 });

--- a/packages/core/src/telemetry/operation-span.ts
+++ b/packages/core/src/telemetry/operation-span.ts
@@ -25,40 +25,41 @@ export async function recordOperationSpan<T>(
         return operation();
     }
 
-    const span = trace
+    return trace
         .getTracer(options.tracerName ?? 'dexto')
-        .startSpan(options.name, { kind: SpanKind.INTERNAL });
-    const spanContext = trace.setSpan(context.active(), span);
+        .startActiveSpan(options.name, { kind: SpanKind.INTERNAL }, async (span) => {
+            const spanContext = trace.setSpan(context.active(), span);
 
-    addBaggageAttributesToSpan(span, spanContext, logger);
-    if (options.componentName !== undefined) {
-        span.setAttribute('componentName', options.componentName);
-    }
-    setOperationSpanAttributes(span, options.attributes);
+            addBaggageAttributesToSpan(span, spanContext, logger);
+            if (options.componentName !== undefined) {
+                span.setAttribute('componentName', options.componentName);
+            }
+            setOperationSpanAttributes(span, options.attributes);
 
-    try {
-        const result = await context.with(spanContext, operation);
-        try {
-            setOperationSpanAttributes(span, options.resultAttributes?.(result));
-        } catch (error) {
-            logger?.debug('Failed to set OpenTelemetry result attributes', {
-                error: error instanceof Error ? error.message : String(error),
-                span: options.name,
-            });
-        }
-        span.setStatus({ code: SpanStatusCode.OK });
-        return result;
-    } catch (error) {
-        if (error instanceof Error) {
-            span.recordException(error);
-            span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-        } else {
-            span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
-        }
-        throw error;
-    } finally {
-        span.end();
-    }
+            try {
+                const result = await operation();
+                try {
+                    setOperationSpanAttributes(span, options.resultAttributes?.(result));
+                } catch (error) {
+                    logger?.debug('Failed to set OpenTelemetry result attributes', {
+                        error: error instanceof Error ? error.message : String(error),
+                        span: options.name,
+                    });
+                }
+                span.setStatus({ code: SpanStatusCode.OK });
+                return result;
+            } catch (error) {
+                if (error instanceof Error) {
+                    span.recordException(error);
+                    span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+                } else {
+                    span.setStatus({ code: SpanStatusCode.ERROR, message: String(error) });
+                }
+                throw error;
+            } finally {
+                span.end();
+            }
+        });
 }
 
 function setOperationSpanAttributes(

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -125,9 +125,14 @@ function mergePropertySchema(
         return current;
     }
 
-    const enumValues = [...(readEnumValues(current) ?? []), ...(readEnumValues(next) ?? [])];
-    if (enumValues.length > 0) {
-        return { enum: mergeEnumValues(enumValues) };
+    const currentEnumValues = readEnumValues(current);
+    const nextEnumValues = readEnumValues(next);
+    if (currentEnumValues !== undefined && nextEnumValues !== undefined) {
+        return { enum: mergeEnumValues([...currentEnumValues, ...nextEnumValues]) };
+    }
+
+    if (currentEnumValues !== undefined || nextEnumValues !== undefined) {
+        return {};
     }
 
     if (current.type !== undefined && valuesEqual(current.type, next.type)) {

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -125,10 +125,9 @@ function mergePropertySchema(
         return current;
     }
 
-    const currentEnum = readEnumValues(current);
-    const nextEnum = readEnumValues(next);
-    if (currentEnum !== undefined && nextEnum !== undefined) {
-        return { enum: mergeEnumValues([...currentEnum, ...nextEnum]) };
+    const enumValues = [...(readEnumValues(current) ?? []), ...(readEnumValues(next) ?? [])];
+    if (enumValues.length > 0) {
+        return { enum: mergeEnumValues(enumValues) };
     }
 
     if (current.type !== undefined && valuesEqual(current.type, next.type)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
         specifier: ^2.8.3
         version: 2.8.3
     devDependencies:
+      '@opentelemetry/context-async-hooks':
+        specifier: ^1.28.0
+        version: 1.28.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-http':
         specifier: ^0.210.0
         version: 0.210.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary
- add top-level turn loop spans for model execution, tool execution, and next-step decisions
- add per-tool prepare, execute, and persist spans
- attach step/model/provider and result attributes so hosted traces can explain latency inside the agent loop

## Validation
- pnpm --filter @dexto/llm build
- pnpm --filter @dexto/core lint
- pnpm --filter @dexto/core build
- pnpm vitest run packages/core/src/llm/executor/turn-executor.integration.test.ts
- pnpm typecheck:core
- pnpm prettier --check packages/core/src/llm/executor/turn-executor.ts packages/core/src/llm/executor/turn-executor.integration.test.ts

## Cloud preview bridge
Cloud PR truffle-ai/dexto-cloudflare#85 includes a temporary packed @dexto/core artifact from this branch so its preview can validate these spans before this core PR is merged/published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive telemetry tracing for turn-loop execution, including model steps, tool execution, and decision-making phases.
  * Enhanced observability for LLM streaming and tool call operations with detailed span attributes.

* **Bug Fixes**
  * Improved enum/const value merging logic in property schemas.

* **Tests**
  * Added integration tests for turn-loop tracing and telemetry spans.
  * Added telemetry validation tests for chat session operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->