### PR TITLE
Inline text file uploads for model calls

### DIFF
--- a/.changeset/markdown-file-inputs.md
+++ b/.changeset/markdown-file-inputs.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Inline text-like file uploads as text in Vercel model messages so markdown attachments are understood by providers that do not accept them as native file parts.

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -12,6 +12,44 @@ const mockLogger = createMockLogger();
 
 describe('VercelMessageFormatter', () => {
     describe('URL string auto-detection', () => {
+        test('should inline markdown file content as text for model messages', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const markdown = '# Project notes\n\n- keep this as markdown';
+            const messages: InternalMessage[] = [
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'text', text: 'Summarize this file' },
+                        {
+                            type: 'file',
+                            data: Buffer.from(markdown, 'utf8').toString('base64'),
+                            mimeType: 'text/markdown',
+                            filename: 'notes.md',
+                        },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                'You are helpful'
+            );
+
+            const userMessage = result.find((m) => m.role === 'user');
+            expect(userMessage).toBeDefined();
+            if (!userMessage) throw new Error('Expected user message');
+
+            const content = userMessage.content as Array<{ type: string; text?: string }>;
+            expect(content).toHaveLength(2);
+            expect(content.some((p) => p.type === 'file')).toBe(false);
+            expect(content[0]).toEqual({ type: 'text', text: 'Summarize this file' });
+            expect(content[1]).toEqual({
+                type: 'text',
+                text: `Attached file "notes.md" (text/markdown):\n\n${markdown}`,
+            });
+        });
+
         test('should convert image URL string to URL object', () => {
             const formatter = new VercelMessageFormatter(mockLogger);
             const messages: InternalMessage[] = [

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -50,6 +50,41 @@ describe('VercelMessageFormatter', () => {
             });
         });
 
+        test('should inline plain string markdown file content verbatim', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const markdown = '# Project notes\n\nTEST\n\nAAAA';
+            const messages: InternalMessage[] = [
+                {
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'file',
+                            data: markdown,
+                            mimeType: 'text/markdown',
+                            filename: 'notes.md',
+                        },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                'You are helpful'
+            );
+
+            const userMessage = result.find((m) => m.role === 'user');
+            expect(userMessage).toBeDefined();
+            if (!userMessage) throw new Error('Expected user message');
+
+            expect(userMessage.content).toEqual([
+                {
+                    type: 'text',
+                    text: `Attached file "notes.md" (text/markdown):\n\n${markdown}`,
+                },
+            ]);
+        });
+
         test('should convert image URL string to URL object', () => {
             const formatter = new VercelMessageFormatter(mockLogger);
             const messages: InternalMessage[] = [

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -1,6 +1,11 @@
 import type { ModelMessage, AssistantContent, ToolContent, ToolResultPart } from 'ai';
 import type { LLMContext } from '@dexto/llm';
-import type { InternalMessage, AssistantMessage, ToolMessage } from '../../context/types.js';
+import type {
+    InternalMessage,
+    AssistantMessage,
+    ToolMessage,
+    FilePart,
+} from '../../context/types.js';
 import {
     getImageData,
     getFileData,
@@ -35,6 +40,73 @@ function normalizeToolMediaData(data: string): string | null {
     }
 
     return data;
+}
+
+function isTextLikeMimeType(mimeType: string): boolean {
+    const normalized = mimeType.toLowerCase().split(';', 1)[0]?.trim() ?? '';
+    if (normalized.startsWith('text/')) return true;
+    if (normalized.endsWith('+json') || normalized.endsWith('+xml')) return true;
+
+    return [
+        'application/json',
+        'application/ld+json',
+        'application/xml',
+        'application/yaml',
+        'application/x-yaml',
+        'application/toml',
+        'application/x-toml',
+        'application/javascript',
+        'application/typescript',
+        'application/x-sh',
+        'application/sql',
+    ].includes(normalized);
+}
+
+function isRemoteFileData(data: FilePart['data']): boolean {
+    return (
+        data instanceof URL ||
+        (typeof data === 'string' &&
+            (/^https?:\/\//i.test(data) || data.startsWith('blob:') || data.startsWith('@blob:')))
+    );
+}
+
+function looksLikeBase64(value: string): boolean {
+    const normalized = value.replace(/\s/g, '');
+    return (
+        normalized.length > 0 &&
+        normalized.length % 4 === 0 &&
+        /^[A-Za-z0-9+/]+={0,2}$/.test(normalized)
+    );
+}
+
+function decodeBase64Text(value: string): string {
+    return Buffer.from(value.replace(/\s/g, ''), 'base64').toString('utf8');
+}
+
+function decodeTextFileData(data: FilePart['data']): string | null {
+    if (data instanceof URL) return null;
+
+    if (typeof data === 'string') {
+        const dataUri = parseDataUri(data);
+        if (dataUri) return decodeBase64Text(dataUri.base64);
+        if (isRemoteFileData(data)) return null;
+        return looksLikeBase64(data) ? decodeBase64Text(data) : data;
+    }
+
+    return Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data).toString('utf8');
+}
+
+function filePartToText(part: FilePart): { type: 'text'; text: string } | null {
+    if (!isTextLikeMimeType(part.mimeType) || isRemoteFileData(part.data)) return null;
+
+    const text = decodeTextFileData(part.data);
+    if (text === null) return null;
+
+    const filename = part.filename ?? 'attachment';
+    return {
+        type: 'text',
+        text: `Attached file "${filename}" (${part.mimeType}):\n\n${text}`,
+    };
 }
 
 /**
@@ -128,6 +200,9 @@ export class VercelMessageFormatter {
                                       )
                                       .map((part) => {
                                           if (part.type === 'file') {
+                                              const textPart = filePartToText(part);
+                                              if (textPart) return textPart;
+
                                               return {
                                                   type: 'file' as const,
                                                   data: toUrlIfString(part.data),

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -70,13 +70,30 @@ function isRemoteFileData(data: FilePart['data']): boolean {
     );
 }
 
-function looksLikeBase64(value: string): boolean {
+function decodeLikelyBase64Text(value: string): string | null {
     const normalized = value.replace(/\s/g, '');
-    return (
-        normalized.length > 0 &&
-        normalized.length % 4 === 0 &&
-        /^[A-Za-z0-9+/]+={0,2}$/.test(normalized)
-    );
+    if (
+        normalized.length === 0 ||
+        normalized.length % 4 !== 0 ||
+        !/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)
+    ) {
+        return null;
+    }
+
+    const decoded = Buffer.from(normalized, 'base64');
+    const canonical = decoded.toString('base64').replace(/=+$/, '');
+    if (canonical !== normalized.replace(/=+$/, '')) return null;
+
+    const text = decoded.toString('utf8');
+    const hasInvalidControlCharacter = [...text].some((char) => {
+        const code = char.charCodeAt(0);
+        return code < 32 && code !== 9 && code !== 10 && code !== 13;
+    });
+    if (text.includes('\uFFFD') || hasInvalidControlCharacter) {
+        return null;
+    }
+
+    return text;
 }
 
 function decodeBase64Text(value: string): string {
@@ -90,7 +107,10 @@ function decodeTextFileData(data: FilePart['data']): string | null {
         const dataUri = parseDataUri(data);
         if (dataUri) return decodeBase64Text(dataUri.base64);
         if (isRemoteFileData(data)) return null;
-        return looksLikeBase64(data) ? decodeBase64Text(data) : data;
+
+        // Bare strings can be valid plain text and valid base64 at the same time; explicit data
+        // URIs avoid that ambiguity. For bare strings, decode only when the bytes look like text.
+        return decodeLikelyBase64Text(data) ?? data;
     }
 
     return Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data).toString('utf8');


### PR DESCRIPTION
## Summary
- inline text-like local file uploads as text in Vercel model messages
- preserve non-text and remote file parts as file inputs
- add a regression test for markdown uploads with gpt-5.4-mini
- add a patch changeset for @dexto/core

## Why
Markdown attachments are product-level files, but provider/model transports do not consistently accept text documents as native file parts. Converting text-like local files at the formatter boundary keeps UI/history attachment behavior intact while ensuring the model receives the document contents.

## Validation
- pnpm --filter @dexto/core exec vitest run src/llm/formatters/vercel.test.ts
- pnpm --filter @dexto/core typecheck
- pnpm --filter @dexto/core lint
- pnpm --filter @dexto/core build
- pnpm format:check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown and text-like file uploads are now inlined as plain text within model messages to improve compatibility with providers that don’t support native file parts.

* **Bug Fixes**
  * Prevents markdown attachments from being dropped or misinterpreted by converting text-like files into inline message content.

* **Tests**
  * Added coverage ensuring markdown file parts are converted to inline text in model messages (including auto-detection and decoding behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->