### PR TITLE
Avoid retaining stack-bearing turn cleanup errors

### DIFF
--- a/.changeset/clean-turn-aborts.md
+++ b/.changeset/clean-turn-aborts.md
@@ -1,0 +1,6 @@
+---
+"@dexto/core": patch
+---
+
+Avoid retaining stack-bearing abort errors when cleaning up event listeners and completed turn
+steps.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.9.5",
+    "version": "1.9.7",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -248,6 +248,7 @@ export type HostRuntimeEventContext = {
 
 export type EventArgs<TEvent> = [TEvent] extends [void] ? [] : [TEvent];
 export type EventListener<TEvent> = (...args: EventArgs<TEvent>) => void;
+export const EVENT_LISTENER_CLEANUP_REASON = 'dexto.event-listener-cleanup';
 
 type WithHostRuntime<TEventMap extends object> = {
     [K in keyof TEventMap]: TEventMap[K] extends void

--- a/packages/core/src/llm/executor/turn-executor.integration.test.ts
+++ b/packages/core/src/llm/executor/turn-executor.integration.test.ts
@@ -460,6 +460,17 @@ describe('TurnExecutor Integration Tests', () => {
             });
         });
 
+        it('aborts the completed model step with a primitive cleanup reason', async () => {
+            await contextManager.addUserMessage([{ type: 'text', text: 'Hello' }]);
+
+            await executor.execute({ mcpManager }, true);
+
+            const providerSignal = vi.mocked(streamText).mock.calls[0]?.[0].abortSignal;
+            expect(providerSignal?.aborted).toBe(true);
+            expect(providerSignal?.reason).toBe('dexto.turn-step-cleanup');
+            expect(providerSignal?.reason).not.toBeInstanceOf(globalThis.DOMException);
+        });
+
         it('can drive a turn through the explicit turn driver boundary', async () => {
             const runCompleteHandler = vi.fn();
             sessionEventBus.on('run:complete', runCompleteHandler);
@@ -3935,6 +3946,9 @@ describe('TurnExecutor Integration Tests', () => {
             const result = await executorWithSignal.execute({ mcpManager }, true);
 
             expect(result.finishReason).toBe('cancelled');
+            const providerSignal = vi.mocked(streamText).mock.calls[0]?.[0].abortSignal;
+            expect(providerSignal?.reason).toBeInstanceOf(globalThis.DOMException);
+            expect(providerSignal?.reason).toEqual(expect.objectContaining({ name: 'AbortError' }));
         });
 
         it('appends a cancelled tool result when aborted while approval is pending', async () => {

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -78,6 +78,7 @@ import { cloneStructuredValuePreservingUrls } from '../../context/content-clone.
 const MCP_TOOL_PREFIX = 'mcp--';
 const MODEL_REQUEST_MAX_RETRIES = 2;
 const TOOL_SUPPORT_PROBE_TIMEOUT_MS = 5000;
+const TURN_STEP_CLEANUP_REASON = 'dexto.turn-step-cleanup';
 type ToolSupportValidationResult =
     | {
           supported: boolean;
@@ -2342,7 +2343,7 @@ export class TurnExecutor {
 
         // Abort any pending operations for current step
         if (!this.stepAbortController.signal.aborted) {
-            this.stepAbortController.abort();
+            this.stepAbortController.abort(TURN_STEP_CLEANUP_REASON);
         }
     }
 

--- a/packages/core/src/resources/manager.test.ts
+++ b/packages/core/src/resources/manager.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { AgentEventBus, EVENT_LISTENER_CLEANUP_REASON } from '../events/index.js';
+import { createMockLogger } from '../logger/v2/test-utils.js';
+import { MCPManager } from '../mcp/manager.js';
+import { InMemoryDextoStores } from '../storage/index.js';
+import { ResourceManager } from './manager.js';
+
+describe('ResourceManager cleanup', () => {
+    it('removes notification listeners without creating a default AbortError', () => {
+        const eventBus = new AgentEventBus();
+        const onSpy = vi.spyOn(eventBus, 'on');
+        const invalidated = vi.fn();
+        eventBus.on('resource:cache-invalidated', invalidated);
+        const logger = createMockLogger();
+        const manager = new ResourceManager(
+            new MCPManager(logger, eventBus),
+            {
+                artifactStore: new InMemoryDextoStores().getStore('artifacts'),
+                resourcesConfig: [],
+            },
+            eventBus,
+            logger
+        );
+        const cleanupSignal = onSpy.mock.calls.find(
+            ([eventName]) => eventName === 'mcp:resource-updated'
+        )?.[2]?.signal;
+
+        eventBus.emit('mcp:resource-updated', {
+            resourceUri: 'resource://before-cleanup',
+            serverName: 'test-server',
+        });
+        expect(invalidated).toHaveBeenCalledTimes(1);
+
+        manager.cleanup();
+
+        expect(cleanupSignal?.aborted).toBe(true);
+        expect(cleanupSignal?.reason).toBe(EVENT_LISTENER_CLEANUP_REASON);
+        expect(cleanupSignal?.reason).not.toBeInstanceOf(globalThis.DOMException);
+
+        eventBus.emit('mcp:resource-updated', {
+            resourceUri: 'resource://after-cleanup',
+            serverName: 'test-server',
+        });
+        expect(invalidated).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/resources/manager.test.ts
+++ b/packages/core/src/resources/manager.test.ts
@@ -32,6 +32,7 @@ describe('ResourceManager cleanup', () => {
         expect(invalidated).toHaveBeenCalledTimes(1);
 
         manager.cleanup();
+        manager.cleanup();
 
         expect(cleanupSignal?.aborted).toBe(true);
         expect(cleanupSignal?.reason).toBe(EVENT_LISTENER_CLEANUP_REASON);

--- a/packages/core/src/resources/manager.ts
+++ b/packages/core/src/resources/manager.ts
@@ -6,7 +6,7 @@ import type { ValidatedResourcesConfig } from './schemas.js';
 import type { InternalResourceServices } from './handlers/types.js';
 import type { Logger } from '../logger/v2/types.js';
 import { DextoLogComponent } from '../logger/v2/types.js';
-import type { AgentEventBus } from '../events/index.js';
+import { EVENT_LISTENER_CLEANUP_REASON, type AgentEventBus } from '../events/index.js';
 import type { ArtifactStore } from '../storage/artifacts/types.js';
 
 export interface ResourceManagerOptions {
@@ -56,7 +56,7 @@ export class ResourceManager {
 
     cleanup(): void {
         if (!this.listenerAbort.signal.aborted) {
-            this.listenerAbort.abort();
+            this.listenerAbort.abort(EVENT_LISTENER_CLEANUP_REASON);
             this.logger.debug('ResourceManager event listeners cleaned up');
         }
     }

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -3503,10 +3503,21 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 ([eventName]) => eventName === 'workspace:changed'
             )?.[2]?.signal;
             await toolManager.cleanup();
+            await toolManager.cleanup();
 
             expect(workspaceListenerSignal?.aborted).toBe(true);
             expect(workspaceListenerSignal?.reason).toBe(EVENT_LISTENER_CLEANUP_REASON);
             expect(workspaceListenerSignal?.reason).not.toBeInstanceOf(globalThis.DOMException);
+            expect(
+                eventBus.emit('workspace:changed', {
+                    workspace: {
+                        id: 'workspace-after-cleanup',
+                        path: '/tmp/workspace-after-cleanup',
+                        createdAt: 2,
+                        lastActiveAt: 2,
+                    },
+                })
+            ).toBe(false);
         });
     });
 

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -11,7 +11,7 @@ import { MCPManager } from '../mcp/manager.js';
 import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 import { ToolErrorCode } from './error-codes.js';
 import { ErrorScope, ErrorType } from '../errors/types.js';
-import { AgentEventBus } from '../events/index.js';
+import { AgentEventBus, EVENT_LISTENER_CLEANUP_REASON } from '../events/index.js';
 import type { ApprovalManager } from '../approval/manager.js';
 import type { AllowedToolsProvider } from './approval/allowed-tools-provider/types.js';
 import { ApprovalStatus, ApprovalType } from '../approval/types.js';
@@ -22,6 +22,7 @@ import type { SessionToolPreferences } from './session-tool-preferences-store.js
 import { createAgentRunContext } from '../runtime/run-context.js';
 import { InMemoryDextoStores } from '../storage/index.js';
 import { createToolExecutionId } from '../storage/tool-executions/types.js';
+import { WorkspaceManager } from '../workspace/manager.js';
 
 function createDeferred<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void;
@@ -3477,6 +3478,35 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             await toolManager.getAllTools();
 
             expect(mockMcpManager.getAllTools).toHaveBeenCalledTimes(2);
+        });
+
+        it('cleans up its workspace listener without creating a default AbortError', async () => {
+            const eventBus = new AgentEventBus();
+            const onSpy = vi.spyOn(eventBus, 'on');
+            const stores = new InMemoryDextoStores();
+
+            const toolManager = createToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'manual',
+                eventBus,
+                { alwaysAllow: [] },
+                [],
+                mockLogger
+            );
+
+            await toolManager.setWorkspaceManager(
+                new WorkspaceManager(stores.getStore('workspaces'), eventBus, mockLogger)
+            );
+            const workspaceListenerSignal = onSpy.mock.calls.find(
+                ([eventName]) => eventName === 'workspace:changed'
+            )?.[2]?.signal;
+            await toolManager.cleanup();
+
+            expect(workspaceListenerSignal?.aborted).toBe(true);
+            expect(workspaceListenerSignal?.reason).toBe(EVENT_LISTENER_CLEANUP_REASON);
+            expect(workspaceListenerSignal?.reason).not.toBeInstanceOf(globalThis.DOMException);
         });
     });
 

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -14,7 +14,7 @@ import { DextoRuntimeError, ErrorScope, ErrorType } from '../errors/index.js';
 import type { Logger } from '../logger/v2/types.js';
 import { DextoLogComponent } from '../logger/v2/types.js';
 import { convertZodSchemaToJsonSchema } from '../utils/schema.js';
-import type { AgentEventBus } from '../events/index.js';
+import { EVENT_LISTENER_CLEANUP_REASON, type AgentEventBus } from '../events/index.js';
 import type {
     ApprovalDecisionInput,
     ApprovalManager,
@@ -396,7 +396,7 @@ export class ToolManager {
             );
             this.registerCleanup(() => {
                 if (!this.workspaceListenerAbort.signal.aborted) {
-                    this.workspaceListenerAbort.abort();
+                    this.workspaceListenerAbort.abort(EVENT_LISTENER_CLEANUP_REASON);
                 }
             });
         }


### PR DESCRIPTION
## Summary

- abort event-listener cleanup with a shared primitive reason instead of constructing stack-bearing `AbortError` objects
- make resource/tool listener cleanup idempotent and verify repeated cleanup
- abort completed model-step controllers with the same primitive cleanup reason
- add a patch changeset for `@dexto/core`
- sync the already-stale OpenAPI metadata version from `1.9.5` to current `1.9.7` in a separate commit

## Why

Cloudflare Workflow heap snapshots showed completed turns retaining `DOMException` / `ErrorStackData` through listener and step abort reasons. These objects carry stack traces despite representing normal cleanup, not errors.

The Cloud integration profile with this Core patch and the corresponding Cloud event-listener reason retained no completed `DextoAgent`, `TurnExecutor`, `ToolManager`, or `ApprovalManager` object instances and no `ErrorStackData` after five four-turn loops. Snapshot-forced GC reduced the warm isolate from a `145.22 MiB` observed high-water peak to `75.70 MiB` used.

This does not change cancellation behavior. Active cancellation still uses its real cancellation reason; only normal completed-step/listener cleanup uses the primitive marker.

## Validation

- focused event bus, resource manager, tool manager, and turn executor suites passed
- full repository quality gate passed:
  - build
  - generated OpenAPI check
  - tests
  - lint with zero warnings
  - typecheck
  - Hono inference
- linked Cloud Worker build and 20-turn warm smoke passed

## Changeset

Patch: `@dexto/core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation cleanup for completed AI turn steps.
  * Prevented cleanup operations from retaining stack-bearing abort errors.
  * Added consistent, non-error reasons for internal event-listener cleanup.
  * Ensured cleaned-up resource and workspace listeners no longer respond to later events.

* **Documentation**
  * Updated the OpenAPI specification version from 1.9.5 to 1.9.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->