### PR TITLE
Fix OpenRouter adaptive reasoning variants

### DIFF
--- a/.changeset/large-trams-do.md
+++ b/.changeset/large-trams-do.md
@@ -1,0 +1,5 @@
+---
+'@dexto/llm': patch
+---
+
+Remove unsupported max reasoning from OpenRouter and Dexto Nova adaptive profiles

--- a/packages/core/src/llm/executor/provider-options.test.ts
+++ b/packages/core/src/llm/executor/provider-options.test.ts
@@ -368,19 +368,14 @@ describe('buildProviderOptions', () => {
             });
         });
 
-        it('maps Anthropic adaptive max to OpenRouter xhigh effort', () => {
+        it('does not map Anthropic-only adaptive max on gateway providers', () => {
             expect(
                 buildProviderOptions({
                     provider: 'openrouter',
                     model: 'anthropic/claude-opus-4.6',
                     reasoning: { variant: 'max' },
                 })
-            ).toEqual({
-                openrouter: {
-                    include_reasoning: true,
-                    reasoning: { enabled: true, effort: 'xhigh' },
-                },
-            });
+            ).toBeUndefined();
         });
 
         it('uses max_tokens when budgetTokens is provided', () => {
@@ -475,7 +470,7 @@ describe('buildProviderOptions', () => {
                 },
                 {
                     model: 'anthropic/claude-opus-4.7',
-                    reasoning: { variant: 'max' as const },
+                    reasoning: { variant: 'xhigh' as const },
                 },
                 {
                     model: 'anthropic/claude-sonnet-4.5',

--- a/packages/core/src/llm/executor/provider-options.ts
+++ b/packages/core/src/llm/executor/provider-options.ts
@@ -195,12 +195,7 @@ function buildOpenRouterProviderOptions(config: {
         return undefined;
     }
 
-    const explicitEffort = toOpenAIReasoningEffort(reasoningVariant);
-    const effort =
-        explicitEffort ??
-        (profile.paradigm === 'adaptive-effort' && reasoningVariant === 'max'
-            ? 'xhigh'
-            : undefined);
+    const effort = toOpenAIReasoningEffort(reasoningVariant);
 
     return {
         [provider]: {

--- a/packages/llm/src/reasoning/profile.test.ts
+++ b/packages/llm/src/reasoning/profile.test.ts
@@ -163,7 +163,7 @@ describe('getReasoningProfile', () => {
         expect(getReasoningProfile('openrouter', 'anthropic/claude-fable-5')).toMatchObject({
             capable: true,
             paradigm: 'adaptive-effort',
-            supportedVariants: ['low', 'medium', 'high', 'xhigh', 'max'],
+            supportedVariants: ['low', 'medium', 'high', 'xhigh'],
             defaultVariant: 'high',
             supportsBudgetTokens: true,
         });
@@ -205,9 +205,13 @@ describe('getReasoningProfile', () => {
             const gateways = ['openrouter', 'dexto-nova'] as const;
             for (const gateway of gateways) {
                 const gatewayProfile = getReasoningProfile(gateway, entry.gatewayModel);
+                const expectedVariants =
+                    native.paradigm === 'adaptive-effort'
+                        ? native.supportedVariants.filter((variant) => variant !== 'max')
+                        : native.supportedVariants;
                 expect(gatewayProfile.capable).toBe(native.capable);
                 expect(gatewayProfile.paradigm).toBe(native.paradigm);
-                expect(gatewayProfile.supportedVariants).toEqual(native.supportedVariants);
+                expect(gatewayProfile.supportedVariants).toEqual(expectedVariants);
                 expect(gatewayProfile.defaultVariant).toBe(native.defaultVariant);
             }
         }

--- a/packages/llm/src/reasoning/profile.ts
+++ b/packages/llm/src/reasoning/profile.ts
@@ -93,11 +93,20 @@ function toGatewayReasoningProfile(nativeProfile: ReasoningProfile): ReasoningPr
         return nonCapableProfile();
     }
 
+    const variants =
+        nativeProfile.paradigm === 'adaptive-effort'
+            ? nativeProfile.variants.filter((variant) => variant.id !== 'max')
+            : nativeProfile.variants.map((variant) => ({ ...variant }));
+    const defaultVariant =
+        // Variants are ordered lowest to highest effort, so this picks the strongest gateway-safe fallback.
+        nativeProfile.defaultVariant === 'max' ? variants.at(-1)?.id : nativeProfile.defaultVariant;
+
     return {
         ...nativeProfile,
-        variants: nativeProfile.variants.map((variant) => ({ ...variant })),
-        supportedVariants: [...nativeProfile.supportedVariants],
+        variants,
+        supportedVariants: variants.map((variant) => variant.id),
         supportsBudgetTokens: true,
+        ...(defaultVariant !== undefined && { defaultVariant }),
     };
 }
 


### PR DESCRIPTION
## Summary
- remove native-only max from OpenRouter/Dexto Nova adaptive reasoning profiles
- keep native Anthropic adaptive profiles unchanged
- reject explicit gateway max instead of remapping it to xhigh
- add a patch changeset for @dexto/llm

## Testing
- pnpm --filter @dexto/llm test -- src/reasoning/profile.test.ts --runInBand
- pnpm --filter @dexto/llm lint
- pnpm --filter @dexto/llm typecheck
- pnpm --filter @dexto/llm test
- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm test
- pnpm build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsupported "max" reasoning variant from adaptive profiles for OpenRouter to prevent incorrect option mappings.
* **Tests**
  * Updated tests to reflect the changed supported-variant behavior and maintain gateway-vs-native alignment.
* **Chores**
  * Recorded a patch-level release entry documenting the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->