### PR TITLE
Support multimodal files through Dexto Nova

### DIFF
--- a/.changeset/calm-files-travel.md
+++ b/.changeset/calm-files-travel.md
@@ -1,0 +1,5 @@
+---
+"@dexto/core": patch
+---
+
+Route Dexto Nova through the OpenRouter chat dialect so PDF, document, and inline audio file parts reach the gateway, and avoid retrying deterministic unsupported-functionality failures.

--- a/packages/core/src/llm/executor/provider-error.test.ts
+++ b/packages/core/src/llm/executor/provider-error.test.ts
@@ -1,10 +1,46 @@
 import { describe, expect, it } from 'vitest';
-import { APICallError } from 'ai';
+import { APICallError, UnsupportedFunctionalityError } from 'ai';
 import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
 import { LLMErrorCode } from '../error-codes.js';
 import { mapProviderError } from './provider-error.js';
 
 describe('mapProviderError', () => {
+    it('does not retry deterministic unsupported functionality failures', () => {
+        const mapped = mapProviderError({
+            error: new UnsupportedFunctionalityError({
+                functionality: 'file part media type application/pdf',
+            }),
+            provider: 'dexto-nova',
+            model: 'openai/gpt-5.4',
+            sessionId: 'session-pdf',
+        });
+
+        expect(mapped).toBeInstanceOf(DextoRuntimeError);
+        expect(mapped).toMatchObject({
+            code: LLMErrorCode.GENERATION_FAILED,
+            retryDisposition: 'non_retryable',
+        });
+    });
+
+    it('preserves structured stream error messages from provider adapters', () => {
+        const mapped = mapProviderError({
+            error: {
+                code: 'invalid_request_error',
+                message: "Invalid schema for function 'lookup': schema must have type 'object'.",
+            },
+            provider: 'dexto-nova',
+            model: 'openai/gpt-5.4',
+            sessionId: 'session-tools',
+        });
+
+        expect(mapped).toBeInstanceOf(DextoRuntimeError);
+        expect(mapped).toMatchObject({
+            code: LLMErrorCode.REQUEST_INVALID_SCHEMA,
+            message: "Invalid schema for function 'lookup': schema must have type 'object'.",
+            retryDisposition: 'non_retryable',
+        });
+    });
+
     it('marks insufficient credits provider failures as non-retryable', () => {
         const error = new APICallError({
             message: 'Payment Required',

--- a/packages/core/src/llm/executor/provider-error.ts
+++ b/packages/core/src/llm/executor/provider-error.ts
@@ -1,4 +1,4 @@
-import { APICallError } from 'ai';
+import { APICallError, UnsupportedFunctionalityError } from 'ai';
 import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
 import { ErrorScope, ErrorType } from '../../errors/types.js';
 import type { ErrorRetryDisposition } from '../../errors/types.js';
@@ -125,7 +125,9 @@ function providerMessage(details: LLMProviderErrorDetails, fallback: string): st
 }
 
 function messageFromUnknown(value: unknown): string {
-    return value instanceof Error ? value.message : String(value);
+    if (value instanceof Error) return value.message;
+    if (isRecord(value)) return readString(value.message) ?? String(value);
+    return String(value);
 }
 
 function isInvalidSchemaMessage(message: string): boolean {
@@ -237,6 +239,18 @@ export function mapProviderError(input: MapProviderErrorInput): Error {
 
     if (!APICallError.isInstance?.(input.error)) {
         const message = messageFromUnknown(input.error);
+        if (UnsupportedFunctionalityError.isInstance(input.error)) {
+            return new DextoRuntimeError(
+                LLMErrorCode.GENERATION_FAILED,
+                ErrorScope.LLM,
+                ErrorType.THIRD_PARTY,
+                message,
+                buildContext(input, extractProviderErrorDetails(input)),
+                undefined,
+                undefined,
+                'non_retryable'
+            );
+        }
         if (isInvalidSchemaMessage(message)) {
             return new DextoRuntimeError(
                 LLMErrorCode.REQUEST_INVALID_SCHEMA,

--- a/packages/core/src/llm/executor/provider-options.test.ts
+++ b/packages/core/src/llm/executor/provider-options.test.ts
@@ -360,7 +360,7 @@ describe('buildProviderOptions', () => {
                     reasoning: { variant: 'high' },
                 })
             ).toEqual({
-                'dexto-nova': {
+                openrouter: {
                     include_reasoning: true,
                     reasoning: { enabled: true, effort: 'high' },
                 },
@@ -377,7 +377,7 @@ describe('buildProviderOptions', () => {
                         reasoning: { variant: effort },
                     })
                 ).toEqual({
-                    'dexto-nova': {
+                    openrouter: {
                         include_reasoning: true,
                         reasoning: { enabled: true, effort },
                     },
@@ -392,7 +392,7 @@ describe('buildProviderOptions', () => {
                     model: 'anthropic/claude-fable-5',
                 })
             ).toEqual({
-                'dexto-nova': {
+                openrouter: {
                     include_reasoning: true,
                     reasoning: { enabled: true, effort: 'high' },
                 },
@@ -493,7 +493,7 @@ describe('buildProviderOptions', () => {
             ).toBeUndefined();
         });
 
-        it('keeps openrouter and dexto-nova option payloads aligned under their transport keys', () => {
+        it('uses OpenRouter transport options for both gateway providers', () => {
             const cases = [
                 {
                     model: 'openai/gpt-5.2-codex',
@@ -524,7 +524,7 @@ describe('buildProviderOptions', () => {
                     model: testCase.model,
                     reasoning: testCase.reasoning,
                 });
-                expect(fromDextoNova?.['dexto-nova']).toEqual(fromOpenRouter?.openrouter);
+                expect(fromDextoNova?.openrouter).toEqual(fromOpenRouter?.openrouter);
             }
         });
     });

--- a/packages/core/src/llm/executor/provider-options.ts
+++ b/packages/core/src/llm/executor/provider-options.ts
@@ -168,18 +168,17 @@ function buildOpenRouterProviderOptions(config: {
 }): Record<string, Record<string, unknown>> | undefined {
     const { provider, model, reasoningVariant, budgetTokens } = config;
     const profile = getReasoningProfile(provider, model);
-
     if (!profile.capable) {
         return undefined;
     }
 
     if (reasoningVariant === 'disabled') {
-        return { [provider]: { include_reasoning: false } };
+        return { openrouter: { include_reasoning: false } };
     }
 
     if (budgetTokens !== undefined) {
         return {
-            [provider]: {
+            openrouter: {
                 include_reasoning: true,
                 reasoning: { enabled: true, max_tokens: budgetTokens },
             },
@@ -189,7 +188,7 @@ function buildOpenRouterProviderOptions(config: {
     if (profile.paradigm === 'budget') {
         if (reasoningVariant === undefined || reasoningVariant === 'enabled') {
             return {
-                [provider]: {
+                openrouter: {
                     include_reasoning: true,
                 },
             };
@@ -200,7 +199,7 @@ function buildOpenRouterProviderOptions(config: {
     const effort = toOpenAIReasoningEffort(reasoningVariant);
 
     return {
-        [provider]: {
+        openrouter: {
             include_reasoning: true,
             ...(effort !== undefined ? { reasoning: { enabled: true, effort } } : {}),
         },

--- a/packages/core/src/llm/services/factory.dexto-nova-files.test.ts
+++ b/packages/core/src/llm/services/factory.dexto-nova-files.test.ts
@@ -1,0 +1,182 @@
+import { TextEncoder } from 'node:util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+    LanguageModelV2,
+    LanguageModelV2FilePart,
+    SharedV2ProviderOptions,
+} from '@ai-sdk/provider';
+import { LLMConfigSchema } from '../schemas.js';
+import { createVercelModel } from './factory.js';
+
+function isLanguageModelV2(value: unknown): value is LanguageModelV2 {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        typeof Reflect.get(value, 'doGenerate') === 'function'
+    );
+}
+
+async function captureGatewayRequest(
+    file: LanguageModelV2FilePart,
+    providerOptions: SharedV2ProviderOptions | undefined
+): Promise<unknown> {
+    let request: unknown;
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async (_input: unknown, init?: { body?: unknown }) => {
+            request = JSON.parse(String(init?.body));
+            return Response.json({
+                choices: [
+                    {
+                        finish_reason: 'stop',
+                        index: 0,
+                        message: { content: 'ok', role: 'assistant' },
+                    },
+                ],
+                created: 1,
+                id: 'chatcmpl_file_test',
+                model: 'openai/gpt-5.4',
+                object: 'chat.completion',
+                usage: {
+                    completion_tokens: 1,
+                    prompt_tokens: 1,
+                    total_tokens: 2,
+                },
+            });
+        })
+    );
+
+    const model = await createVercelModel(
+        LLMConfigSchema.parse({
+            apiKey: 'dxt_test_key',
+            baseURL: 'https://gateway.example/v1',
+            model: 'openai/gpt-5.4',
+            provider: 'dexto-nova',
+        })
+    );
+    if (!isLanguageModelV2(model)) {
+        throw new Error('Expected dexto-nova to create an AI SDK language model.');
+    }
+
+    await model.doGenerate({
+        prompt: [
+            {
+                content: [{ text: 'Analyze this file.', type: 'text' }, file],
+                role: 'user',
+            },
+        ],
+        ...(providerOptions === undefined ? {} : { providerOptions }),
+    });
+
+    return request;
+}
+
+describe('createVercelModel dexto-nova file transport', () => {
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it.each([
+        {
+            filename: 'test.pdf',
+            mediaType: 'application/pdf',
+            payload: '%PDF-test',
+        },
+        {
+            filename: 'test.docx',
+            mediaType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            payload: 'PK-docx-test',
+        },
+    ])('sends $mediaType file parts to the Dexto gateway', async (file) => {
+        const request = await captureGatewayRequest(
+            {
+                data: new TextEncoder().encode(file.payload),
+                filename: file.filename,
+                mediaType: file.mediaType,
+                type: 'file',
+            },
+            undefined
+        );
+
+        expect(request).toEqual(
+            expect.objectContaining({
+                messages: [
+                    {
+                        content: [
+                            { text: 'Analyze this file.', type: 'text' },
+                            {
+                                file: {
+                                    file_data: expect.stringMatching(
+                                        new RegExp(`^data:${file.mediaType};base64,`, 'u')
+                                    ),
+                                    filename: file.filename,
+                                },
+                                type: 'file',
+                            },
+                        ],
+                        role: 'user',
+                    },
+                ],
+            })
+        );
+    });
+
+    it('sends audio file parts to the Dexto gateway', async () => {
+        const request = await captureGatewayRequest(
+            {
+                data: new TextEncoder().encode('mp3-test'),
+                filename: 'test.mp3',
+                mediaType: 'audio/mp3',
+                type: 'file',
+            },
+            undefined
+        );
+
+        expect(request).toEqual(
+            expect.objectContaining({
+                messages: [
+                    {
+                        content: [
+                            { text: 'Analyze this file.', type: 'text' },
+                            {
+                                input_audio: {
+                                    data: expect.any(String),
+                                    format: 'mp3',
+                                },
+                                type: 'input_audio',
+                            },
+                        ],
+                        role: 'user',
+                    },
+                ],
+            })
+        );
+    });
+
+    it('preserves Nova reasoning options in the serialized gateway request', async () => {
+        const request = await captureGatewayRequest(
+            {
+                data: new TextEncoder().encode('%PDF-test'),
+                filename: 'test.pdf',
+                mediaType: 'application/pdf',
+                type: 'file',
+            },
+            {
+                openrouter: {
+                    include_reasoning: true,
+                    reasoning: { effort: 'high', enabled: true },
+                },
+            }
+        );
+
+        expect(request).toEqual(
+            expect.objectContaining({
+                include_reasoning: true,
+                reasoning: {
+                    effort: 'high',
+                    enabled: true,
+                },
+            })
+        );
+    });
+});

--- a/packages/core/src/llm/services/factory.test.ts
+++ b/packages/core/src/llm/services/factory.test.ts
@@ -47,9 +47,9 @@ function buildDextoConfig(overrides: Record<string, unknown> = {}) {
 }
 
 function getLastDextoNovaBaseUrl(): string {
-    const lastCall = sdkMocks.createOpenAICompatible.mock.calls.at(-1)?.[0];
+    const lastCall = sdkMocks.createOpenRouter.mock.calls.at(-1)?.[0];
     if (!lastCall || typeof lastCall !== 'object' || !('baseURL' in lastCall)) {
-        throw new Error('createOpenAICompatible call did not capture baseURL');
+        throw new Error('createOpenRouter call did not capture baseURL');
     }
 
     const { baseURL } = lastCall;
@@ -131,7 +131,7 @@ describe('createVercelModel dexto-nova base URL resolution', () => {
         expect(getLastDextoNovaBaseUrl()).toBe('http://localhost:3001/v1');
     });
 
-    it('uses an OpenAI-compatible provider named dexto-nova with gateway headers', async () => {
+    it('uses the OpenRouter provider dialect with gateway headers', async () => {
         await createVercelModel(
             buildDextoConfig({
                 baseURL: 'http://localhost:3001/v1',
@@ -142,14 +142,14 @@ describe('createVercelModel dexto-nova base URL resolution', () => {
             }
         );
 
-        expect(sdkMocks.createOpenAICompatible).toHaveBeenCalledWith({
+        expect(sdkMocks.createOpenRouter).toHaveBeenCalledWith({
             apiKey: 'dxt_test_key',
             baseURL: 'http://localhost:3001/v1',
+            compatibility: 'strict',
             headers: {
                 'X-Dexto-Session-ID': 'session-test',
                 'X-Dexto-Source': 'web',
             },
-            name: 'dexto-nova',
         });
     });
 

--- a/packages/core/src/llm/services/factory.ts
+++ b/packages/core/src/llm/services/factory.ts
@@ -309,16 +309,17 @@ export async function createVercelModel(
                 headers[DEXTO_GATEWAY_HEADERS.CLIENT_VERSION] = process.env.DEXTO_CLI_VERSION;
             }
 
-            // Dexto Gateway exposes an OpenAI-compatible /v1/chat/completions surface.
-            // Model IDs remain gateway model IDs, usually OpenRouter-style provider/model IDs.
-            const { createOpenAICompatible } = await import('@ai-sdk/openai-compatible');
-            const provider = createOpenAICompatible({
-                name: 'dexto-nova',
+            // Dexto Gateway accepts OpenRouter's multimodal chat-completions content dialect.
+            // The generic OpenAI-compatible provider rejects non-image file parts before sending.
+            const { createOpenRouter } = await import('@openrouter/ai-sdk-provider');
+            const provider = createOpenRouter({
                 baseURL: dextoBaseURL,
+                compatibility: 'strict',
                 headers,
                 ...(apiKey?.trim() ? { apiKey } : {}),
+                ...(runtimeFetch ? { fetch: runtimeFetch } : {}),
             });
-            const chatModel = provider.chatModel(model);
+            const chatModel = provider.chat(model);
             if (!isLanguageModel(chatModel)) {
                 throw LLMError.generationFailed(
                     'Dexto gateway provider returned an invalid language model instance',


### PR DESCRIPTION
## What changed

- route the logical `dexto-nova` provider through the existing OpenRouter AI SDK adapter
- preserve Nova reasoning options under the adapter's `openrouter` transport key
- classify deterministic unsupported-functionality failures as non-retryable
- preserve structured provider stream error messages
- add behavioral serialization tests for PDF, DOCX, inline audio, and reasoning options

## Root cause

`dexto-nova` used the generic OpenAI-compatible adapter. That adapter only serializes image file parts and throws for `application/pdf` and every other non-image file before an HTTP request reaches the Dexto gateway.

The installed OpenRouter adapter matches the gateway protocol: images become `image_url`, PDF/general files become `file`, and inline audio becomes `input_audio`.

## Validation

- local Core build passed
- Core unit tests passed
- Core lint passed
- Core typecheck passed
- Hono client inference passed
- changed files pass Prettier
- linked this Core checkout into Dexto Cloud and completed browser uploads with GPT-5.6 Luna for PDF, DOCX, XLSX, TXT, and JSON
- independent architecture/correctness review found no blockers

The repository-wide OpenAPI freshness check currently reports the committed 89-route OpenAPI snapshot as stale. This change does not touch server routes or OpenAPI output, so no unrelated generated documentation is included.

## Release

- patch changeset included for `@dexto/core`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dexto Nova now supports PDF, document, and inline audio inputs through the gateway.
  * Reasoning settings are correctly preserved when using Dexto Nova.
* **Bug Fixes**
  * Improved handling of provider errors, including clearer messages for invalid requests.
  * Deterministic unsupported-functionality errors are now identified as non-retryable, avoiding unnecessary retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->