### PR TITLE
Keep remote tool media out of the model heap

### DIFF
--- a/.changeset/bright-tools-stream.md
+++ b/.changeset/bright-tools-stream.md
@@ -1,0 +1,5 @@
+---
+'@dexto/core': patch
+---
+
+Keep provider-readable tool media as remote URLs while preparing model history so large artifacts are not downloaded and expanded into the model process heap.

--- a/packages/core/src/context/utils.test.ts
+++ b/packages/core/src/context/utils.test.ts
@@ -1344,6 +1344,52 @@ describe('expandBlobReferences', () => {
         });
     });
 
+    test('should expand image blobs to provider URLs without reading base64 data', async () => {
+        const retrieve = vi.fn(async (input: { format?: string; reference: string }) => {
+            expect(input).toEqual({ format: 'url', reference: 'blob:provider-image' });
+            return {
+                data: 'https://example.test/api/artifact-exports/signed-token',
+                format: 'url' as const,
+                metadata: {
+                    createdAt: new Date(0),
+                    hash: '',
+                    id: 'provider-image',
+                    mimeType: 'image/png',
+                    originalName: 'provider-image.png',
+                    size: 14_523_378,
+                },
+            };
+        });
+        const read = vi.fn();
+        const resourceManager = {
+            getArtifactStore: () => ({ retrieve }),
+            read,
+        } as unknown as import('../resources/index.js').ResourceManager;
+
+        const result = await expandBlobReferences(
+            [
+                {
+                    type: 'image',
+                    image: '@blob:provider-image',
+                    mimeType: 'image/png',
+                },
+            ],
+            resourceManager,
+            mockLogger,
+            ['image/*']
+        );
+
+        expect(result).toEqual([
+            {
+                type: 'image',
+                image: 'https://example.test/api/artifact-exports/signed-token',
+                mimeType: 'image/png',
+            },
+        ]);
+        expect(retrieve).toHaveBeenCalledOnce();
+        expect(read).not.toHaveBeenCalled();
+    });
+
     test('should expand blob reference in file part', async () => {
         const resourceManager = createMockResourceManager({
             fff000eee111: { blob: 'resolvedfiledata', mimeType: 'application/pdf' },

--- a/packages/core/src/context/utils.ts
+++ b/packages/core/src/context/utils.ts
@@ -16,6 +16,7 @@ import { validateModelFileSupport } from '@dexto/llm';
 import type { LLMContext } from '@dexto/llm';
 import { safeStringify } from '../utils/safe-stringify.js';
 import { getFileMediaKind, getResourceKind } from './media-helpers.js';
+import type { ArtifactData } from '../storage/artifacts/types.js';
 
 // Tunable heuristics and shared constants
 const MIN_BASE64_HEURISTIC_LENGTH = 512; // Below this length, treat as regular text
@@ -316,6 +317,50 @@ async function resolveBlobReferenceToParts(
     expandMatchingMedia = true
 ): Promise<Array<TextPart | ImagePart | FilePart>> {
     try {
+        let urlArtifact: ArtifactData | null = null;
+        try {
+            urlArtifact = await resourceManager
+                .getArtifactStore()
+                .retrieve({ reference: resourceUri, format: 'url' });
+        } catch {
+            // Stores without provider-readable URLs retain the base64 resource path below.
+        }
+        const urlMimeType = urlArtifact?.metadata.mimeType;
+        const shouldPlaceholderForUrlMedia =
+            urlMimeType !== undefined &&
+            ((!expandMatchingMedia && isBinaryMediaMimeType(urlMimeType)) ||
+                (allowedMediaTypes !== undefined &&
+                    !matchesAnyMimePattern(urlMimeType, allowedMediaTypes)));
+
+        if (urlArtifact !== null && shouldPlaceholderForUrlMedia) {
+            return [
+                {
+                    type: 'text',
+                    text: generateMediaPlaceholder({
+                        mimeType: urlArtifact.metadata.mimeType,
+                        size: urlArtifact.metadata.size,
+                        ...(urlArtifact.metadata.originalName === undefined
+                            ? {}
+                            : { originalName: urlArtifact.metadata.originalName }),
+                    }),
+                },
+            ];
+        }
+
+        if (
+            urlArtifact?.format === 'url' &&
+            (urlArtifact.data.startsWith('https://') || urlArtifact.data.startsWith('http://')) &&
+            urlMimeType?.startsWith('image/')
+        ) {
+            return [
+                {
+                    type: 'image',
+                    image: urlArtifact.data,
+                    mimeType: urlMimeType,
+                },
+            ];
+        }
+
         const result = await resourceManager.read(normalizeResourceUriForRead(resourceUri));
         const mimeType = result.contents[0]?.mimeType;
         const metadata = result._meta as { size?: number; originalName?: string } | undefined;

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -514,6 +514,83 @@ describe('VercelMessageFormatter', () => {
             ]);
         });
 
+        test('should keep remote media with its turn when a parallel tool call is interrupted', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    assistantOutput: { status: 'complete' },
+                    content: [],
+                    toolCalls: [
+                        {
+                            id: 'call-media',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                        {
+                            id: 'call-interrupted',
+                            type: 'function',
+                            function: { name: 'search', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-media',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        {
+                            type: 'image',
+                            image: 'https://example.test/image.png',
+                            mimeType: 'image/png',
+                        },
+                    ],
+                },
+                {
+                    role: 'user',
+                    content: [{ type: 'text', text: 'Continue after the interrupted tool.' }],
+                },
+                {
+                    role: 'assistant',
+                    assistantOutput: { status: 'complete' },
+                    content: [{ type: 'text', text: 'Done' }],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+
+            expect(result.map((message) => message.role)).toEqual([
+                'assistant',
+                'tool',
+                'tool',
+                'user',
+                'user',
+                'assistant',
+            ]);
+            expect(result[2]).toMatchObject({
+                role: 'tool',
+                content: [
+                    {
+                        toolCallId: 'call-interrupted',
+                        isError: true,
+                    },
+                ],
+            });
+            expect(result[3]).toMatchObject({
+                role: 'user',
+                content: [{ type: 'image', mediaType: 'image/png' }],
+            });
+            expect(result[4]).toEqual({
+                role: 'user',
+                content: [{ type: 'text', text: 'Continue after the interrupted tool.' }],
+            });
+        });
+
         test('should keep tool-result URL media as text references', () => {
             const formatter = new VercelMessageFormatter(mockLogger);
             const messages: InternalMessage[] = [

--- a/packages/core/src/llm/formatters/vercel.test.ts
+++ b/packages/core/src/llm/formatters/vercel.test.ts
@@ -391,6 +391,129 @@ describe('VercelMessageFormatter', () => {
             ]);
         });
 
+        test('should send remote tool-result images as a following user message', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    assistantOutput: { status: 'complete' },
+                    content: [{ type: 'text', text: 'Reading image' }],
+                    toolCalls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-1',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        { type: 'text', text: 'Read image' },
+                        {
+                            type: 'image',
+                            image: 'https://example.test/api/artifact-exports/signed-token',
+                            mimeType: 'image/png',
+                        },
+                    ],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+
+            expect(result.slice(-2)).toEqual([
+                {
+                    role: 'tool',
+                    content: [
+                        {
+                            type: 'tool-result',
+                            toolCallId: 'call-1',
+                            toolName: 'read_media_file',
+                            output: {
+                                type: 'text',
+                                value: 'Read image\nAttached image: https://example.test/api/artifact-exports/signed-token',
+                            },
+                        },
+                    ],
+                },
+                {
+                    role: 'user',
+                    content: [
+                        {
+                            type: 'image',
+                            image: new URL(
+                                'https://example.test/api/artifact-exports/signed-token'
+                            ),
+                            mediaType: 'image/png',
+                        },
+                    ],
+                },
+            ]);
+        });
+
+        test('should keep parallel tool results together before remote media', () => {
+            const formatter = new VercelMessageFormatter(mockLogger);
+            const messages: InternalMessage[] = [
+                {
+                    role: 'assistant',
+                    assistantOutput: { status: 'complete' },
+                    content: [],
+                    toolCalls: [
+                        {
+                            id: 'call-1',
+                            type: 'function',
+                            function: { name: 'read_media_file', arguments: '{}' },
+                        },
+                        {
+                            id: 'call-2',
+                            type: 'function',
+                            function: { name: 'search', arguments: '{}' },
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-1',
+                    name: 'read_media_file',
+                    success: true,
+                    content: [
+                        {
+                            type: 'image',
+                            image: 'https://example.test/image.png',
+                            mimeType: 'image/png',
+                        },
+                    ],
+                },
+                {
+                    role: 'tool',
+                    toolCallId: 'call-2',
+                    name: 'search',
+                    success: true,
+                    content: [{ type: 'text', text: 'Search result' }],
+                },
+            ];
+
+            const result = formatter.format(
+                messages,
+                { provider: 'openai', model: 'gpt-5.4-mini' },
+                null
+            );
+
+            expect(result.map((message) => message.role)).toEqual([
+                'assistant',
+                'tool',
+                'tool',
+                'user',
+            ]);
+        });
+
         test('should keep tool-result URL media as text references', () => {
             const formatter = new VercelMessageFormatter(mockLogger);
             const messages: InternalMessage[] = [

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -206,7 +206,40 @@ export class VercelMessageFormatter {
         const pendingToolCalls = new Map<string, string>();
         let pendingRemoteToolMedia: RemoteToolMedia[] = [];
 
+        const closePendingToolTurn = () => {
+            for (const [toolCallId, toolName] of pendingToolCalls) {
+                formatted.push({
+                    role: 'tool',
+                    content: [
+                        {
+                            type: 'tool-result',
+                            toolCallId,
+                            toolName,
+                            output: {
+                                type: 'text',
+                                value: 'Error: Tool execution was interrupted (session crashed or cancelled before completion)',
+                            },
+                            isError: true,
+                        } as ToolResultPart,
+                    ],
+                });
+                this.logger.warn(
+                    `Tool call ${toolCallId} (${toolName}) had no matching tool result - added synthetic error result to prevent API errors`
+                );
+            }
+            pendingToolCalls.clear();
+
+            if (pendingRemoteToolMedia.length > 0) {
+                formatted.push({ role: 'user', content: pendingRemoteToolMedia });
+                pendingRemoteToolMedia = [];
+            }
+        };
+
         for (const msg of filteredHistory) {
+            if (msg.role !== 'tool' && pendingToolCalls.size > 0) {
+                closePendingToolTurn();
+            }
+
             switch (msg.role) {
                 case 'user':
                     // Images (and text) in user content arrays are handled natively
@@ -304,34 +337,7 @@ export class VercelMessageFormatter {
             }
         }
 
-        // Add synthetic error results for any orphaned tool calls
-        // This can happen when CLI crashes/interrupts before tool execution completes
-        if (pendingToolCalls.size > 0) {
-            for (const [toolCallId, toolName] of pendingToolCalls.entries()) {
-                // Vercel AI SDK uses tool-result content parts with output property
-                formatted.push({
-                    role: 'tool',
-                    content: [
-                        {
-                            type: 'tool-result',
-                            toolCallId: toolCallId,
-                            toolName: toolName,
-                            output: {
-                                type: 'text',
-                                value: 'Error: Tool execution was interrupted (session crashed or cancelled before completion)',
-                            },
-                            isError: true,
-                        } as ToolResultPart,
-                    ],
-                });
-                this.logger.warn(
-                    `Tool call ${toolCallId} (${toolName}) had no matching tool result - added synthetic error result to prevent API errors`
-                );
-            }
-        }
-        if (pendingRemoteToolMedia.length > 0) {
-            formatted.push({ role: 'user', content: pendingRemoteToolMedia });
-        }
+        closePendingToolTurn();
 
         return formatted;
     }

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage, AssistantContent, ToolContent, ToolResultPart } from 'ai';
+import type { ModelMessage, AssistantContent, ToolResultPart } from 'ai';
 import type { LLMContext } from '@dexto/llm';
 import type {
     InternalMessage,
@@ -14,6 +14,10 @@ import {
 } from '../../context/utils.js';
 import type { Logger } from '../../logger/v2/types.js';
 import { DextoLogComponent } from '../../logger/v2/types.js';
+
+type RemoteToolMedia =
+    | { type: 'image'; image: URL; mediaType: string }
+    | { type: 'file'; data: URL; mediaType: string; filename?: string };
 
 /**
  * Checks if a string is a URL (http:// or https://).
@@ -200,6 +204,7 @@ export class VercelMessageFormatter {
         // Track pending tool calls to detect orphans (tool calls without results)
         // Map stores toolCallId -> toolName for proper synthetic result generation
         const pendingToolCalls = new Map<string, string>();
+        let pendingRemoteToolMedia: RemoteToolMedia[] = [];
 
         for (const msg of filteredHistory) {
             switch (msg.role) {
@@ -279,9 +284,15 @@ export class VercelMessageFormatter {
                 case 'tool':
                     // Only add if we've seen the corresponding tool call
                     if (msg.toolCallId && pendingToolCalls.has(msg.toolCallId)) {
-                        formatted.push({ role: 'tool', ...this.formatToolMessage(msg) });
+                        const toolResult = this.formatToolMessage(msg);
+                        formatted.push(toolResult.message);
+                        pendingRemoteToolMedia.push(...toolResult.remoteMedia);
                         // Remove from pending since we found its result
                         pendingToolCalls.delete(msg.toolCallId);
+                        if (pendingToolCalls.size === 0 && pendingRemoteToolMedia.length > 0) {
+                            formatted.push({ role: 'user', content: pendingRemoteToolMedia });
+                            pendingRemoteToolMedia = [];
+                        }
                     } else {
                         // Orphaned tool result (result without matching call)
                         // Skip it to prevent API errors - can't send result without corresponding call
@@ -317,6 +328,9 @@ export class VercelMessageFormatter {
                     `Tool call ${toolCallId} (${toolName}) had no matching tool result - added synthetic error result to prevent API errors`
                 );
             }
+        }
+        if (pendingRemoteToolMedia.length > 0) {
+            formatted.push({ role: 'user', content: pendingRemoteToolMedia });
         }
 
         return formatted;
@@ -442,8 +456,12 @@ export class VercelMessageFormatter {
     }
 
     // Helper to format Tool result messages
-    private formatToolMessage(msg: ToolMessage): { content: ToolContent } {
+    private formatToolMessage(msg: ToolMessage): {
+        message: ModelMessage;
+        remoteMedia: RemoteToolMedia[];
+    } {
         let toolResultPart: ToolResultPart;
+        const remoteMedia: RemoteToolMedia[] = [];
         if (Array.isArray(msg.content)) {
             const content = msg.content
                 .map((part) => {
@@ -452,6 +470,13 @@ export class VercelMessageFormatter {
                     }
                     if (part.type === 'image') {
                         const data = getImageData(part, this.logger);
+                        if (/^https?:\/\//i.test(data)) {
+                            remoteMedia.push({
+                                type: 'image',
+                                image: new URL(data),
+                                mediaType: part.mimeType || 'image/jpeg',
+                            });
+                        }
                         const mediaData = normalizeToolMediaData(data);
                         if (!mediaData) {
                             return { type: 'text' as const, text: `Attached image: ${data}` };
@@ -464,6 +489,14 @@ export class VercelMessageFormatter {
                     }
                     if (part.type === 'file') {
                         const data = getFileData(part, this.logger);
+                        if (/^https?:\/\//i.test(data)) {
+                            remoteMedia.push({
+                                type: 'file',
+                                data: new URL(data),
+                                mediaType: part.mimeType,
+                                ...(part.filename === undefined ? {} : { filename: part.filename }),
+                            });
+                        }
                         const mediaData = normalizeToolMediaData(data);
                         if (!mediaData) {
                             return { type: 'text' as const, text: `Attached file: ${data}` };
@@ -517,6 +550,9 @@ export class VercelMessageFormatter {
                 },
             };
         }
-        return { content: [toolResultPart] };
+        return {
+            message: { role: 'tool', content: [toolResultPart] },
+            remoteMedia,
+        };
     }
 }

--- a/packages/core/src/llm/services/factory.test.ts
+++ b/packages/core/src/llm/services/factory.test.ts
@@ -93,6 +93,14 @@ describe('createVercelModel dexto-nova base URL resolution', () => {
         expect(getLastDextoNovaBaseUrl()).toBe('https://app.dexto.ai/v1');
     });
 
+    it('passes remote image URLs through to the Dexto gateway', async () => {
+        const model = await createVercelModel(buildDextoConfig());
+
+        expect(Reflect.get(Object(model), 'supportedUrls')).toEqual({
+            'image/*': [/^https?:\/\/.*$/],
+        });
+    });
+
     it('uses llm.baseURL when explicitly provided', async () => {
         await createVercelModel(
             buildDextoConfig({

--- a/packages/core/src/llm/services/factory.ts
+++ b/packages/core/src/llm/services/factory.ts
@@ -327,6 +327,13 @@ export async function createVercelModel(
                     model
                 );
             }
+            Object.defineProperty(chatModel, 'supportedUrls', {
+                configurable: true,
+                enumerable: true,
+                value: {
+                    'image/*': [/^https?:\/\/.*$/],
+                },
+            });
             return chatModel;
         }
         case 'vertex': {

--- a/packages/core/src/workspace/types.ts
+++ b/packages/core/src/workspace/types.ts
@@ -22,6 +22,7 @@ export interface OpenWorkspaceInput {
 
 export interface WorkspaceFiles {
     readFile(path: string): Promise<string>;
+    readFileSize?(path: string): Promise<number>;
     readText(path: string): Promise<string>;
     glob(pattern: string): Promise<string[]>;
     writeFile(path: string, content: string): Promise<void>;


### PR DESCRIPTION
## Summary

- resolve provider-readable blob artifacts to signed HTTP image URLs before falling back to base64
- preserve remote tool media as a following user media message while keeping parallel tool results contiguous
- declare native HTTP image URL support on the Dexto Nova AI SDK model so the SDK does not download and base64-expand remote images
- expose optional workspace file-size reads for hosted implementations

## Why

A production-shaped `read_media_file` run returned a 14,523,378-byte PNG. The previous model preparation path materialized the image as base64, and AI SDK could download URL media again at the next gateway boundary. In split-worker local profiling, this shape reached roughly 406 MiB in the workflow-side path and 398.82 MiB in the app gateway.

With the complete URL-preserving path, the same run completed and the app worker peaked at 103.84 MiB used heap. The durable tool message was 1,024 bytes, contained only a blob reference, and contained no PNG base64 signature.

## Validation

- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test` (3,307 passed, 25 skipped)
- `pnpm --filter @dexto/core build`
- focused context, formatter, model factory, and parallel tool-result tests
- production-build local end-to-end large-media run with GPT-5 Nano

The aggregate `scripts/quality-checks.sh` additionally passed build before stopping on an unrelated pre-existing OpenAPI snapshot mismatch in `docs/static/openapi/openapi.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserved remote images/files from tool results as URL references (no longer downloaded and embedded).
  - Inserted remote media at the correct point in the conversation, including correct ordering for parallel tool calls and interruption handling.
  - Added support for HTTP(S) `image/*` URLs on the Dexto model.
  - Extended workspace file utilities with optional `readFileSize`.

- **Bug Fixes**
  - Improved blob/URL handling to fall back to placeholders when media types are disallowed or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->