### PR TITLE
Retain media from model-visible tool results

### DIFF
--- a/.changeset/bright-tools-see-media.md
+++ b/.changeset/bright-tools-see-media.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Retain recent tool-returned media in LLM context so model-visible tool outputs are rehydrated like user attachments.

--- a/packages/core/src/context/manager.test.ts
+++ b/packages/core/src/context/manager.test.ts
@@ -260,7 +260,7 @@ describe('ContextManager', () => {
             ]);
         });
 
-        it('should not rehydrate tool media for the LLM', async () => {
+        it('should rehydrate recent tool media for the LLM', async () => {
             const formatter = createMockFormatter();
             const stores = new InMemoryDextoStores();
             const resourceManager = {
@@ -293,7 +293,7 @@ describe('ContextManager', () => {
                     {
                         role: 'tool',
                         toolCallId: 'call-tool-image',
-                        name: 'read_media_file',
+                        name: 'media_tool',
                         success: true,
                         content: [
                             {
@@ -309,7 +309,90 @@ describe('ContextManager', () => {
             const formattedHistory = vi.mocked(formatter.format).mock
                 .calls[0]?.[0] as InternalMessage[];
             expect(formattedHistory[0]?.content).toEqual([
+                { type: 'image', image: 'tool-image-data', mimeType: 'image/png' },
+            ]);
+        });
+
+        it('should keep older tool media compact after the media retention limit', async () => {
+            const formatter = createMockFormatter();
+            const stores = new InMemoryDextoStores();
+            const resourceManager = {
+                read: vi.fn(async (uri: string) => {
+                    if (uri === 'blob:tool-image') {
+                        return {
+                            contents: [{ blob: 'tool-image-data', mimeType: 'image/png' }],
+                            _meta: { size: 4096, originalName: 'tool-image.png' },
+                        };
+                    }
+                    if (uri === 'blob:middle-image') {
+                        return {
+                            contents: [{ blob: 'middle-image-data', mimeType: 'image/png' }],
+                            _meta: { size: 2048, originalName: 'middle-image.png' },
+                        };
+                    }
+                    if (uri === 'blob:new-image') {
+                        return {
+                            contents: [{ blob: 'new-image-data', mimeType: 'image/png' }],
+                            _meta: { size: 3072, originalName: 'new-image.png' },
+                        };
+                    }
+                    throw new Error(`Unexpected blob URI: ${uri}`);
+                }),
+                getArtifactStore: vi.fn().mockReturnValue(stores.getStore('artifacts')),
+            } as unknown as ResourceManager;
+
+            const contextManager = createContextManager({
+                formatter,
+                resourceManager,
+                llmConfig: {
+                    ...createMockLLMConfig(),
+                    allowedMediaTypes: ['image/*'],
+                } as ValidatedLLMConfig,
+            });
+
+            await contextManager.getFormattedMessages(
+                createMockContributorContext(),
+                { provider: 'openai', model: 'gpt-4' },
+                'System prompt',
+                [
+                    {
+                        role: 'tool',
+                        toolCallId: 'call-tool-image',
+                        name: 'media_tool',
+                        success: true,
+                        content: [
+                            {
+                                type: 'image',
+                                image: '@blob:tool-image',
+                                mimeType: 'image/png',
+                            },
+                        ],
+                    } as InternalMessage,
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'image', image: '@blob:middle-image', mimeType: 'image/png' },
+                        ],
+                    } as InternalMessage,
+                    {
+                        role: 'user',
+                        content: [
+                            { type: 'image', image: '@blob:new-image', mimeType: 'image/png' },
+                        ],
+                    } as InternalMessage,
+                ]
+            );
+
+            const formattedHistory = vi.mocked(formatter.format).mock
+                .calls[0]?.[0] as InternalMessage[];
+            expect(formattedHistory[0]?.content).toEqual([
                 { type: 'text', text: '[Image: tool-image.png (4 KB)]' },
+            ]);
+            expect(formattedHistory[1]?.content).toEqual([
+                { type: 'image', image: 'middle-image-data', mimeType: 'image/png' },
+            ]);
+            expect(formattedHistory[2]?.content).toEqual([
+                { type: 'image', image: 'new-image-data', mimeType: 'image/png' },
             ]);
         });
     });
@@ -516,17 +599,13 @@ describe('ContextManager', () => {
                     },
                 ],
                 meta: {
-                    toolName: 'read_media_file',
+                    toolName: 'media_tool',
                     toolCallId: 'call-existing-blob',
                     success: true,
                 },
             };
 
-            await contextManager.addToolResult(
-                'call-existing-blob',
-                'read_media_file',
-                sanitizedResult
-            );
+            await contextManager.addToolResult('call-existing-blob', 'media_tool', sanitizedResult);
 
             const history = await contextManager.getHistory();
             expect(history[0]?.content).toEqual([

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -1030,9 +1030,8 @@ export class ContextManager<TMessage = unknown> {
         }
 
         // Resolve blob references using resource manager with filtering.
-        // Only recent user media is rehydrated into model-visible binary parts.
-        // Tool media stays as compact resource text so large tool outputs cannot
-        // balloon the prompt on later turns.
+        // Recent user and tool media is rehydrated into binary parts. Older media
+        // stays compact so large attachments cannot balloon later prompts.
         this.logger.debug('Resolving blob references in message history before formatting');
         const retainedMediaMessageIndexes = new Set<number>();
         let retainedMediaMessages = 0;
@@ -1042,7 +1041,10 @@ export class ContextManager<TMessage = unknown> {
             }
 
             const message = messageHistory[index]!;
-            if (isUserMessage(message) && ContextManager.hasRetainableMedia(message)) {
+            if (
+                (isUserMessage(message) || isToolMessage(message)) &&
+                ContextManager.hasRetainableMedia(message)
+            ) {
                 retainedMediaMessageIndexes.add(index);
                 retainedMediaMessages += 1;
             }
@@ -1066,12 +1068,13 @@ export class ContextManager<TMessage = unknown> {
                     return { ...message, content: expandedContent };
                 }
                 if (isToolMessage(message)) {
+                    const expandToolMedia = retainedMediaMessageIndexes.has(index);
                     const expandedContent = await expandBlobReferences(
                         message.content,
                         this.resourceManager,
                         this.logger,
                         allowedMediaTypes,
-                        false
+                        expandToolMedia
                     );
                     return { ...message, content: expandedContent };
                 }


### PR DESCRIPTION
## Summary
- Rehydrate recent media returned by tool messages before LLM formatting using the existing media retention window.
- Keep older tool media compact so large tool outputs do not inflate later prompts.
- Add context manager regressions for retained recent tool media, compacted older tool media, and blob-backed tool resource preservation.

## Test plan
- `pnpm test:unit packages/core/src/context/manager.test.ts`
- `pnpm typecheck:core`
- `pnpm build:core`
- `pnpm exec prettier --check packages/core/src/context/manager.ts packages/core/src/context/manager.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool-provided media (e.g., images returned by tools) retained in recent history is now rehydrated for the model, enabling analysis and responses based on that media.
  * Tool media not retained in the recent window remains excluded to control prompt size.

* **Tests**
  * Updated and added tests covering retained tool-media rehydration and other media-handling cases.

* **Chores**
  * Patch release metadata added for the core package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->