### PR TITLE
Export session title generator from @dexto/core

### DIFF
--- a/.changeset/export-session-title-generator.md
+++ b/.changeset/export-session-title-generator.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Export `@dexto/core/session/title-generator` for hosted session title generation without spinning up a full agent runtime.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,6 +113,11 @@
             "import": "./dist/session/index.js",
             "require": "./dist/session/index.cjs"
         },
+        "./session/title-generator": {
+            "types": "./dist/session/title-generator.d.ts",
+            "import": "./dist/session/title-generator.js",
+            "require": "./dist/session/title-generator.cjs"
+        },
         "./storage": {
             "types": "./dist/storage/index.d.ts",
             "import": "./dist/storage/index.js",


### PR DESCRIPTION
## Summary
- Export `@dexto/core/session/title-generator` so consumers can call `generateSessionTitle` and `deriveHeuristicTitle` directly.
- Enables hosted/cloud session title generation from stripped first-user-message text without starting a full `DextoAgent` runtime.

## Test plan
- [x] `pnpm build --filter @dexto/core`
- [ ] Verify `import { generateSessionTitle } from "@dexto/core/session/title-generator"` resolves in a consumer package


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public session title generator export for the core package.
  * Enables hosted session title generation without needing the full agent runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->