### PR TITLE
Reduce memory used by old chat attachments

### DIFF
--- a/.changeset/quiet-media-context.md
+++ b/.changeset/quiet-media-context.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Avoid loading old or unsupported canonical media resource bytes when building model context.

--- a/packages/core/src/context/manager.test.ts
+++ b/packages/core/src/context/manager.test.ts
@@ -238,12 +238,6 @@ describe('ContextManager', () => {
             const stores = new InMemoryDextoStores();
             const resourceManager = {
                 read: vi.fn(async (uri: string) => {
-                    if (uri === 'blob:old-image') {
-                        return {
-                            contents: [{ blob: 'old-image-data', mimeType: 'image/png' }],
-                            _meta: { size: 1024, originalName: 'old-image.png' },
-                        };
-                    }
                     if (uri === 'blob:middle-image') {
                         return {
                             contents: [{ blob: 'middle-image-data', mimeType: 'image/png' }],
@@ -273,17 +267,42 @@ describe('ContextManager', () => {
             const history: InternalMessage[] = [
                 {
                     role: 'user',
-                    content: [{ type: 'image', image: '@blob:old-image', mimeType: 'image/png' }],
-                } as InternalMessage,
-                {
-                    role: 'user',
                     content: [
-                        { type: 'image', image: '@blob:middle-image', mimeType: 'image/png' },
+                        {
+                            type: 'resource',
+                            uri: 'blob:old-image',
+                            name: 'old-image.png',
+                            mimeType: 'image/png',
+                            kind: 'image',
+                            size: 1024,
+                        },
                     ],
                 } as InternalMessage,
                 {
                     role: 'user',
-                    content: [{ type: 'image', image: '@blob:new-image', mimeType: 'image/png' }],
+                    content: [
+                        {
+                            type: 'resource',
+                            uri: 'blob:middle-image',
+                            name: 'middle-image.png',
+                            mimeType: 'image/png',
+                            kind: 'image',
+                            size: 2048,
+                        },
+                    ],
+                } as InternalMessage,
+                {
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'resource',
+                            uri: 'blob:new-image',
+                            name: 'new-image.png',
+                            mimeType: 'image/png',
+                            kind: 'image',
+                            size: 3072,
+                        },
+                    ],
                 } as InternalMessage,
             ];
 
@@ -299,14 +318,22 @@ describe('ContextManager', () => {
                 .calls[0]?.[0] as InternalMessage[];
             expect(formattedHistory).toBeDefined();
             expect(formattedHistory[0]?.content).toEqual([
+                { type: 'text', text: 'Attached image: blob:old-image (old-image.png)' },
                 { type: 'text', text: '[Image: old-image.png (1 KB)]' },
             ]);
             expect(formattedHistory[1]?.content).toEqual([
+                {
+                    type: 'text',
+                    text: 'Attached image: blob:middle-image (middle-image.png)',
+                },
                 { type: 'image', image: 'middle-image-data', mimeType: 'image/png' },
             ]);
             expect(formattedHistory[2]?.content).toEqual([
+                { type: 'text', text: 'Attached image: blob:new-image (new-image.png)' },
                 { type: 'image', image: 'new-image-data', mimeType: 'image/png' },
             ]);
+            expect(resourceManager.read).toHaveBeenCalledTimes(2);
+            expect(resourceManager.read).not.toHaveBeenCalledWith('blob:old-image');
         });
 
         it('should rehydrate recent tool media for the LLM', async () => {

--- a/packages/core/src/context/utils.test.ts
+++ b/packages/core/src/context/utils.test.ts
@@ -1474,6 +1474,69 @@ describe('expandBlobReferences', () => {
         expect(result).toEqual([{ type: 'text', text: '[Image: older-image.png (2 KB)]' }]);
     });
 
+    test('should demote older resource media without reading artifact bytes', async () => {
+        const resourceManager = {
+            read: vi.fn(),
+        } as unknown as import('../resources/index.js').ResourceManager;
+
+        const result = await expandBlobReferences(
+            [
+                {
+                    type: 'resource',
+                    uri: 'blob:uploaded-image',
+                    name: 'uploaded-image.png',
+                    mimeType: 'image/png',
+                    kind: 'image',
+                    size: 2048,
+                },
+            ],
+            resourceManager,
+            mockLogger,
+            ['image/*'],
+            false
+        );
+
+        expect(result).toEqual([
+            {
+                type: 'text',
+                text: 'Attached image: blob:uploaded-image (uploaded-image.png)',
+            },
+            { type: 'text', text: '[Image: uploaded-image.png (2 KB)]' },
+        ]);
+        expect(resourceManager.read).not.toHaveBeenCalled();
+    });
+
+    test('should demote unsupported resource media without reading artifact bytes', async () => {
+        const resourceManager = {
+            read: vi.fn(),
+        } as unknown as import('../resources/index.js').ResourceManager;
+
+        const result = await expandBlobReferences(
+            [
+                {
+                    type: 'resource',
+                    uri: 'blob:uploaded-video',
+                    name: 'uploaded-video.mp4',
+                    mimeType: 'video/mp4',
+                    kind: 'video',
+                    size: 5 * 1024 * 1024,
+                },
+            ],
+            resourceManager,
+            mockLogger,
+            ['image/*']
+        );
+
+        expect(result).toEqual([
+            {
+                type: 'text',
+                text: 'Attached video: blob:uploaded-video (uploaded-video.mp4)',
+            },
+            { type: 'text', text: '[Video: uploaded-video.mp4 (5 MB)]' },
+        ]);
+        expect(resourceManager.read).not.toHaveBeenCalled();
+    });
+
     test('should still expand text blobs when prompt media expansion is disabled', async () => {
         const resourceManager = createMockResourceManager({
             abc123def456: { text: 'Long text attachment', mimeType: 'text/plain' },

--- a/packages/core/src/context/utils.ts
+++ b/packages/core/src/context/utils.ts
@@ -897,6 +897,24 @@ export async function expandBlobReferences(
         }
 
         if (part.type === 'resource') {
+            const shouldPlaceholderForUnsupportedMedia =
+                allowedMediaTypes !== undefined &&
+                !matchesAnyMimePattern(part.mimeType, allowedMediaTypes);
+            const shouldPlaceholderForRetainedHistoryMedia =
+                isBinaryMediaMimeType(part.mimeType) && !expandMatchingMedia;
+            if (shouldPlaceholderForUnsupportedMedia || shouldPlaceholderForRetainedHistoryMedia) {
+                expandedParts.push({ type: 'text', text: buildResourceAnchorText(part) });
+                expandedParts.push({
+                    type: 'text',
+                    text: generateMediaPlaceholder({
+                        mimeType: part.mimeType,
+                        size: part.size ?? 0,
+                        originalName: part.name,
+                    }),
+                });
+                continue;
+            }
+
             const resolved = await resolveBlobReferenceToParts(
                 part.uri,
                 resourceManager,


### PR DESCRIPTION
## Summary

- avoid reading canonical resource bytes when media is outside the active context expansion window
- render old or unsupported resources from descriptor metadata instead
- preserve byte expansion for recent supported media that is actually sent to the model

## Scope

This is storage-agnostic Core behavior. It does not know about R2 or Cloudflare and does not change legacy inline image/file handling. Dexto Cloud will keep existing inline messages readable and migrate those rows separately after its companion improvement merges.

## Test plan

- `pnpm vitest run packages/core/src/context/manager.test.ts packages/core/src/context/utils.test.ts`
- `pnpm --filter @dexto/core lint`
- `pnpm --filter @dexto/core typecheck`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of media in model context creation.
  * Prevented unsupported or outdated image and video resources from being loaded unnecessarily.
  * Displayed compact placeholders and descriptive text when media cannot be included.
  * Preserved supported media content while avoiding redundant resource reads.

* **Tests**
  * Added coverage for supported, unsupported, and retained media scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->