### PR TITLE
Default hosted URLs to app.dexto.ai

### DIFF
--- a/.changeset/curly-owls-share.md
+++ b/.changeset/curly-owls-share.md
@@ -1,0 +1,7 @@
+---
+"dexto": minor
+"@dexto/core": minor
+"@dexto/llm": minor
+---
+
+Update hosted Dexto defaults to use the app.dexto.ai domain for login, control-plane requests, and the Nova gateway.

--- a/packages/cli/src/cli/auth/constants.test.ts
+++ b/packages/cli/src/cli/auth/constants.test.ts
@@ -6,12 +6,20 @@ describe('auth constants', () => {
         vi.resetModules();
     });
 
-    it('defaults the platform control-plane host to platform.dexto.ai', async () => {
+    it('defaults the app control-plane host to app.dexto.ai', async () => {
         delete process.env.DEXTO_PLATFORM_URL;
 
         const { DEXTO_PLATFORM_URL } = await import('./constants.js');
 
-        expect(DEXTO_PLATFORM_URL).toBe('https://platform.dexto.ai');
+        expect(DEXTO_PLATFORM_URL).toBe('https://app.dexto.ai');
+    });
+
+    it('defaults the gateway host to app.dexto.ai', async () => {
+        delete process.env.DEXTO_API_URL;
+
+        const { DEXTO_API_URL } = await import('./constants.js');
+
+        expect(DEXTO_API_URL).toBe('https://app.dexto.ai');
     });
 
     it('honors DEXTO_PLATFORM_URL overrides', async () => {

--- a/packages/cli/src/cli/auth/constants.ts
+++ b/packages/cli/src/cli/auth/constants.ts
@@ -15,7 +15,7 @@
  * - SUPABASE_URL: Override Supabase URL (e.g., http://localhost:54321)
  * - SUPABASE_ANON_KEY: Override anon key (from `supabase start` output)
  * - DEXTO_API_URL: Override Dexto gateway URL for data-plane calls (e.g., http://localhost:3001)
- * - DEXTO_PLATFORM_URL: Override Dexto platform URL for auth/key/account control-plane calls (e.g., http://localhost:3002)
+ * - DEXTO_PLATFORM_URL: Override Dexto app URL for auth/key/account control-plane calls (e.g., http://localhost:3002)
  */
 export const SUPABASE_URL = process.env.SUPABASE_URL || 'https://gdfbxznhnnsamvsrtwjq.supabase.co';
 export const SUPABASE_ANON_KEY =
@@ -25,12 +25,12 @@ export const SUPABASE_ANON_KEY =
 /**
  * Dexto gateway URL for retained data-plane endpoints.
  */
-export const DEXTO_API_URL = process.env.DEXTO_API_URL || 'https://api.dexto.ai';
+export const DEXTO_API_URL = process.env.DEXTO_API_URL || 'https://app.dexto.ai';
 
 /**
- * Dexto platform URL for auth/key/account control-plane endpoints.
+ * Dexto app URL for auth/key/account control-plane endpoints.
  */
-export const DEXTO_PLATFORM_URL = process.env.DEXTO_PLATFORM_URL || 'https://platform.dexto.ai';
+export const DEXTO_PLATFORM_URL = process.env.DEXTO_PLATFORM_URL || 'https://app.dexto.ai';
 
 /**
  * Dexto Nova credits purchase URL

--- a/packages/cli/src/cli/commands/trace/client.test.ts
+++ b/packages/cli/src/cli/commands/trace/client.test.ts
@@ -210,7 +210,7 @@ describe('createTraceClient', () => {
     it('defaults trace reads to the hosted Dexto platform', async () => {
         const { resolveTracePlatformUrl } = await import('./client.js');
 
-        expect(resolveTracePlatformUrl()).toBe('https://platform.dexto.ai');
+        expect(resolveTracePlatformUrl()).toBe('https://app.dexto.ai');
     });
 
     it('honors DEXTO_PLATFORM_URL for trace reads', async () => {

--- a/packages/core/src/llm/executor/turn-executor.integration.test.ts
+++ b/packages/core/src/llm/executor/turn-executor.integration.test.ts
@@ -3542,7 +3542,7 @@ describe('TurnExecutor Integration Tests', () => {
                         },
                     },
                 }),
-                url: 'https://api.dexto.ai/v1/chat/completions',
+                url: 'https://app.dexto.ai/v1/chat/completions',
                 requestBodyValues: {},
                 isRetryable: false,
             });

--- a/packages/core/src/llm/services/factory.test.ts
+++ b/packages/core/src/llm/services/factory.test.ts
@@ -90,7 +90,7 @@ describe('createVercelModel dexto-nova base URL resolution', () => {
     it('uses the production gateway by default', () => {
         createVercelModel(buildDextoConfig());
 
-        expect(getLastDextoNovaBaseUrl()).toBe('https://api.dexto.ai/v1');
+        expect(getLastDextoNovaBaseUrl()).toBe('https://app.dexto.ai/v1');
     });
 
     it('uses llm.baseURL when explicitly provided', () => {

--- a/packages/core/src/llm/services/factory.ts
+++ b/packages/core/src/llm/services/factory.ts
@@ -47,7 +47,7 @@ function isLanguageModel(value: unknown): value is LanguageModel {
     );
 }
 
-const DEFAULT_DEXTO_GATEWAY_BASE_URL = 'https://api.dexto.ai/v1';
+const DEFAULT_DEXTO_GATEWAY_BASE_URL = 'https://app.dexto.ai/v1';
 
 function trimTrailingSlash(value: string): string {
     return value.trim().replace(/\/$/, '');
@@ -291,7 +291,7 @@ export function createVercelModel(
         }
         case 'dexto-nova': {
             // Dexto Gateway - OpenAI-compatible proxy with per-request billing
-            // Routes through api.dexto.ai to OpenRouter, deducts from user balance
+            // Routes through app.dexto.ai/v1 to OpenRouter, deducts from user balance
             // Requires DEXTO_API_KEY from `dexto login`
             //
             // Model IDs are in OpenRouter format (e.g., 'anthropic/claude-sonnet-4-5-20250929')

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -409,7 +409,7 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
         supportedFileTypes: ['image'],
         supportsCustomModels: true,
     },
-    // Dexto Gateway - OpenAI-compatible proxy through api.dexto.ai
+    // Dexto Gateway - OpenAI-compatible proxy through app.dexto.ai/v1
     // Routes to OpenRouter with per-request billing (balance decrement)
     // Requires DEXTO_API_KEY from dexto login
     //

--- a/packages/llm/src/types.ts
+++ b/packages/llm/src/types.ts
@@ -16,7 +16,7 @@ export const LLM_PROVIDERS = [
     'bedrock',
     'local', // Native node-llama-cpp execution (GGUF models)
     'ollama', // Ollama server integration
-    'dexto-nova', // Dexto gateway - routes through api.dexto.ai/v1 with billing
+    'dexto-nova', // Dexto gateway - routes through app.dexto.ai/v1 with billing
 ] as const;
 export type LLMProvider = (typeof LLM_PROVIDERS)[number];
 


### PR DESCRIPTION
## Summary

- Change CLI hosted defaults so control-plane traffic defaults to `https://app.dexto.ai`.
- Keep the core Dexto Nova OpenAI-compatible gateway base URL at `https://app.dexto.ai/v1`.
- Update tests/comments that previously treated `api.dexto.ai` or `platform.dexto.ai` as canonical defaults.

## Pre-Merge Steps

1. Merge/deploy `truffle-ai/dexto-cloudflare#171` first.
2. Verify these production routes are live:
   - `https://app.dexto.ai/healthz`
   - `https://app.dexto.ai/api/auth/device/start`
   - `https://app.dexto.ai/v1/models`
3. Keep `api.dexto.ai` and `platform.dexto.ai` temporarily for old clients/rollback.

## Validation

- `pnpm --filter @dexto/llm build`
- `pnpm exec vitest run packages/cli/src/cli/auth/constants.test.ts packages/cli/src/cli/commands/trace/client.test.ts packages/core/src/llm/services/factory.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unified default API endpoints for authentication, control-plane, and LLM services to route through `app.dexto.ai`.
  * Updated related test assertions and documentation to reflect the new endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->