### PR TITLE
Add mandatory approval request policy

### DIFF
--- a/.changeset/quiet-pandas-approve.md
+++ b/.changeset/quiet-pandas-approve.md
@@ -1,0 +1,7 @@
+---
+'@dexto/agent-management': patch
+'@dexto/core': minor
+---
+
+Add a per-request auto-approval policy so hosts can require an explicit approval even when the
+agent otherwise runs in auto-approve mode, including approvals delegated from sub-agents.

--- a/packages/agent-management/src/runtime/approval-delegation.test.ts
+++ b/packages/agent-management/src/runtime/approval-delegation.test.ts
@@ -1,9 +1,10 @@
+import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
-import type { ApprovalManager, ApprovalRequest, ApprovalRequestDetails } from '@dexto/core';
-import { ApprovalStatus, ApprovalType } from '@dexto/core';
+import type { ApprovalRequest, ApprovalRequestDetails, ApprovalStore, Logger } from '@dexto/core';
+import { ApprovalManager, ApprovalStatus, ApprovalType } from '@dexto/core';
 import { createDelegatingApprovalHandler } from './approval-delegation.js';
 
-function createMockLogger() {
+function createMockLogger(): Logger {
     return {
         debug: vi.fn(),
         silly: vi.fn(),
@@ -17,6 +18,19 @@ function createMockLogger() {
         setLevel: vi.fn(),
         getLevel: vi.fn(() => 'info' as const),
         getLogFilePath: vi.fn(() => null),
+    };
+}
+
+function createMockApprovalStore(): ApprovalStore {
+    return {
+        createRequest: vi.fn(async ({ request }) => request),
+        deleteSessionState: vi.fn(async () => undefined),
+        getRequest: vi.fn(async () => undefined),
+        getResponse: vi.fn(async () => undefined),
+        listPending: vi.fn(async () => []),
+        loadSessionState: vi.fn(async () => ({ approvedKeys: {} })),
+        saveResponse: vi.fn(async ({ response }) => ({ response, status: 'created' as const })),
+        saveSessionState: vi.fn(async () => undefined),
     };
 }
 
@@ -101,5 +115,45 @@ describe('createDelegatingApprovalHandler', () => {
 
         const forwarded = requestApproval.mock.calls[0]![0];
         expect(forwarded.sessionId).toBe('session-sub');
+    });
+
+    it('preserves mandatory policy when delegating to an auto-approving parent', async () => {
+        const parentApprovalManager = new ApprovalManager(
+            {
+                elicitation: { enabled: false },
+                permissions: { mode: 'auto-approve' },
+            },
+            createMockLogger(),
+            createMockApprovalStore()
+        );
+        const parentHandler = vi.fn(async (request: ApprovalRequest) => ({
+            approvalId: request.approvalId,
+            sessionId: request.sessionId,
+            status: ApprovalStatus.APPROVED,
+        }));
+        parentApprovalManager.setHandler(parentHandler);
+        const handler = createDelegatingApprovalHandler(
+            parentApprovalManager,
+            'agent-sub',
+            'session-parent',
+            createMockLogger()
+        );
+
+        await handler({
+            approvalId: randomUUID(),
+            autoApproval: 'disallowed',
+            metadata: {
+                args: { path: 'report.md' },
+                toolCallId: 'call-mandatory',
+                toolName: 'write_file',
+            },
+            sessionId: 'session-sub',
+            timestamp: new Date(),
+            type: ApprovalType.TOOL_APPROVAL,
+        });
+
+        expect(parentHandler).toHaveBeenCalledWith(
+            expect.objectContaining({ autoApproval: 'disallowed' })
+        );
     });
 });

--- a/packages/agent-management/src/runtime/approval-delegation.ts
+++ b/packages/agent-management/src/runtime/approval-delegation.ts
@@ -15,19 +15,6 @@ import type {
 } from '@dexto/core';
 
 /**
- * Extended metadata type that includes delegation information
- */
-interface DelegatedMetadata {
-    /** Original metadata from the request */
-    [key: string]: unknown;
-    /** ID of the sub-agent that originated the request */
-    delegatedFromAgent: string;
-
-    /** Original sessionId from the sub-agent */
-    delegatedFromSessionId?: string;
-}
-
-/**
  * Creates an ApprovalHandler that delegates requests to a parent's ApprovalManager.
  *
  * This allows sub-agent tool approvals to flow through the parent's approval system,
@@ -68,18 +55,21 @@ export function createDelegatingApprovalHandler(
             pendingApprovalIds.add(request.approvalId);
 
             try {
-                // Build delegated request details with sub-agent context
                 const delegatedDetails: ApprovalRequestDetails = {
+                    ...(request.autoApproval === undefined
+                        ? {}
+                        : { autoApproval: request.autoApproval }),
+                    ...(request.hostRuntime === undefined
+                        ? {}
+                        : { hostRuntime: request.hostRuntime }),
                     type: request.type,
                     timeout: request.timeout,
-                    // IMPORTANT: use the parent sessionId so the interactive CLI surfaces
-                    // the approval in the correct active session.
                     sessionId: parentSessionId ?? request.sessionId,
                     metadata: {
                         ...request.metadata,
                         delegatedFromAgent: subAgentId,
                         delegatedFromSessionId: request.sessionId,
-                    } as DelegatedMetadata,
+                    },
                 };
 
                 // Forward to parent's approval manager

--- a/packages/core/src/approval/factory.ts
+++ b/packages/core/src/approval/factory.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'crypto';
+import { ApprovalAutoApprovalPolicySchema } from './schemas.js';
 import type { ApprovalRequest, ApprovalRequestDetails } from './types.js';
 
 type ApprovalId = ApprovalRequest['approvalId'];
@@ -30,12 +31,17 @@ export function createApprovalRequest(
     details: ApprovalRequestDetails,
     approvalId: ApprovalId = randomUUID()
 ): ApprovalRequest {
+    const autoApproval =
+        details.autoApproval === undefined
+            ? undefined
+            : ApprovalAutoApprovalPolicySchema.parse(details.autoApproval);
     return {
         approvalId,
+        ...(autoApproval === undefined ? {} : { autoApproval }),
         type: details.type,
-        sessionId: details.sessionId,
-        hostRuntime: details.hostRuntime,
-        timeout: details.timeout,
+        ...(details.hostRuntime === undefined ? {} : { hostRuntime: details.hostRuntime }),
+        ...(details.sessionId === undefined ? {} : { sessionId: details.sessionId }),
+        ...(details.timeout === undefined ? {} : { timeout: details.timeout }),
         timestamp: new Date(),
         metadata: details.metadata,
     } as ApprovalRequest;

--- a/packages/core/src/approval/index.ts
+++ b/packages/core/src/approval/index.ts
@@ -4,6 +4,7 @@
 
 // Types
 export type {
+    ApprovalAutoApprovalPolicy,
     ApprovalHandler,
     ApprovalRequest,
     ApprovalResponse,
@@ -34,6 +35,7 @@ export {
 
 // Schemas
 export {
+    ApprovalAutoApprovalPolicySchema,
     ApprovalTypeSchema,
     ApprovalStatusSchema,
     DenialReasonSchema,

--- a/packages/core/src/approval/manager.test.ts
+++ b/packages/core/src/approval/manager.test.ts
@@ -10,6 +10,7 @@ import type { Logger } from '../logger/v2/types.js';
 import type { ApprovalStore, SessionApprovalState } from '../storage/approvals/types.js';
 import { createInMemorySessionApprovalStore } from '../test-utils/session-state-stores.js';
 import { ToolApprovalMetadataSchema } from './schemas.js';
+import type { ApprovalRequestDetails } from './types.js';
 
 function createDeferred<T>() {
     let resolve!: (value: T | PromiseLike<T>) => void;
@@ -61,6 +62,48 @@ describe('ApprovalManager', () => {
             });
 
             expect(toolResponse.status).toBe(ApprovalStatus.APPROVED);
+        });
+
+        it('should require the handler when one request disallows auto approval', async () => {
+            const manager = createApprovalManager(
+                {
+                    permissions: {
+                        mode: 'auto-approve',
+                        timeout: 120000,
+                    },
+                    elicitation: {
+                        enabled: false,
+                    },
+                },
+                mockLogger
+            );
+            const handler = vi.fn(async (request) => ({
+                approvalId: request.approvalId,
+                sessionId: request.sessionId,
+                status: ApprovalStatus.APPROVED,
+            }));
+            manager.setHandler(handler);
+            const mandatoryToolApproval = {
+                args: { path: 'report.md' },
+                autoApproval: 'disallowed' as const,
+                sessionId: 'session-1',
+                toolCallId: 'test-call-id',
+                toolName: 'write_file',
+            };
+
+            const response = await manager.requestToolApproval(mandatoryToolApproval);
+
+            expect(response.status).toBe(ApprovalStatus.APPROVED);
+            expect(handler).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    autoApproval: 'disallowed',
+                    metadata: {
+                        args: { path: 'report.md' },
+                        toolCallId: 'test-call-id',
+                        toolName: 'write_file',
+                    },
+                })
+            );
         });
 
         it('should reject elicitation when disabled, even if tools are auto-approved', async () => {
@@ -340,6 +383,92 @@ describe('ApprovalManager', () => {
                     identity
                 )
             ).rejects.toThrow(/conflicts with existing approval request/);
+        });
+
+        it('normalizes allowed replay policy and rejects a mandatory-policy conflict', async () => {
+            const manager = createApprovalManager({
+                permissions: {
+                    mode: 'manual',
+                    timeout: 120000,
+                },
+                elicitation: {
+                    enabled: true,
+                    timeout: 120000,
+                },
+            });
+            const identity = {
+                runId: 'run-1',
+                turnId: 'turn-1',
+                modelStepId: 'step-1',
+                toolCallId: 'call-policy',
+            };
+            const details = {
+                type: ApprovalType.TOOL_APPROVAL,
+                sessionId: 'session-1',
+                metadata: {
+                    toolName: 'write_file',
+                    toolCallId: 'call-policy',
+                    args: { path: 'src/app.ts' },
+                },
+            } as const;
+
+            const first = await manager.recordApprovalRequest(details, identity);
+            await expect(
+                manager.recordApprovalRequest({ ...details, autoApproval: 'allowed' }, identity)
+            ).resolves.toEqual(first);
+            await expect(
+                manager.recordApprovalRequest({ ...details, autoApproval: 'disallowed' }, identity)
+            ).rejects.toThrow(/conflicts with existing approval request/);
+        });
+
+        it('rejects invalid auto-approval policy at the manager boundary', async () => {
+            const manager = createApprovalManager({
+                permissions: {
+                    mode: 'auto-approve',
+                    timeout: 120000,
+                },
+                elicitation: {
+                    enabled: false,
+                },
+            });
+
+            await expect(
+                manager.requestApproval({
+                    autoApproval: 'sometimes',
+                    metadata: {
+                        args: {},
+                        toolCallId: 'call-invalid-policy',
+                        toolName: 'write_file',
+                    },
+                    type: ApprovalType.TOOL_APPROVAL,
+                } as unknown as ApprovalRequestDetails)
+            ).rejects.toThrow();
+        });
+
+        it('rejects invalid auto-approval policy on an existing request', async () => {
+            const manager = createApprovalManager({
+                permissions: {
+                    mode: 'auto-approve',
+                    timeout: 120000,
+                },
+                elicitation: {
+                    enabled: false,
+                },
+            });
+
+            await expect(
+                manager.requestApprovalDecision({
+                    approvalId: 'b6edbf50-0131-4a5a-b8e4-79611873005e',
+                    autoApproval: 'sometimes',
+                    metadata: {
+                        args: {},
+                        toolCallId: 'call-invalid-existing-policy',
+                        toolName: 'write_file',
+                    },
+                    timestamp: new Date(),
+                    type: ApprovalType.TOOL_APPROVAL,
+                } as unknown as Parameters<typeof manager.requestApprovalDecision>[0])
+            ).rejects.toThrow();
         });
 
         it('rejects response recording when the expected request does not match persisted state', async () => {

--- a/packages/core/src/approval/manager.ts
+++ b/packages/core/src/approval/manager.ts
@@ -1,5 +1,6 @@
 import { isDeepStrictEqual } from 'node:util';
 import type {
+    ApprovalAutoApprovalPolicy,
     ApprovalHandler,
     ApprovalRequest,
     ApprovalResponse,
@@ -10,6 +11,7 @@ import type {
 } from './types.js';
 import { ApprovalType, ApprovalStatus } from './types.js';
 import {
+    ApprovalAutoApprovalPolicySchema,
     CommandApprovalResponseSchema,
     CustomApprovalResponseSchema,
     ElicitationResponseSchema,
@@ -345,29 +347,6 @@ export class ApprovalManager {
         });
     }
 
-    private createApprovalDetails(
-        type: ApprovalType,
-        metadata: ApprovalRequestDetails['metadata'],
-        sessionId: string | undefined,
-        hostRuntime?: ApprovalRequestDetails['hostRuntime'],
-        timeout?: number
-    ): ApprovalRequestDetails {
-        const details: ApprovalRequestDetails = {
-            type,
-            timeout: this.getApprovalTimeout(type, timeout),
-            metadata,
-        };
-
-        if (sessionId !== undefined) {
-            details.sessionId = sessionId;
-        }
-        if (hostRuntime !== undefined) {
-            details.hostRuntime = hostRuntime;
-        }
-
-        return details;
-    }
-
     private withDefaultTimeout(details: ApprovalRequestDetails): ApprovalRequestDetails {
         return {
             ...details,
@@ -389,6 +368,7 @@ export class ApprovalManager {
         candidate: ApprovalRequest
     ): void {
         const existingComparable = {
+            autoApproval: existing.autoApproval ?? 'allowed',
             type: existing.type,
             sessionId: existing.sessionId,
             hostRuntime: existing.hostRuntime,
@@ -396,6 +376,7 @@ export class ApprovalManager {
             metadata: existing.metadata,
         };
         const candidateComparable = {
+            autoApproval: candidate.autoApproval ?? 'allowed',
             type: candidate.type,
             sessionId: candidate.sessionId,
             hostRuntime: candidate.hostRuntime,
@@ -578,6 +559,11 @@ export class ApprovalManager {
      * @private
      */
     private async handleApproval(request: ApprovalRequest): Promise<ApprovalResponse> {
+        const autoApproval =
+            request.autoApproval === undefined
+                ? 'allowed'
+                : ApprovalAutoApprovalPolicySchema.parse(request.autoApproval);
+
         // Elicitation always uses manual mode (requires handler)
         if (request.type === ApprovalType.ELICITATION) {
             const handler = this.ensureHandler();
@@ -591,7 +577,7 @@ export class ApprovalManager {
         const mode = this.config.permissions.mode;
 
         // Auto-approve mode
-        if (mode === 'auto-approve') {
+        if (mode === 'auto-approve' && autoApproval === 'allowed') {
             this.logger.info(
                 `Auto-approve approval '${request.type}', approvalId: ${request.approvalId}`
             );
@@ -617,21 +603,21 @@ export class ApprovalManager {
      */
     async requestToolApproval(
         metadata: ToolApprovalMetadata & {
+            autoApproval?: ApprovalAutoApprovalPolicy;
             sessionId?: string;
             hostRuntime?: ApprovalRequestDetails['hostRuntime'];
             timeout?: number;
         }
     ): Promise<ApprovalResponse> {
-        const { sessionId, hostRuntime, timeout, ...toolMetadata } = metadata;
-        return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.TOOL_APPROVAL,
-                toolMetadata,
-                sessionId,
-                hostRuntime,
-                timeout
-            )
-        );
+        const { autoApproval, sessionId, hostRuntime, timeout, ...toolMetadata } = metadata;
+        return this.requestApproval({
+            ...(autoApproval === undefined ? {} : { autoApproval }),
+            ...(hostRuntime === undefined ? {} : { hostRuntime }),
+            metadata: toolMetadata,
+            ...(sessionId === undefined ? {} : { sessionId }),
+            ...(timeout === undefined ? {} : { timeout }),
+            type: ApprovalType.TOOL_APPROVAL,
+        });
     }
 
     /**
@@ -657,21 +643,21 @@ export class ApprovalManager {
      */
     async requestCommandApproval(
         metadata: CommandApprovalMetadata & {
+            autoApproval?: ApprovalAutoApprovalPolicy;
             sessionId?: string;
             hostRuntime?: ApprovalRequestDetails['hostRuntime'];
             timeout?: number;
         }
     ): Promise<ApprovalResponse> {
-        const { sessionId, hostRuntime, timeout, ...commandMetadata } = metadata;
-        return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.COMMAND_APPROVAL,
-                commandMetadata,
-                sessionId,
-                hostRuntime,
-                timeout
-            )
-        );
+        const { autoApproval, sessionId, hostRuntime, timeout, ...commandMetadata } = metadata;
+        return this.requestApproval({
+            ...(autoApproval === undefined ? {} : { autoApproval }),
+            ...(hostRuntime === undefined ? {} : { hostRuntime }),
+            metadata: commandMetadata,
+            ...(sessionId === undefined ? {} : { sessionId }),
+            ...(timeout === undefined ? {} : { timeout }),
+            type: ApprovalType.COMMAND_APPROVAL,
+        });
     }
 
     /**
@@ -689,15 +675,13 @@ export class ApprovalManager {
         }
     ): Promise<ApprovalResponse> {
         const { sessionId, hostRuntime, timeout, ...elicitationMetadata } = metadata;
-        return this.requestApproval(
-            this.createApprovalDetails(
-                ApprovalType.ELICITATION,
-                elicitationMetadata,
-                sessionId,
-                hostRuntime,
-                timeout
-            )
-        );
+        return this.requestApproval({
+            ...(hostRuntime === undefined ? {} : { hostRuntime }),
+            metadata: elicitationMetadata,
+            ...(sessionId === undefined ? {} : { sessionId }),
+            ...(timeout === undefined ? {} : { timeout }),
+            type: ApprovalType.ELICITATION,
+        });
     }
 
     /**
@@ -706,6 +690,7 @@ export class ApprovalManager {
      */
     async checkToolApproval(
         metadata: ToolApprovalMetadata & {
+            autoApproval?: ApprovalAutoApprovalPolicy;
             sessionId?: string;
             hostRuntime?: ApprovalRequestDetails['hostRuntime'];
             timeout?: number;

--- a/packages/core/src/approval/schemas.ts
+++ b/packages/core/src/approval/schemas.ts
@@ -28,6 +28,10 @@ export const ApprovalStatusSchema = z.enum(APPROVAL_STATUSES);
  */
 export const DenialReasonSchema = z.enum(DENIAL_REASONS);
 
+export const ApprovalAutoApprovalPolicySchema = z
+    .enum(['allowed', 'disallowed'])
+    .describe('Whether configured automatic approval may satisfy this request.');
+
 // Custom Zod schema for ToolDisplayData validation
 const ToolDisplayDataSchema = z.custom<ToolDisplayData>((val) => isValidDisplayData(val), {
     message: 'Invalid ToolDisplayData',
@@ -109,6 +113,7 @@ export const CustomApprovalMetadataSchema = z
 export const BaseApprovalRequestSchema = z
     .object({
         approvalId: z.string().uuid().describe('Unique approval identifier'),
+        autoApproval: ApprovalAutoApprovalPolicySchema.optional(),
         type: ApprovalTypeSchema.describe('Type of approval'),
         sessionId: z.string().optional().describe('Session identifier'),
         hostRuntime: HostRuntimeContextSchema.optional().describe(
@@ -279,6 +284,7 @@ export const ApprovalResponseSchema = z.union([
  */
 export const ApprovalRequestDetailsSchema = z
     .object({
+        autoApproval: ApprovalAutoApprovalPolicySchema.optional(),
         type: ApprovalTypeSchema,
         sessionId: z.string().optional(),
         hostRuntime: HostRuntimeContextSchema.optional().describe(

--- a/packages/core/src/approval/types.ts
+++ b/packages/core/src/approval/types.ts
@@ -4,6 +4,7 @@
 
 import type { z } from 'zod';
 import type {
+    ApprovalAutoApprovalPolicySchema,
     ToolApprovalMetadataSchema,
     CommandApprovalMetadataSchema,
     ElicitationMetadataSchema,
@@ -26,6 +27,8 @@ import type {
     CustomApprovalResponseSchema,
     ApprovalResponseSchema,
 } from './schemas.js';
+
+export type ApprovalAutoApprovalPolicy = z.output<typeof ApprovalAutoApprovalPolicySchema>;
 
 /**
  * Types of approval requests supported by the system


### PR DESCRIPTION
## Summary
- add a top-level per-request `autoApproval` policy to the generic approval contract
- enforce `disallowed` before the global auto-approve shortcut and during replay validation
- preserve the policy when sub-agent approvals delegate to a parent runtime

## Why
Hosts need a generic way to require explicit user consent for billed, destructive, credential, or egress actions even when an agent session otherwise uses auto-approval.

## Validation
- build
- tests
- lint
- typecheck
- Hono inference
- focused approval manager and delegation tests

The repository OpenAPI freshness check currently fails on unchanged `main`; this PR does not touch server routes or generated OpenAPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-request approval policies that can require explicit approval, even when automatic approval is enabled.
  * Approval policies are validated and supported across tool, command, and elicitation requests.
  * Delegated approval requests now preserve mandatory approval requirements.

* **Bug Fixes**
  * Improved approval request normalization and conflict detection.
  * Invalid approval policy values are now rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->