### PR TITLE
Fix OpenRouter Fable alias routing

### DIFF
--- a/.changeset/fable-openrouter-alias.md
+++ b/.changeset/fable-openrouter-alias.md
@@ -1,0 +1,5 @@
+---
+"@dexto/llm": patch
+---
+
+Resolve Anthropic Fable 5 to OpenRouter's priced Fable alias and preserve gateway reasoning metadata for that alias.

--- a/packages/core/src/llm/executor/provider-options.test.ts
+++ b/packages/core/src/llm/executor/provider-options.test.ts
@@ -366,6 +366,18 @@ describe('buildProviderOptions', () => {
                     reasoning: { enabled: true, effort: 'high' },
                 },
             });
+
+            expect(
+                buildProviderOptions({
+                    provider: 'dexto-nova',
+                    model: '~anthropic/claude-fable-latest',
+                })
+            ).toEqual({
+                'dexto-nova': {
+                    include_reasoning: true,
+                    reasoning: { enabled: true, effort: 'high' },
+                },
+            });
         });
 
         it('does not map Anthropic-only adaptive max on gateway providers', () => {

--- a/packages/core/src/llm/registry/index.test.ts
+++ b/packages/core/src/llm/registry/index.test.ts
@@ -1001,6 +1001,15 @@ describe('transformModelNameForProvider', () => {
             expect(result).toBe('anthropic/claude-haiku-4.5');
         });
 
+        it('transforms Anthropic Fable to the priced OpenRouter alias', () => {
+            const result = transformModelNameForProvider(
+                'claude-fable-5',
+                'anthropic',
+                'dexto-nova'
+            );
+            expect(result).toBe('~anthropic/claude-fable-latest');
+        });
+
         it('transforms OpenAI models to OpenRouter format', () => {
             const result = transformModelNameForProvider('gpt-5-mini', 'openai', 'dexto-nova');
             expect(result).toBe('openai/gpt-5-mini');

--- a/packages/llm/src/reasoning/profile.test.ts
+++ b/packages/llm/src/reasoning/profile.test.ts
@@ -167,6 +167,14 @@ describe('getReasoningProfile', () => {
             defaultVariant: 'high',
             supportsBudgetTokens: true,
         });
+
+        expect(getReasoningProfile('openrouter', '~anthropic/claude-fable-latest')).toMatchObject({
+            capable: true,
+            paradigm: 'adaptive-effort',
+            supportedVariants: ['low', 'medium', 'high', 'xhigh'],
+            defaultVariant: 'high',
+            supportsBudgetTokens: true,
+        });
     });
 
     it('returns OpenRouter Gemini-3 thinking-level profile', () => {

--- a/packages/llm/src/reasoning/profiles/openrouter.test.ts
+++ b/packages/llm/src/reasoning/profiles/openrouter.test.ts
@@ -28,6 +28,10 @@ describe('openrouter reasoning profile routing', () => {
                 upstreamProvider: 'anthropic',
                 modelId: 'claude-opus-4.6',
             });
+            expect(getOpenRouterReasoningTarget('~anthropic/claude-fable-latest')).toEqual({
+                upstreamProvider: 'anthropic',
+                modelId: 'claude-fable-5',
+            });
         });
 
         it('maps only Gemini-3 Google models', () => {

--- a/packages/llm/src/reasoning/profiles/openrouter.ts
+++ b/packages/llm/src/reasoning/profiles/openrouter.ts
@@ -77,7 +77,13 @@ export function getOpenRouterReasoningTarget(model: string): OpenRouterReasoning
     const split = splitGatewayModelId(modelLower);
     if (!split) return null;
 
-    const { providerPrefix, modelId } = split;
+    const providerPrefix = split.providerPrefix.replace(/^~/, '');
+    const modelId =
+        split.providerPrefix.startsWith('~') &&
+        providerPrefix === 'anthropic' &&
+        split.modelId === 'claude-fable-latest'
+            ? 'claude-fable-5'
+            : split.modelId;
     const rule = OPENROUTER_REASONING_TARGET_RULES[providerPrefix];
     if (!rule || !rule.acceptsModelId(modelId, modelLower)) {
         return null;

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -746,7 +746,11 @@ export function getOpenRouterCandidateModelIds(
     if (originalProvider === 'anthropic') {
         const noDate = model.replace(/-\d{8}.*$/i, '');
         const dotted = noDate.replace(/-(\d)-(\d)\b/g, '-$1.$2');
-        return [`${prefix}/${dotted}`, `${prefix}/${noDate}`, `${prefix}/${model}`];
+        const candidates = [`${prefix}/${dotted}`, `${prefix}/${noDate}`, `${prefix}/${model}`];
+        if (noDate.toLowerCase() === 'claude-fable-5') {
+            return [`~${prefix}/claude-fable-latest`, ...candidates];
+        }
+        return candidates;
     }
 
     // Google Gemini: some models use a "-001" suffix on OpenRouter, but others don't.


### PR DESCRIPTION
## Summary
- route native Anthropic Fable 5 to OpenRouter's priced Fable alias
- preserve gateway reasoning metadata for the `~anthropic/claude-fable-latest` alias
- add focused registry/reasoning/provider-options coverage

## Validation
- `pnpm exec vitest run packages/llm/src/reasoning/profiles/openrouter.test.ts packages/llm/src/reasoning/profile.test.ts packages/core/src/llm/registry/index.test.ts packages/core/src/llm/executor/provider-options.test.ts`
- `pnpm --filter @dexto/llm build`
- `pnpm --filter @dexto/llm typecheck`
- `pnpm --filter @dexto/llm lint`
- `pnpm --filter @dexto/core typecheck`
- `pnpm --filter @dexto/core lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model resolution for Anthropic Fable models, including OpenRouter’s priced alias handling.
  * Reasoning profiles now recognize the alias with the expected high-effort defaults and budget-token support.

* **Bug Fixes**
  * Fixed routing so `claude-fable-latest` resolves correctly to the intended Anthropic model and preserves reasoning behavior for gateway requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->