### PR TITLE
Use model history for long-session loading

### DIFF
--- a/.changeset/model-history-loading-boundary.md
+++ b/.changeset/model-history-loading-boundary.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Load and compact model-visible history through the conversation store boundary to avoid full-history reads in long sessions.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.9.0",
+    "version": "1.9.2",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/core/src/context/error-codes.ts
+++ b/packages/core/src/context/error-codes.ts
@@ -13,6 +13,7 @@ export enum ContextErrorCode {
     // Assistant message validation
     ASSISTANT_MESSAGE_CONTENT_OR_TOOLS_REQUIRED = 'context_assistant_message_content_or_tools_required',
     ASSISTANT_MESSAGE_TOOL_CALLS_INVALID = 'context_assistant_message_tool_calls_invalid',
+    ASSISTANT_MESSAGE_ID_MISSING = 'context_assistant_message_id_missing',
 
     // Tool message validation
     TOOL_MESSAGE_FIELDS_MISSING = 'context_tool_message_fields_missing',

--- a/packages/core/src/context/errors.ts
+++ b/packages/core/src/context/errors.ts
@@ -52,6 +52,17 @@ export class ContextError {
         );
     }
 
+    static assistantMessageIdMissing() {
+        return new DextoRuntimeError(
+            ContextErrorCode.ASSISTANT_MESSAGE_ID_MISSING,
+            ErrorScope.CONTEXT,
+            ErrorType.SYSTEM,
+            'Expected assistant message id after saving message',
+            {},
+            'Check conversation store saveMessage behavior'
+        );
+    }
+
     static toolMessageFieldsMissing() {
         return new DextoRuntimeError(
             ContextErrorCode.TOOL_MESSAGE_FIELDS_MISSING,

--- a/packages/core/src/context/manager.test.ts
+++ b/packages/core/src/context/manager.test.ts
@@ -9,6 +9,7 @@ import type { ResourceManager } from '../resources/manager.js';
 import type { DynamicContributorContext } from '../systemPrompt/types.js';
 import type { MCPManager } from '../mcp/manager.js';
 import { InMemoryDextoStores } from '../storage/stores/in-memory.js';
+import type { ConversationStore } from '../storage/conversation/types.js';
 
 // Create mock dependencies
 const mockLogger = createMockLogger();
@@ -58,8 +59,10 @@ function createContextManager(options?: {
     formatter?: VercelMessageFormatter;
     systemPromptManager?: SystemPromptManager;
     resourceManager?: ResourceManager;
+    conversationStore?: ConversationStore;
 }) {
-    const conversationStore = new InMemoryDextoStores().getStore('conversation');
+    const conversationStore =
+        options?.conversationStore ?? new InMemoryDextoStores().getStore('conversation');
     const formatter = options?.formatter ?? createMockFormatter();
     const systemPromptManager = options?.systemPromptManager ?? createMockSystemPromptManager();
     const resourceManager = options?.resourceManager ?? createMockResourceManager();
@@ -105,6 +108,42 @@ describe('ContextManager', () => {
                 textLength: 13,
                 textSha256: '315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3',
             });
+        });
+
+        it('does not load full history after saving messages', async () => {
+            const savedMessages: InternalMessage[] = [];
+            const listMessages = vi.fn(async () => {
+                throw new Error('Unexpected full-history read');
+            });
+            const saveMessage = vi.fn(
+                async (input: { sessionId: string; message: InternalMessage }) => {
+                    savedMessages.push(input.message);
+                }
+            );
+            const conversationStore: ConversationStore = {
+                listMessages,
+                loadModelHistory: vi.fn(async () => ({
+                    messages: [],
+                    stats: {
+                        returnedMessages: 0,
+                        skippedPreSummaryMessages: 0,
+                        summaryMessageId: null,
+                    },
+                })),
+                saveMessage,
+                updateMessage: vi.fn(async () => {}),
+                clearMessages: vi.fn(async () => {}),
+                flush: vi.fn(async () => {}),
+            };
+            const manager = createContextManager({ conversationStore });
+
+            await manager.addUserMessage([{ type: 'text', text: 'Hello' }]);
+            const assistantId = await manager.addAssistantMessage('Hi');
+
+            expect(saveMessage).toHaveBeenCalledTimes(2);
+            expect(listMessages).not.toHaveBeenCalled();
+            expect(assistantId).toBe(savedMessages[1]?.id);
+            expect(typeof assistantId).toBe('string');
         });
 
         it('should add a user message with multiple text parts', async () => {
@@ -927,6 +966,73 @@ describe('ContextManager', () => {
         });
     });
 
+    describe('prepareModelHistory', () => {
+        it('uses the model-history store boundary instead of full-history reads', async () => {
+            const listMessages = vi.fn(async () => {
+                throw new Error('full history should not be loaded for model preparation');
+            });
+            const loadModelHistory = vi.fn(async () => ({
+                messages: [
+                    {
+                        id: 'summary-1',
+                        role: 'assistant',
+                        assistantOutput: { status: 'complete' },
+                        content: [{ type: 'text', text: 'Summary' }],
+                        metadata: { isSummary: true, originalMessageCount: 2000 },
+                        timestamp: 1,
+                    },
+                    {
+                        id: 'user-1',
+                        role: 'user',
+                        content: [{ type: 'text', text: 'Visible question' }],
+                        timestamp: 2,
+                    },
+                    {
+                        id: 'assistant-stopped',
+                        role: 'assistant',
+                        assistantOutput: { status: 'stopped', reason: 'cancelled' },
+                        content: [{ type: 'text', text: 'Hidden stopped text' }],
+                        timestamp: 3,
+                    },
+                    {
+                        id: 'assistant-complete',
+                        role: 'assistant',
+                        assistantOutput: { status: 'complete' },
+                        content: [{ type: 'text', text: 'Visible answer' }],
+                        timestamp: 4,
+                    },
+                ] satisfies InternalMessage[],
+                stats: {
+                    returnedMessages: 4,
+                    skippedPreSummaryMessages: 2000,
+                    summaryMessageId: 'summary-1',
+                },
+            }));
+            const conversationStore: ConversationStore = {
+                clearMessages: vi.fn(),
+                flush: vi.fn(),
+                listMessages,
+                loadModelHistory,
+                saveMessage: vi.fn(),
+                updateMessage: vi.fn(),
+            };
+            const manager = createContextManager({ conversationStore });
+
+            const result = await manager.prepareModelHistory();
+
+            expect(loadModelHistory).toHaveBeenCalledWith({ sessionId: 'test-session-id' });
+            expect(listMessages).not.toHaveBeenCalled();
+            expect(result.stats.originalCount).toBe(2004);
+            expect(
+                result.preparedHistory.map((message) =>
+                    message.role === 'assistant'
+                        ? (message.content?.[0] as { text: string }).text
+                        : message.role
+                )
+            ).toEqual(['Summary', 'user', 'Visible answer']);
+        });
+    });
+
     describe('getContextTokenEstimate', () => {
         const mockContributorContext = createMockContributorContext();
         const mockTools = {
@@ -936,6 +1042,52 @@ describe('ContextManager', () => {
                 parameters: { type: 'object', properties: {} },
             },
         };
+
+        it('uses the model-history store boundary instead of full-history reads', async () => {
+            const listMessages = vi.fn(async () => {
+                throw new Error('full history should not be loaded for context estimation');
+            });
+            const loadModelHistory = vi.fn(async () => ({
+                messages: [
+                    {
+                        id: 'summary-1',
+                        role: 'assistant',
+                        assistantOutput: { status: 'complete' },
+                        content: [{ type: 'text', text: 'Summary' }],
+                        metadata: { isSummary: true, originalMessageCount: 1000 },
+                        timestamp: 1,
+                    },
+                    {
+                        id: 'user-1',
+                        role: 'user',
+                        content: [{ type: 'text', text: 'Visible question' }],
+                        timestamp: 2,
+                    },
+                ] satisfies InternalMessage[],
+                stats: {
+                    returnedMessages: 2,
+                    skippedPreSummaryMessages: 1000,
+                    summaryMessageId: 'summary-1',
+                },
+            }));
+            const manager = createContextManager({
+                conversationStore: {
+                    clearMessages: vi.fn(),
+                    flush: vi.fn(),
+                    listMessages,
+                    loadModelHistory,
+                    saveMessage: vi.fn(),
+                    updateMessage: vi.fn(),
+                },
+            });
+
+            const result = await manager.getContextTokenEstimate(mockContributorContext, mockTools);
+
+            expect(result.stats.originalMessageCount).toBe(1002);
+            expect(result.stats.filteredMessageCount).toBe(2);
+            expect(loadModelHistory).toHaveBeenCalledWith({ sessionId: 'test-session-id' });
+            expect(listMessages).not.toHaveBeenCalled();
+        });
 
         it('should calculate total as sum of breakdown components', async () => {
             await contextManager.addUserMessage([{ type: 'text', text: 'Hello' }]);
@@ -1157,6 +1309,107 @@ describe('ContextManager', () => {
                 parameters: { type: 'object', properties: {} },
             },
         };
+
+        it('records the last call boundary from model history instead of full history', async () => {
+            const listMessages = vi.fn(async () => {
+                throw new Error('full history should not be loaded for model boundary tracking');
+            });
+            const loadModelHistory = vi.fn(async () => ({
+                messages: [
+                    {
+                        id: 'summary-1',
+                        role: 'assistant',
+                        assistantOutput: { status: 'complete' },
+                        content: [{ type: 'text', text: 'Summary' }],
+                        metadata: { isSummary: true, originalMessageCount: 2000 },
+                        timestamp: 1,
+                    },
+                    {
+                        id: 'user-1',
+                        role: 'user',
+                        content: [{ type: 'text', text: 'Visible question' }],
+                        timestamp: 2,
+                    },
+                ] satisfies InternalMessage[],
+                stats: {
+                    returnedMessages: 2,
+                    skippedPreSummaryMessages: 2000,
+                    summaryMessageId: 'summary-1',
+                },
+            }));
+            const manager = createContextManager({
+                conversationStore: {
+                    clearMessages: vi.fn(),
+                    flush: vi.fn(),
+                    listMessages,
+                    loadModelHistory,
+                    saveMessage: vi.fn(),
+                    updateMessage: vi.fn(),
+                },
+            });
+
+            await manager.recordLastCallMessageCount();
+
+            expect(manager.getLastCallMessageCount()).toBe(2);
+            expect(loadModelHistory).toHaveBeenCalledWith({ sessionId: 'test-session-id' });
+            expect(listMessages).not.toHaveBeenCalled();
+        });
+
+        it('estimates actual-token deltas from model history instead of full history', async () => {
+            const listMessages = vi.fn(async () => {
+                throw new Error('full history should not be loaded for token estimation');
+            });
+            const boundaryMessages: InternalMessage[] = [
+                {
+                    id: 'user-1',
+                    role: 'user',
+                    content: [{ type: 'text', text: 'Hello' }],
+                    timestamp: 1,
+                },
+            ];
+            const newMessage: InternalMessage = {
+                id: 'assistant-1',
+                role: 'assistant',
+                assistantOutput: { status: 'complete' },
+                content: [{ type: 'text', text: 'A'.repeat(400) }],
+                timestamp: 2,
+            };
+            let modelMessages = boundaryMessages;
+            const loadModelHistory = vi.fn(async () => ({
+                messages: modelMessages,
+                stats: {
+                    returnedMessages: modelMessages.length,
+                    skippedPreSummaryMessages: 0,
+                    summaryMessageId: null,
+                },
+            }));
+            const manager = createContextManager({
+                conversationStore: {
+                    clearMessages: vi.fn(),
+                    flush: vi.fn(),
+                    listMessages,
+                    loadModelHistory,
+                    saveMessage: vi.fn(),
+                    updateMessage: vi.fn(),
+                },
+            });
+
+            manager.setLastActualInputTokens(5000);
+            manager.setLastActualOutputTokens(200);
+            await manager.recordLastCallMessageCount();
+            modelMessages = [...boundaryMessages, newMessage];
+
+            const estimated = await manager.getEstimatedNextInputTokens(
+                'System',
+                modelMessages,
+                mockTools
+            );
+
+            const { estimateMessagesTokens } = await import('./utils.js');
+            expect(estimated).toBe(5000 + 200 + estimateMessagesTokens([newMessage]));
+            expect(loadModelHistory).toHaveBeenCalledTimes(2);
+            expect(listMessages).not.toHaveBeenCalled();
+        });
 
         it('should calculate formula exactly: lastInput + lastOutput + newMessagesEstimate', async () => {
             // Setup: one message BEFORE recording

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -24,7 +24,7 @@ import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 import { getResourceKind } from './media-helpers.js';
 import { describeContentPartsForAudit } from './content-audit.js';
 
-type PreparedHistoryResult = {
+export type PreparedHistoryResult = {
     preparedHistory: InternalMessage[];
     stats: {
         /** Total messages in raw or model-history source */
@@ -950,7 +950,7 @@ export class ContextManager<TMessage = unknown> {
         });
 
         if (message.id === undefined) {
-            throw new Error('Expected assistant message id after saving message.');
+            throw ContextError.assistantMessageIdMissing();
         }
 
         return message.id;

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -24,6 +24,18 @@ import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 import { getResourceKind } from './media-helpers.js';
 import { describeContentPartsForAudit } from './content-audit.js';
 
+type PreparedHistoryResult = {
+    preparedHistory: InternalMessage[];
+    stats: {
+        /** Total messages in raw or model-history source */
+        originalCount: number;
+        /** Messages after model-history filters */
+        filteredCount: number;
+        /** Messages with compactedAt that were transformed to placeholders */
+        prunedToolCount: number;
+    };
+};
+
 function isVisibleInPreparedHistory(message: InternalMessage): boolean {
     if (message.role !== 'assistant') {
         return true;
@@ -83,7 +95,7 @@ export class ContextManager<TMessage = unknown> {
     private lastActualOutputTokens: number | null = null;
 
     /**
-     * Message count at the time of the last LLM call.
+     * Model-visible message count at the time of the last LLM call.
      * Used to identify which messages are "new" since the last call.
      * Messages after this index are estimated with length/4 heuristic.
      */
@@ -418,7 +430,7 @@ export class ContextManager<TMessage = unknown> {
     }
 
     /**
-     * Returns the message count at the time of the last LLM call.
+     * Returns the model-visible message count at the time of the last LLM call.
      * Returns null if no LLM call has been made yet.
      */
     getLastCallMessageCount(): number | null {
@@ -426,12 +438,14 @@ export class ContextManager<TMessage = unknown> {
     }
 
     /**
-     * Records the current message count after an LLM call completes.
+     * Records the current model-visible message count after an LLM call completes.
      * This marks the boundary for "new messages" calculation.
      */
     async recordLastCallMessageCount(): Promise<void> {
-        const history = await this.conversationStore.listMessages({ sessionId: this.sessionId });
-        this.lastCallMessageCount = history.length;
+        const history = await this.conversationStore.loadModelHistory({
+            sessionId: this.sessionId,
+        });
+        this.lastCallMessageCount = history.messages.length;
         this.logger.debug(`Recorded lastCallMessageCount: ${this.lastCallMessageCount}`);
     }
 
@@ -469,25 +483,48 @@ export class ContextManager<TMessage = unknown> {
      *
      * @returns Prepared history and statistics about the transformations
      */
-    async prepareHistory(): Promise<{
-        preparedHistory: InternalMessage[];
-        stats: {
-            /** Total messages in raw history */
-            originalCount: number;
-            /** Messages after model-history filters */
-            filteredCount: number;
-            /** Messages with compactedAt that were transformed to placeholders */
-            prunedToolCount: number;
-        };
-    }> {
+    async prepareHistory(): Promise<PreparedHistoryResult> {
         const fullHistory = await this.conversationStore.listMessages({
             sessionId: this.sessionId,
         });
-        const originalCount = fullHistory.length;
+        return this.prepareVisibleHistory({
+            history: filterCompacted(fullHistory),
+            originalCount: fullHistory.length,
+            source: 'prepareHistory',
+        });
+    }
 
-        // Step 1: Filter compacted and non-complete assistant outputs
+    /**
+     * Prepares model-visible history without first materializing the whole durable session.
+     * This is the model execution boundary; Worker/Workflow model calls should use this
+     * method instead of prepareHistory().
+     */
+    async prepareModelHistory(): Promise<PreparedHistoryResult> {
+        const modelHistory = await this.conversationStore.loadModelHistory({
+            sessionId: this.sessionId,
+        });
+        return this.prepareVisibleHistory({
+            history: modelHistory.messages,
+            originalCount:
+                modelHistory.stats.returnedMessages + modelHistory.stats.skippedPreSummaryMessages,
+            source: 'prepareModelHistory',
+        });
+    }
+
+    async getModelHistory(): Promise<Readonly<InternalMessage[]>> {
+        const modelHistory = await this.conversationStore.loadModelHistory({
+            sessionId: this.sessionId,
+        });
+        return modelHistory.messages;
+    }
+
+    private prepareVisibleHistory(input: {
+        history: InternalMessage[];
+        originalCount: number;
+        source: string;
+    }): PreparedHistoryResult {
         const visibleToolCallIds = new Set<string>();
-        let history = filterCompacted(fullHistory).filter((message) => {
+        let history = input.history.filter((message) => {
             const isVisible = isVisibleInPreparedHistory(message);
             if (isVisible && message.role === 'assistant') {
                 for (const toolCall of message.toolCalls ?? []) {
@@ -502,14 +539,12 @@ export class ContextManager<TMessage = unknown> {
         });
         const filteredCount = history.length;
 
-        if (filteredCount < originalCount) {
+        if (filteredCount < input.originalCount) {
             this.logger.debug(
-                `prepareHistory: reduced from ${originalCount} to ${filteredCount} model-visible messages`
+                `${input.source}: reduced from ${input.originalCount} to ${filteredCount} model-visible messages`
             );
         }
 
-        // Step 2: Transform compacted tool messages to placeholders
-        // Original content is preserved in storage, placeholder sent to LLM
         let prunedToolCount = 0;
         history = history.map((msg) => {
             if (msg.role === 'tool' && msg.compactedAt) {
@@ -526,14 +561,14 @@ export class ContextManager<TMessage = unknown> {
 
         if (prunedToolCount > 0) {
             this.logger.debug(
-                `prepareHistory: Transformed ${prunedToolCount} pruned tool messages to placeholders`
+                `${input.source}: Transformed ${prunedToolCount} pruned tool messages to placeholders`
             );
         }
 
         return {
             preparedHistory: history,
             stats: {
-                originalCount,
+                originalCount: input.originalCount,
                 filteredCount,
                 prunedToolCount,
             },
@@ -753,7 +788,7 @@ export class ContextManager<TMessage = unknown> {
      * @param message The message to add to the history
      * @throws Error if message validation fails
      */
-    async addMessage(message: InternalMessage): Promise<void> {
+    async addMessage(message: InternalMessage): Promise<InternalMessage> {
         switch (message.role) {
             case 'user':
                 // User messages must have non-empty content array
@@ -821,14 +856,14 @@ export class ContextManager<TMessage = unknown> {
             `ContextManager: Adding message to conversation store: ${JSON.stringify(message, null, 2)}`
         );
 
-        // Save to conversation store
         await this.conversationStore.saveMessage({ sessionId: this.sessionId, message });
-
-        // Get updated history for logging
-        const history = await this.conversationStore.listMessages({ sessionId: this.sessionId });
-        this.logger.debug(`ContextManager: History now contains ${history.length} messages`);
+        this.logger.debug('ContextManager: Message saved to conversation store', {
+            messageId: message.id,
+            role: message.role,
+        });
 
         // Note: Compression is currently handled lazily in getFormattedMessages
+        return message;
     }
 
     /**
@@ -890,7 +925,7 @@ export class ContextManager<TMessage = unknown> {
             usageScopeId?: AssistantMessage['usageScopeId'];
             assistantOutput?: AssistantMessage['assistantOutput'];
         }
-    ): Promise<void> {
+    ): Promise<string> {
         // Validate that either content or toolCalls is provided
         if (content === null && (!toolCalls || toolCalls.length === 0)) {
             throw ContextError.assistantMessageContentOrToolsRequired();
@@ -900,7 +935,7 @@ export class ContextManager<TMessage = unknown> {
             content !== null ? [{ type: 'text', text: content }] : null;
         // Further validation happens within addMessage
         // addMessage will populate llm config metadata also
-        await this.addMessage({
+        const message = await this.addMessage({
             role: 'assistant' as const,
             content: contentArray,
             ...(toolCalls && toolCalls.length > 0 && { toolCalls }),
@@ -913,6 +948,12 @@ export class ContextManager<TMessage = unknown> {
             ...(metadata?.usageScopeId && { usageScopeId: metadata.usageScopeId }),
             assistantOutput: metadata?.assistantOutput ?? { status: 'complete' },
         });
+
+        if (message.id === undefined) {
+            throw new Error('Expected assistant message id after saving message.');
+        }
+
+        return message.id;
     }
 
     /**
@@ -1125,8 +1166,8 @@ export class ContextManager<TMessage = unknown> {
         // Step 1: Get system prompt
         const systemPrompt = await this.getSystemPrompt(contributorContext);
 
-        // Step 2: Prepare history (single source of truth for transformations)
-        const { preparedHistory } = await this.prepareHistory();
+        // Step 2: Prepare model history without loading full durable history
+        const { preparedHistory } = await this.prepareModelHistory();
 
         // Step 3: Format messages with prepared history
         const formattedMessages = await this.getFormattedMessages(
@@ -1145,7 +1186,8 @@ export class ContextManager<TMessage = unknown> {
 
     /**
      * Estimates context token usage for the /context command and compaction decisions.
-     * Uses the same prepareHistory() logic as getFormattedMessagesForLLM() to ensure consistency.
+     * Uses the same model-history preparation logic as getFormattedMessagesForLLM() to ensure
+     * consistency.
      *
      * When actuals are available from previous LLM calls:
      *   estimatedNextInput = lastInputTokens + lastOutputTokens + newMessagesEstimate
@@ -1199,17 +1241,23 @@ export class ContextManager<TMessage = unknown> {
         // Step 1: Get system prompt (same as LLM preparation)
         const systemPrompt = await this.getSystemPrompt(contributorContext);
 
-        // Step 2: Prepare history (same as LLM preparation - single source of truth)
-        const { preparedHistory, stats } = await this.prepareHistory();
+        // Step 2: Prepare model history (same as LLM preparation - single source of truth)
+        const modelHistory = await this.conversationStore.loadModelHistory({
+            sessionId: this.sessionId,
+        });
+        const { preparedHistory, stats } = this.prepareVisibleHistory({
+            history: modelHistory.messages,
+            originalCount:
+                modelHistory.stats.returnedMessages + modelHistory.stats.skippedPreSummaryMessages,
+            source: 'getContextTokenEstimate',
+        });
 
         // Step 3: Calculate tokens using Phase 4 formula when actuals are available
         // Formula: estimatedNextInput = lastInputTokens + lastOutputTokens + newMessagesEstimate
         const lastInput = this.lastActualInputTokens;
         const lastOutput = this.lastActualOutputTokens;
         const lastMsgCount = this.lastCallMessageCount;
-        const currentHistory = await this.conversationStore.listMessages({
-            sessionId: this.sessionId,
-        });
+        const currentHistory = modelHistory.messages;
 
         // Get pure estimate as fallback and for breakdown calculation
         const pureEstimate = estimateContextTokens(systemPrompt, preparedHistory, tools);
@@ -1343,13 +1391,13 @@ export class ContextManager<TMessage = unknown> {
         const lastInput = this.lastActualInputTokens;
         const lastOutput = this.lastActualOutputTokens;
         const lastMsgCount = this.lastCallMessageCount;
-        const currentHistory = await this.conversationStore.listMessages({
-            sessionId: this.sessionId,
-        });
 
         // Use actuals-based formula if we have all the required values
         if (lastInput !== null && lastOutput !== null && lastMsgCount !== null) {
-            const newMessages = currentHistory.slice(lastMsgCount);
+            const modelHistory = await this.conversationStore.loadModelHistory({
+                sessionId: this.sessionId,
+            });
+            const newMessages = modelHistory.messages.slice(lastMsgCount);
             const newMessagesEstimate = estimateMessagesTokens(newMessages);
             const total = lastInput + lastOutput + newMessagesEstimate;
 

--- a/packages/core/src/llm/executor/stream-processor.test.ts
+++ b/packages/core/src/llm/executor/stream-processor.test.ts
@@ -33,7 +33,7 @@ function createMocks() {
     const emittedEvents: Array<{ name: string; payload: unknown }> = [];
 
     const mockContextManager = {
-        addAssistantMessage: vi.fn().mockResolvedValue(undefined),
+        addAssistantMessage: vi.fn().mockResolvedValue('msg-1'),
         appendAssistantText: vi.fn().mockResolvedValue(undefined),
         updateAssistantMessage: vi.fn().mockResolvedValue(undefined),
         addToolCall: vi.fn().mockResolvedValue(undefined),

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -205,13 +205,13 @@ export class StreamProcessor {
                         setStreamAttribute('last_delta_kind', 'text');
                         if (!this.assistantMessageId) {
                             // Create assistant message on first text delta if not exists
-                            this.assistantMessageId = await this.contextManager
-                                .addAssistantMessage('', [], {
+                            this.assistantMessageId = await this.contextManager.addAssistantMessage(
+                                '',
+                                [],
+                                {
                                     assistantOutput: { status: 'draft' },
-                                })
-                                .then(() => {
-                                    return this.getLastMessageId();
-                                });
+                                }
+                            );
                         }
 
                         await this.contextManager.appendAssistantText(
@@ -800,17 +800,9 @@ export class StreamProcessor {
     }
 
     private async createAssistantMessage(): Promise<string> {
-        await this.contextManager.addAssistantMessage('', [], {
+        return this.contextManager.addAssistantMessage('', [], {
             assistantOutput: { status: 'draft' },
         });
-        return this.getLastMessageId();
-    }
-
-    private async getLastMessageId(): Promise<string> {
-        const history = await this.contextManager.getHistory();
-        const last = history[history.length - 1];
-        if (!last || !last.id) throw new Error('Failed to get last message ID');
-        return last.id;
     }
 
     /**

--- a/packages/core/src/llm/executor/turn-executor.integration.test.ts
+++ b/packages/core/src/llm/executor/turn-executor.integration.test.ts
@@ -4321,6 +4321,34 @@ describe('TurnExecutor Integration Tests', () => {
             expect(compactionStrategy.compact).toHaveBeenCalledTimes(1);
         });
 
+        it('compacts through the model-history boundary instead of raw history', async () => {
+            const compactionStrategy = createTestCompactionStrategy((tokens) => tokens > 10);
+            vi.mocked(streamText).mockImplementation((options) => {
+                const requestJson = JSON.stringify(options.messages);
+                expect(requestJson).toContain('Compacted test summary');
+                expect(requestJson).not.toContain('Message 1 before summary');
+                return createMockStream({
+                    text: 'Response',
+                    finishReason: 'stop',
+                    usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+                }) as unknown as ReturnType<typeof streamText>;
+            });
+
+            const compactingExecutor = createExecutorWithCompaction(compactionStrategy);
+
+            await seedCompactionEligibleHistory();
+            const rawHistorySpy = vi
+                .spyOn(contextManager, 'getHistory')
+                .mockRejectedValue(new Error('Compaction should use model history'));
+            const modelHistorySpy = vi.spyOn(contextManager, 'getModelHistory');
+
+            await compactingExecutor.execute({ mcpManager }, true);
+
+            expect(rawHistorySpy).not.toHaveBeenCalled();
+            expect(modelHistorySpy).toHaveBeenCalled();
+            expect(compactionStrategy.compact).toHaveBeenCalledTimes(1);
+        });
+
         it('queues steer submitted during compaction for the next model step', async () => {
             const events: string[] = [];
             const compactionStrategy = createTestCompactionStrategy((tokens) => tokens > 10);

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -1360,7 +1360,7 @@ export class TurnExecutor {
                 },
             },
             async () => {
-                const preparedHistory = (await this.contextManager.prepareHistory())
+                const preparedHistory = (await this.contextManager.prepareModelHistory())
                     .preparedHistory;
                 const formattedMessages = await this.contextManager.getFormattedMessages(
                     input.contributorContext,
@@ -1452,7 +1452,7 @@ export class TurnExecutor {
                         },
                     },
                     async () => {
-                        const preparedHistory = (await this.contextManager.prepareHistory())
+                        const preparedHistory = (await this.contextManager.prepareModelHistory())
                             .preparedHistory;
                         const formattedMessages = await this.contextManager.getFormattedMessages(
                             input.contributorContext,
@@ -1641,12 +1641,12 @@ export class TurnExecutor {
 
     private async runModelStepWithRetry(request: ModelStepRequest): Promise<StreamProcessorResult> {
         for (let failedAttempts = 0; ; failedAttempts += 1) {
-            const historyLengthBefore = (await this.contextManager.getHistory()).length;
+            const historyLengthBefore = (await this.contextManager.getModelHistory()).length;
 
             try {
                 return await this.runModelStep(request);
             } catch (error) {
-                const historyLengthAfter = (await this.contextManager.getHistory()).length;
+                const historyLengthAfter = (await this.contextManager.getModelHistory()).length;
                 const historyLengthChanged = historyLengthAfter !== historyLengthBefore;
 
                 if (
@@ -2209,7 +2209,7 @@ export class TurnExecutor {
     /**
      * Prunes old tool outputs by marking them with compactedAt timestamp.
      * Does NOT modify content - transformation happens at format time in
-     * ContextManager.prepareHistory().
+     * ContextManager.prepareModelHistory().
      *
      * Algorithm:
      * 1. Go backwards through history (most recent first)
@@ -2219,7 +2219,7 @@ export class TurnExecutor {
      * 5. Only prune if savings exceed PRUNE_MINIMUM
      */
     private async pruneOldToolOutputs(): Promise<{ prunedCount: number; savedTokens: number }> {
-        const history = await this.contextManager.getHistory();
+        const history = await this.contextManager.getModelHistory();
         let totalToolTokens = 0;
         let prunedTokens = 0;
         const toPrune: string[] = []; // Message IDs to mark
@@ -2357,7 +2357,7 @@ export class TurnExecutor {
             `Context overflow detected (${originalTokens} tokens), checking if compression is possible`
         );
 
-        const history = await this.contextManager.getHistory();
+        const history = await this.contextManager.getModelHistory();
         const { filterCompacted } = await import('../../context/utils.js');
         const originalFiltered = filterCompacted(history);
         const originalMessages = originalFiltered.length;

--- a/packages/core/src/storage/conversation/database.test.ts
+++ b/packages/core/src/storage/conversation/database.test.ts
@@ -35,6 +35,59 @@ describe('DatabaseConversationStore', () => {
         ]);
     });
 
+    it('loads the model-visible compacted history', async () => {
+        const database = createInMemoryDatabase();
+        const store = new DatabaseConversationStore(database, createMockLogger());
+        await database.connect();
+
+        const messages: InternalMessage[] = [
+            {
+                id: 'old-user',
+                role: 'user',
+                content: [{ type: 'text', text: 'old question' }],
+                timestamp: 1,
+            },
+            {
+                id: 'preserved-user',
+                role: 'user',
+                content: [{ type: 'text', text: 'preserved question' }],
+                timestamp: 2,
+            },
+            {
+                id: 'summary',
+                role: 'assistant',
+                assistantOutput: { status: 'complete' },
+                content: [{ type: 'text', text: 'summary' }],
+                metadata: { isSummary: true, originalMessageCount: 1 },
+                timestamp: 3,
+            },
+            {
+                id: 'after-summary',
+                role: 'assistant',
+                assistantOutput: { status: 'complete' },
+                content: [{ type: 'text', text: 'recent answer' }],
+                timestamp: 4,
+            },
+        ];
+
+        for (const message of messages) {
+            await store.saveMessage({ sessionId: 'session-1', message });
+        }
+
+        const modelHistory = await store.loadModelHistory({ sessionId: 'session-1' });
+
+        expect(modelHistory.messages.map((message) => message.id)).toEqual([
+            'summary',
+            'preserved-user',
+            'after-summary',
+        ]);
+        expect(modelHistory.stats).toEqual({
+            returnedMessages: 3,
+            skippedPreSummaryMessages: 1,
+            summaryMessageId: 'summary',
+        });
+    });
+
     it('flushes message updates back to durable storage', async () => {
         const database = createInMemoryDatabase();
         const store = new DatabaseConversationStore(database, createMockLogger());

--- a/packages/core/src/storage/conversation/database.ts
+++ b/packages/core/src/storage/conversation/database.ts
@@ -1,10 +1,11 @@
 import { cloneInternalMessage, cloneInternalMessages } from '../../context/content-clone.js';
 import type { InternalMessage } from '../../context/types.js';
+import { filterCompacted } from '../../context/utils.js';
 import type { Logger } from '../../logger/v2/types.js';
 import { DextoLogComponent } from '../../logger/v2/types.js';
 import type { Database } from '../database/types.js';
 import { StorageError } from '../errors.js';
-import type { ConversationStore } from './types.js';
+import type { ConversationStore, ModelHistoryLoad } from './types.js';
 
 type SessionConversationState = {
     cache: InternalMessage[] | null;
@@ -30,6 +31,25 @@ export class DatabaseConversationStore implements ConversationStore {
     async listMessages(input: { sessionId: string }): Promise<InternalMessage[]> {
         const state = await this.loadState(input.sessionId);
         return cloneInternalMessages(state.cache ?? []);
+    }
+
+    async loadModelHistory(input: { sessionId: string }): Promise<ModelHistoryLoad> {
+        const fullHistory = await this.listMessages(input);
+        const messages = filterCompacted(fullHistory);
+        const firstMessage = messages[0];
+        const summaryMessageId =
+            firstMessage?.metadata?.isSummary === true ||
+            firstMessage?.metadata?.isSessionSummary === true
+                ? (firstMessage.id ?? null)
+                : null;
+        return {
+            messages,
+            stats: {
+                returnedMessages: messages.length,
+                skippedPreSummaryMessages: fullHistory.length - messages.length,
+                summaryMessageId,
+            },
+        };
     }
 
     async saveMessage(input: { sessionId: string; message: InternalMessage }): Promise<void> {

--- a/packages/core/src/storage/conversation/types.ts
+++ b/packages/core/src/storage/conversation/types.ts
@@ -1,7 +1,19 @@
 import type { InternalMessage } from '../../context/types.js';
 
+export type ModelHistoryLoadStats = {
+    returnedMessages: number;
+    skippedPreSummaryMessages: number;
+    summaryMessageId: string | null;
+};
+
+export type ModelHistoryLoad = {
+    messages: InternalMessage[];
+    stats: ModelHistoryLoadStats;
+};
+
 export interface ConversationStore {
     listMessages(input: { sessionId: string }): Promise<InternalMessage[]>;
+    loadModelHistory(input: { sessionId: string }): Promise<ModelHistoryLoad>;
     saveMessage(input: { sessionId: string; message: InternalMessage }): Promise<void>;
     updateMessage(input: { sessionId: string; message: InternalMessage }): Promise<void>;
     clearMessages(input: { sessionId: string }): Promise<void>;

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -39,7 +39,11 @@ export {
 export type { DextoStoresLifecycle } from './stores/backend.js';
 export type { DextoStoreMap, DextoStoreName, DextoStores } from './stores/types.js';
 export { DatabaseConversationStore } from './conversation/database.js';
-export type { ConversationStore } from './conversation/types.js';
+export type {
+    ConversationStore,
+    ModelHistoryLoad,
+    ModelHistoryLoadStats,
+} from './conversation/types.js';
 export type { SessionStore } from './sessions/types.js';
 export type { MemoryStore } from './memories/types.js';
 export type { WorkspaceStore } from './workspaces/types.js';

--- a/packages/core/src/storage/stores/in-memory.ts
+++ b/packages/core/src/storage/stores/in-memory.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'crypto';
 import type { ApprovalRequest, ApprovalResponse } from '../../approval/types.js';
 import { cloneInternalMessage, cloneInternalMessages } from '../../context/content-clone.js';
 import type { InternalMessage } from '../../context/types.js';
+import { filterCompacted } from '../../context/utils.js';
 import type { Memory } from '../../memory/types.js';
 import type { StoredCustomPrompt } from '../../prompts/providers/custom-prompt-provider.js';
 import { cloneQueuedMessage, cloneQueuedMessages } from '../../session/queue-clone.js';
@@ -19,7 +20,7 @@ import type {
     ArtifactStore,
     StoredArtifactMetadata,
 } from '../artifacts/types.js';
-import type { ConversationStore } from '../conversation/types.js';
+import type { ConversationStore, ModelHistoryLoad } from '../conversation/types.js';
 import type { MemoryStore } from '../memories/types.js';
 import type { SessionMessageQueueStore } from '../message-queue/types.js';
 import type { CustomPromptStore } from '../prompts/types.js';
@@ -58,6 +59,25 @@ class InMemoryConversationStore implements ConversationStore {
 
     async listMessages(input: { sessionId: string }): Promise<InternalMessage[]> {
         return cloneInternalMessages(this.messages.get(input.sessionId) ?? []);
+    }
+
+    async loadModelHistory(input: { sessionId: string }): Promise<ModelHistoryLoad> {
+        const fullHistory = await this.listMessages(input);
+        const messages = filterCompacted(fullHistory);
+        const firstMessage = messages[0];
+        const summaryMessageId =
+            firstMessage?.metadata?.isSummary === true ||
+            firstMessage?.metadata?.isSessionSummary === true
+                ? (firstMessage.id ?? null)
+                : null;
+        return {
+            messages,
+            stats: {
+                returnedMessages: messages.length,
+                skippedPreSummaryMessages: fullHistory.length - messages.length,
+                summaryMessageId,
+            },
+        };
     }
 
     async saveMessage(input: { sessionId: string; message: InternalMessage }): Promise<void> {


### PR DESCRIPTION
## Summary
- add a conversation-store model-history loading boundary so long sessions can avoid unnecessary full-history materialization
- make compaction and streaming use the model-history/message-id boundary instead of rereading raw history
- add a patch changeset for @dexto/core and sync generated OpenAPI version metadata

## Validation
- pnpm --filter @dexto/core lint
- pnpm --filter @dexto/core typecheck
- pnpm --filter @dexto/core exec vitest run src/llm/executor/turn-executor.integration.test.ts --reporter=dot
- pnpm --filter @dexto/core exec vitest run src/context/manager.test.ts src/llm/executor/stream-processor.test.ts src/storage/conversation/database.test.ts --reporter=dot
- pnpm format:check
- ./scripts/quality-checks.sh all 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-history loading to provide a compacted, model-visible conversation view without reading full history for long sessions.
  * Updated context preparation so formatting, retries, compaction decisions, and token estimates use the model-history boundary.
  * Assistant message creation now returns the saved message ID immediately.

* **Bug Fixes**
  * Reduced full-history reads during long sessions to improve consistency and performance.
  * Added stronger validation and coverage to ensure assistant message IDs are reliably tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->