### PR TITLE
docs: move CLI docs to cli.dexto.ai

### DIFF
--- a/.changeset/cli-docs-domain.md
+++ b/.changeset/cli-docs-domain.md
@@ -1,0 +1,9 @@
+---
+"@dexto/agent-management": patch
+"dexto": patch
+"@dexto/core": patch
+"@dexto/tui": patch
+"@dexto/webui": patch
+---
+
+Route user-facing CLI and package documentation links through `cli.dexto.ai`.

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ cd dexto && pnpm install && pnpm install-cli
 ```
 
 Upgrade/uninstall and migration troubleshooting live in docs:
-- Installation guide: https://docs.dexto.ai/docs/getting-started/installation
-- CLI command reference: https://docs.dexto.ai/docs/guides/cli/overview
+- Installation guide: https://cli.dexto.ai/docs/getting-started/installation
+- CLI command reference: https://cli.dexto.ai/docs/guides/cli/overview
 
 ### Run
 
@@ -330,7 +330,7 @@ const { server } = await startHonoApiServer(agent, 3001);
 // POST /api/message, GET /api/sessions, etc.
 ```
 
-This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://docs.dexto.ai/api/rest/) for available endpoints.
+This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://cli.dexto.ai/api/rest/) for available endpoints.
 
 <details>
 <summary><strong>Advanced SDK Usage</strong></summary>
@@ -426,7 +426,7 @@ sessions:
 - **Cache**: Redis, In-Memory
 - **Database**: PostgreSQL, SQLite, In-Memory
 
-See the [Storage Configuration guide](https://docs.dexto.ai/docs/guides/configuring-dexto/storage) for details.
+See the [Storage Configuration guide](https://cli.dexto.ai/docs/guides/configuring-dexto/storage) for details.
 
 </details>
 
@@ -447,7 +447,7 @@ dexto --agent coding-agent
 
 **Available:** Coding, Podcast, Image Editor, Video (Sora), Database, GitHub, Triage (multi-agent), and more.
 
-See the full [Agent Registry](https://docs.dexto.ai/docs/guides/agent-registry).
+See the full [Agent Registry](https://cli.dexto.ai/docs/guides/agent-registry).
 
 ---
 
@@ -529,7 +529,7 @@ dexto -m llama-4-scout
 
 Switch within interactive CLI (`/model`) or Web UI without config changes.
 
-See the [Configuration Guide](https://docs.dexto.ai/docs/category/agent-configuration-guide).
+See the [Configuration Guide](https://cli.dexto.ai/docs/category/agent-configuration-guide).
 
 ---
 
@@ -626,10 +626,10 @@ Full reference: `dexto --help`
 
 ## Documentation
 
-- **[Quick Start](https://docs.dexto.ai/docs/getting-started/intro/)** – Get running in minutes
-- **[Configuration Guide](https://docs.dexto.ai/docs/category/guides/)** – Agents, LLMs, tools
-- **[SDK Reference](https://docs.dexto.ai/api/sdk/dexto-agent)** – Programmatic usage
-- **[REST API](https://docs.dexto.ai/api/rest/)** – HTTP endpoints
+- **[Quick Start](https://cli.dexto.ai/docs/getting-started/intro/)** – Get running in minutes
+- **[Configuration Guide](https://cli.dexto.ai/docs/category/guides/)** – Agents, LLMs, tools
+- **[SDK Reference](https://cli.dexto.ai/api/sdk/dexto-agent)** – Programmatic usage
+- **[REST API](https://cli.dexto.ai/api/rest/)** – HTTP endpoints
 
 ---
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -10,7 +10,7 @@ const config: Config = {
     favicon: 'img/dexto/dexto_logo_icon.svg',
 
     // Set the production url of your site here
-    url: 'https://docs.dexto.ai',
+    url: 'https://cli.dexto.ai',
     // Set the /<baseUrl>/ pathname under which your site is served
     baseUrl: '/',
 
@@ -226,7 +226,7 @@ const config: Config = {
                         },
                         {
                             label: 'llms.txt',
-                            href: 'https://docs.dexto.ai/llms.txt',
+                            href: 'https://cli.dexto.ai/llms.txt',
                         },
                     ],
                 },

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -6,80 +6,80 @@ Dexto is an AI Agent Runtime that orchestrates intelligent, stateful agents capa
 
 ### Getting Started
 
-- [Introduction](https://docs.dexto.ai/docs/getting-started/intro.md): Introduction
-- [Installation](https://docs.dexto.ai/docs/getting-started/installation.md): Installation
-- [Build Your First Agent](https://docs.dexto.ai/docs/getting-started/build-first-agent-tutorial.md): Build Your First Agent
-- [Install Your First Agent](https://docs.dexto.ai/docs/getting-started/install-first-agent-tutorial.md): Install Your First Agent
+- [Introduction](https://cli.dexto.ai/docs/getting-started/intro.md): Introduction
+- [Installation](https://cli.dexto.ai/docs/getting-started/installation.md): Installation
+- [Build Your First Agent](https://cli.dexto.ai/docs/getting-started/build-first-agent-tutorial.md): Build Your First Agent
+- [Install Your First Agent](https://cli.dexto.ai/docs/getting-started/install-first-agent-tutorial.md): Install Your First Agent
 
 ### Guides
 
-- [CLI Guide](https://docs.dexto.ai/docs/guides/cli.md): CLI Guide
-- [agent.yml – Annotated Example](https://docs.dexto.ai/docs/guides/configuring-dexto/agent-yml.md): agent.yml – Annotated Example
-- [Agent Card Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/agentCard.md): Agent Card Configuration
-- [Runtime / Dynamic Configuration Changes](https://docs.dexto.ai/docs/guides/configuring-dexto/dynamic-changes.md): Runtime / Dynamic Configuration Changes
-- [Configuration Reference](https://docs.dexto.ai/docs/guides/configuring-dexto/llm/configuration.md): Configuration Reference
-- [LLM Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/llm/index.md): LLM Configuration
-- [Supported Providers](https://docs.dexto.ai/docs/guides/configuring-dexto/llm/providers.md): Supported Providers
-- [MCP Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/mcp.md): MCP Configuration
-- [Configuring Dexto](https://docs.dexto.ai/docs/guides/configuring-dexto/overview.md): Configuring Dexto
-- [Sessions Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/sessions.md): Sessions Configuration
-- [Storage Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/storage.md): Storage Configuration
-- [System Prompt Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/systemPrompt.md): System Prompt Configuration
-- [Permissions Configuration](https://docs.dexto.ai/docs/guides/configuring-dexto/permissions.md): Permissions Configuration
-- [Deployment Guide](https://docs.dexto.ai/docs/guides/deployment.md): Deployment Guide
-- [Dexto as an MCP Server](https://docs.dexto.ai/docs/guides/dexto-as-mcp-server.md): Dexto Agent as an MCP Server
-- [Using Dexto Agents in Cursor](https://docs.dexto.ai/docs/guides/dexto-in-cursor.md): Using Dexto Agents in Cursor
-- [Using Dexto CLI to group MCP servers together](https://docs.dexto.ai/docs/guides/dexto-group-mcp-servers.md): Using Dexto CLI to group MCP servers together
-- [Dexto SDK Guide](https://docs.dexto.ai/docs/guides/dexto-sdk.md): Dexto SDK Guide
-- [MCP Manager](https://docs.dexto.ai/docs/guides/mcp-manager.md): MCP Manager
-- [Web UI](https://docs.dexto.ai/docs/guides/web-ui.md): Web playground
+- [CLI Guide](https://cli.dexto.ai/docs/guides/cli.md): CLI Guide
+- [agent.yml – Annotated Example](https://cli.dexto.ai/docs/guides/configuring-dexto/agent-yml.md): agent.yml – Annotated Example
+- [Agent Card Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/agentCard.md): Agent Card Configuration
+- [Runtime / Dynamic Configuration Changes](https://cli.dexto.ai/docs/guides/configuring-dexto/dynamic-changes.md): Runtime / Dynamic Configuration Changes
+- [Configuration Reference](https://cli.dexto.ai/docs/guides/configuring-dexto/llm/configuration.md): Configuration Reference
+- [LLM Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/llm/index.md): LLM Configuration
+- [Supported Providers](https://cli.dexto.ai/docs/guides/configuring-dexto/llm/providers.md): Supported Providers
+- [MCP Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/mcp.md): MCP Configuration
+- [Configuring Dexto](https://cli.dexto.ai/docs/guides/configuring-dexto/overview.md): Configuring Dexto
+- [Sessions Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/sessions.md): Sessions Configuration
+- [Storage Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/storage.md): Storage Configuration
+- [System Prompt Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/systemPrompt.md): System Prompt Configuration
+- [Permissions Configuration](https://cli.dexto.ai/docs/guides/configuring-dexto/permissions.md): Permissions Configuration
+- [Deployment Guide](https://cli.dexto.ai/docs/guides/deployment.md): Deployment Guide
+- [Dexto as an MCP Server](https://cli.dexto.ai/docs/guides/dexto-as-mcp-server.md): Dexto Agent as an MCP Server
+- [Using Dexto Agents in Cursor](https://cli.dexto.ai/docs/guides/dexto-in-cursor.md): Using Dexto Agents in Cursor
+- [Using Dexto CLI to group MCP servers together](https://cli.dexto.ai/docs/guides/dexto-group-mcp-servers.md): Using Dexto CLI to group MCP servers together
+- [Dexto SDK Guide](https://cli.dexto.ai/docs/guides/dexto-sdk.md): Dexto SDK Guide
+- [MCP Manager](https://cli.dexto.ai/docs/guides/mcp-manager.md): MCP Manager
+- [Web UI](https://cli.dexto.ai/docs/guides/web-ui.md): Web playground
 
 ### MCP
 
-- [Configure MCP Connections](https://docs.dexto.ai/docs/mcp/connecting-servers.md): Configure MCP Connections
-- [Dexto as an MCP Server](https://docs.dexto.ai/docs/mcp/dexto-as-mcp-server.md): Expose Dexto as an MCP Server
-- [Aggregate Multiple MCP Servers](https://docs.dexto.ai/docs/mcp/grouping-servers.md): Aggregate Multiple MCP Servers
-- [MCP Manager](https://docs.dexto.ai/docs/mcp/mcp-manager.md): MCP Manager
-- [MCP Overview](https://docs.dexto.ai/docs/mcp/overview.md): MCP Overview
+- [Configure MCP Connections](https://cli.dexto.ai/docs/mcp/connecting-servers.md): Configure MCP Connections
+- [Dexto as an MCP Server](https://cli.dexto.ai/docs/mcp/dexto-as-mcp-server.md): Expose Dexto as an MCP Server
+- [Aggregate Multiple MCP Servers](https://cli.dexto.ai/docs/mcp/grouping-servers.md): Aggregate Multiple MCP Servers
+- [MCP Manager](https://cli.dexto.ai/docs/mcp/mcp-manager.md): MCP Manager
+- [MCP Overview](https://cli.dexto.ai/docs/mcp/overview.md): MCP Overview
 
 ### Tutorials
 
-- [Advanced Patterns and Best Practices](https://docs.dexto.ai/docs/tutorials/advanced-patterns.md): Advanced Patterns and Best Practices
-- [React Chat App using Dexto](https://docs.dexto.ai/docs/tutorials/backend-server.md): React Chat App using Dexto
-- [Customer Support Triage System](https://docs.dexto.ai/docs/tutorials/building-triage-system.md): Customer Support Triage System
-- [Database Agent Tutorial](https://docs.dexto.ai/docs/tutorials/database-agent.md): Database Agent Tutorial
-- [Image Editor Agent](https://docs.dexto.ai/docs/tutorials/image-editor-agent.md): Image Editor Agent
-- [Building Applications](https://docs.dexto.ai/docs/tutorials/index.md): Building Applications
-- [Integrating Existing Agents: Dexto + LangChain](https://docs.dexto.ai/docs/tutorials/langchain-integration.md): Integrating Existing Agents: Dexto + LangChain
-- [Building Multi-Agent Systems](https://docs.dexto.ai/docs/tutorials/multi-agent-systems.md): Building Multi-Agent Systems
-- [Music Creator Agent](https://docs.dexto.ai/docs/tutorials/music-agent.md): Music Creator Agent
-- [Product Name Scout Agent](https://docs.dexto.ai/docs/tutorials/product-name-scout-agent.md): Product Name Scout Agent
-- [Talk2PDF Agent](https://docs.dexto.ai/docs/tutorials/talk2pdf-agent.md): Talk2PDF Agent
+- [Advanced Patterns and Best Practices](https://cli.dexto.ai/docs/tutorials/advanced-patterns.md): Advanced Patterns and Best Practices
+- [React Chat App using Dexto](https://cli.dexto.ai/docs/tutorials/backend-server.md): React Chat App using Dexto
+- [Customer Support Triage System](https://cli.dexto.ai/docs/tutorials/building-triage-system.md): Customer Support Triage System
+- [Database Agent Tutorial](https://cli.dexto.ai/docs/tutorials/database-agent.md): Database Agent Tutorial
+- [Image Editor Agent](https://cli.dexto.ai/docs/tutorials/image-editor-agent.md): Image Editor Agent
+- [Building Applications](https://cli.dexto.ai/docs/tutorials/index.md): Building Applications
+- [Integrating Existing Agents: Dexto + LangChain](https://cli.dexto.ai/docs/tutorials/langchain-integration.md): Integrating Existing Agents: Dexto + LangChain
+- [Building Multi-Agent Systems](https://cli.dexto.ai/docs/tutorials/multi-agent-systems.md): Building Multi-Agent Systems
+- [Music Creator Agent](https://cli.dexto.ai/docs/tutorials/music-agent.md): Music Creator Agent
+- [Product Name Scout Agent](https://cli.dexto.ai/docs/tutorials/product-name-scout-agent.md): Product Name Scout Agent
+- [Talk2PDF Agent](https://cli.dexto.ai/docs/tutorials/talk2pdf-agent.md): Talk2PDF Agent
 
 ### Examples & Demos
 
-- [Amazon shopping assistant](https://docs.dexto.ai/docs/examples-demos/amazon-shopping.md): Amazon shopping assistant
-- [Email summaries in slack](https://docs.dexto.ai/docs/examples-demos/email-slack.md): Email summaries in slack
-- [Design a website with dexto](https://docs.dexto.ai/docs/examples-demos/website-designer.md): Design a website with dexto
+- [Amazon shopping assistant](https://cli.dexto.ai/docs/examples-demos/amazon-shopping.md): Amazon shopping assistant
+- [Email summaries in slack](https://cli.dexto.ai/docs/examples-demos/email-slack.md): Email summaries in slack
+- [Design a website with dexto](https://cli.dexto.ai/docs/examples-demos/website-designer.md): Design a website with dexto
 
 ### Concepts
 
-- [AI Agents vs. LLM Workflows](https://docs.dexto.ai/docs/concepts/agents-vs-workflows.md): AI Agents vs. LLM Workflows
-- [How do AI Agents work?](https://docs.dexto.ai/docs/concepts/how-do-ai-agents-work.md): How do AI Agents work?
-- [What is MCP (Model Context Protocol)?](https://docs.dexto.ai/docs/concepts/mcp.md): What is MCP (Model Context Protocol)?
-- [Tools](https://docs.dexto.ai/docs/concepts/tools.md): Tools
-- [What is an AI Agent?](https://docs.dexto.ai/docs/concepts/what-is-an-ai-agent.md): What is an AI Agent?
+- [AI Agents vs. LLM Workflows](https://cli.dexto.ai/docs/concepts/agents-vs-workflows.md): AI Agents vs. LLM Workflows
+- [How do AI Agents work?](https://cli.dexto.ai/docs/concepts/how-do-ai-agents-work.md): How do AI Agents work?
+- [What is MCP (Model Context Protocol)?](https://cli.dexto.ai/docs/concepts/mcp.md): What is MCP (Model Context Protocol)?
+- [Tools](https://cli.dexto.ai/docs/concepts/tools.md): Tools
+- [What is an AI Agent?](https://cli.dexto.ai/docs/concepts/what-is-an-ai-agent.md): What is an AI Agent?
 
 ### Architecture
 
-- [Overview](https://docs.dexto.ai/docs/architecture/overview.md): Overview
+- [Overview](https://cli.dexto.ai/docs/architecture/overview.md): Overview
 
 ### API Reference
 
-- [Getting Started](https://docs.dexto.ai/api/): API Getting Started Guide
-- [REST API Reference](https://docs.dexto.ai/api/rest/): Complete REST API documentation (OpenAPI)
-- [SDK Events](https://docs.dexto.ai/api/sdk/events): SSE streaming events
-- [DextoAgent SDK](https://docs.dexto.ai/api/sdk/dexto-agent): DextoAgent API
-- [MCPManager SDK](https://docs.dexto.ai/api/sdk/mcp-manager): MCPManager
-- [Events Reference](https://docs.dexto.ai/api/sdk/events): Events Reference
-- [SDK Types](https://docs.dexto.ai/api/sdk/types): SDK Types for TypeScript
+- [Getting Started](https://cli.dexto.ai/api/): API Getting Started Guide
+- [REST API Reference](https://cli.dexto.ai/api/rest/): Complete REST API documentation (OpenAPI)
+- [SDK Events](https://cli.dexto.ai/api/sdk/events): SSE streaming events
+- [DextoAgent SDK](https://cli.dexto.ai/api/sdk/dexto-agent): DextoAgent API
+- [MCPManager SDK](https://cli.dexto.ai/api/sdk/mcp-manager): MCPManager
+- [Events Reference](https://cli.dexto.ai/api/sdk/events): Events Reference
+- [SDK Types](https://cli.dexto.ai/api/sdk/types): SDK Types for TypeScript

--- a/docs/static/robots.txt
+++ b/docs/static/robots.txt
@@ -13,4 +13,4 @@ Disallow: /*.md$
 Disallow: /*.mdx$
 
 # Sitemap location
-Sitemap: https://docs.dexto.ai/sitemap.xml
+Sitemap: https://cli.dexto.ai/sitemap.xml

--- a/packages/agent-management/src/AgentFactory.ts
+++ b/packages/agent-management/src/AgentFactory.ts
@@ -21,7 +21,7 @@
  * and need discovery/selection capabilities.
  *
  * @see AgentManager for registry-based agent management
- * @see https://docs.dexto.ai/api/sdk/agent-factory for full documentation
+ * @see https://cli.dexto.ai/api/sdk/agent-factory for full documentation
  */
 
 import { promises as fs } from 'fs';

--- a/packages/agent-management/src/AgentManager.ts
+++ b/packages/agent-management/src/AgentManager.ts
@@ -13,7 +13,7 @@
  * programmatically without a registry file.
  *
  * @see AgentFactory.createAgent() for inline config creation
- * @see https://docs.dexto.ai/api/sdk/agent-manager for full documentation
+ * @see https://cli.dexto.ai/api/sdk/agent-manager for full documentation
  */
 
 import { promises as fs } from 'fs';

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -110,8 +110,8 @@ cd dexto && pnpm install && pnpm install-cli
 ```
 
 Upgrade/uninstall and migration troubleshooting live in docs:
-- Installation guide: https://docs.dexto.ai/docs/getting-started/installation
-- CLI command reference: https://docs.dexto.ai/docs/guides/cli/overview
+- Installation guide: https://cli.dexto.ai/docs/getting-started/installation
+- CLI command reference: https://cli.dexto.ai/docs/guides/cli/overview
 
 ### Run
 
@@ -330,7 +330,7 @@ const { server } = await startHonoApiServer(agent, 3001);
 // POST /api/message, GET /api/sessions, etc.
 ```
 
-This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://docs.dexto.ai/api/rest/) for available endpoints.
+This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://cli.dexto.ai/api/rest/) for available endpoints.
 
 <details>
 <summary><strong>Advanced SDK Usage</strong></summary>
@@ -426,7 +426,7 @@ sessions:
 - **Cache**: Redis, In-Memory
 - **Database**: PostgreSQL, SQLite, In-Memory
 
-See the [Storage Configuration guide](https://docs.dexto.ai/docs/guides/configuring-dexto/storage) for details.
+See the [Storage Configuration guide](https://cli.dexto.ai/docs/guides/configuring-dexto/storage) for details.
 
 </details>
 
@@ -447,7 +447,7 @@ dexto --agent coding-agent
 
 **Available:** Coding, Podcast, Image Editor, Video (Sora), Database, GitHub, Triage (multi-agent), and more.
 
-See the full [Agent Registry](https://docs.dexto.ai/docs/guides/agent-registry).
+See the full [Agent Registry](https://cli.dexto.ai/docs/guides/agent-registry).
 
 ---
 
@@ -529,7 +529,7 @@ dexto -m llama-4-scout
 
 Switch within interactive CLI (`/model`) or Web UI without config changes.
 
-See the [Configuration Guide](https://docs.dexto.ai/docs/category/agent-configuration-guide).
+See the [Configuration Guide](https://cli.dexto.ai/docs/category/agent-configuration-guide).
 
 ---
 
@@ -626,10 +626,10 @@ Full reference: `dexto --help`
 
 ## Documentation
 
-- **[Quick Start](https://docs.dexto.ai/docs/getting-started/intro/)** – Get running in minutes
-- **[Configuration Guide](https://docs.dexto.ai/docs/category/guides/)** – Agents, LLMs, tools
-- **[SDK Reference](https://docs.dexto.ai/api/sdk/dexto-agent)** – Programmatic usage
-- **[REST API](https://docs.dexto.ai/api/rest/)** – HTTP endpoints
+- **[Quick Start](https://cli.dexto.ai/docs/getting-started/intro/)** – Get running in minutes
+- **[Configuration Guide](https://cli.dexto.ai/docs/category/guides/)** – Agents, LLMs, tools
+- **[SDK Reference](https://cli.dexto.ai/api/sdk/dexto-agent)** – Programmatic usage
+- **[REST API](https://cli.dexto.ai/api/rest/)** – HTTP endpoints
 
 ---
 

--- a/packages/cli/src/cli/commands/create-app.ts
+++ b/packages/cli/src/cli/commands/create-app.ts
@@ -80,7 +80,7 @@ export async function createDextoProject(
         console.log(`\n${chalk.cyan('Next steps:')}`);
         console.log(`  ${chalk.gray('$')} cd ${projectName}`);
         console.log(`  ${chalk.gray('$')} pnpm start`);
-        console.log(`\n${chalk.gray('Learn more:')} https://docs.dexto.ai\n`);
+        console.log(`\n${chalk.gray('Learn more:')} https://cli.dexto.ai\n`);
 
         return projectPath;
     } catch (error) {

--- a/packages/cli/src/cli/utils/template-engine.ts
+++ b/packages/cli/src/cli/utils/template-engine.ts
@@ -857,7 +857,7 @@ database and blob store (e.g. SQLite + local blobs).
 
 ## Learn More
 
-- [Dexto Documentation](https://docs.dexto.ai)
-- [Agent Configuration Guide](https://docs.dexto.ai/docs/guides/configuration)
+- [Dexto Documentation](https://cli.dexto.ai)
+- [Agent Configuration Guide](https://cli.dexto.ai/docs/guides/configuration)
 `;
 }

--- a/packages/cli/src/index-main.ts
+++ b/packages/cli/src/index-main.ts
@@ -553,7 +553,7 @@ program
             'Advanced Modes:\n' +
             '  dexto --mode server      Run as API server\n' +
             '  dexto --mode mcp         Run as MCP server\n\n' +
-            'Docs: https://docs.dexto.ai'
+            'Docs: https://cli.dexto.ai'
     )
     .action(
         withAnalytics(

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -74,7 +74,7 @@ for await (const event of await agent.stream('Write a story', session.id)) {
 await agent.stop();
 ```
 
-See the [Dexto Agent SDK docs](https://docs.dexto.ai/docs/guides/dexto-sdk) for multimodal content, streaming, MCP tools, and advanced features.
+See the [Dexto Agent SDK docs](https://cli.dexto.ai/docs/guides/dexto-sdk) for multimodal content, streaming, MCP tools, and advanced features.
 
 ---
 
@@ -109,10 +109,10 @@ console.log('Dexto server running at http://localhost:3001');
 // Server provides REST API and SSE streaming endpoints
 // POST /api/message - Send messages
 // GET /api/sessions - List sessions
-// See docs.dexto.ai/api/rest/ for all endpoints
+// See cli.dexto.ai/api/rest/ for all endpoints
 ```
 
-This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://docs.dexto.ai/api/rest/) for available endpoints.
+This starts an HTTP server with full REST and SSE APIs, enabling integration with web frontends, webhooks, and other services. See the [REST API Documentation](https://cli.dexto.ai/api/rest/) for available endpoints.
 
 ### Session Management
 
@@ -279,15 +279,15 @@ logger:
 CLI automatically adds per-agent file transport at `~/.dexto/logs/<agent-id>.log`. See architecture in `src/logger/v2/`.
 
 See the DextoAgent API reference for all methods:
-https://docs.dexto.ai/api/dexto-agent/
+https://cli.dexto.ai/api/dexto-agent/
 
 ---
 
 ## Links
 
-- Docs: https://docs.dexto.ai/
-- Configuration Guide: https://docs.dexto.ai/docs/category/guides/
-- API Reference: https://docs.dexto.ai/api/
+- Docs: https://cli.dexto.ai/
+- Configuration Guide: https://cli.dexto.ai/docs/category/guides/
+- API Reference: https://cli.dexto.ai/api/
 
 ## License
 

--- a/packages/tui/src/components/overlays/custom-model-wizard/LocalModelWizard.tsx
+++ b/packages/tui/src/components/overlays/custom-model-wizard/LocalModelWizard.tsx
@@ -985,7 +985,7 @@ const LocalModelWizard = forwardRef<LocalModelWizardHandle, LocalModelWizardProp
                 <SetupInfoBanner
                     title="Local Models"
                     description="Select a model to download, or use a custom GGUF file. Models run completely on your machine - free, private, and offline."
-                    docsUrl="https://docs.dexto.ai/docs/guides/supported-llm-providers#local-models"
+                    docsUrl="https://cli.dexto.ai/docs/guides/supported-llm-providers#local-models"
                 />
 
                 {/* Model list */}

--- a/packages/tui/src/components/overlays/custom-model-wizard/provider-config.ts
+++ b/packages/tui/src/components/overlays/custom-model-wizard/provider-config.ts
@@ -321,7 +321,7 @@ export const PROVIDER_CONFIGS: Record<CustomModelProvider, ProviderConfig> = {
             title: 'AWS Bedrock Setup',
             description:
                 'Bedrock uses AWS credentials from your environment. Ensure AWS_REGION and either AWS_BEARER_TOKEN_BEDROCK or IAM credentials are set.',
-            docsUrl: 'https://docs.dexto.ai/docs/guides/supported-llm-providers#amazon-bedrock',
+            docsUrl: 'https://cli.dexto.ai/docs/guides/supported-llm-providers#amazon-bedrock',
         },
     },
 
@@ -369,7 +369,7 @@ export const PROVIDER_CONFIGS: Record<CustomModelProvider, ProviderConfig> = {
             title: 'Ollama Setup',
             description:
                 'Add custom Ollama models by name. Ensure Ollama is running (default: http://localhost:11434). Pull models with: ollama pull <model>',
-            docsUrl: 'https://docs.dexto.ai/docs/guides/supported-llm-providers#ollama',
+            docsUrl: 'https://cli.dexto.ai/docs/guides/supported-llm-providers#ollama',
         },
     },
 
@@ -440,7 +440,7 @@ export const PROVIDER_CONFIGS: Record<CustomModelProvider, ProviderConfig> = {
             title: 'Local Models Setup',
             description:
                 'Add custom GGUF models by ID (from registry) or absolute file path. Ensure node-llama-cpp is installed and GPU acceleration is configured.',
-            docsUrl: 'https://docs.dexto.ai/docs/guides/supported-llm-providers#local-models',
+            docsUrl: 'https://cli.dexto.ai/docs/guides/supported-llm-providers#local-models',
         },
     },
 
@@ -478,7 +478,7 @@ export const PROVIDER_CONFIGS: Record<CustomModelProvider, ProviderConfig> = {
             title: 'Google Vertex AI Setup',
             description:
                 'Vertex AI uses Google Cloud Application Default Credentials (ADC). Set GOOGLE_VERTEX_PROJECT and optionally GOOGLE_VERTEX_LOCATION. Run: gcloud auth application-default login',
-            docsUrl: 'https://docs.dexto.ai/docs/guides/supported-llm-providers#google-vertex-ai',
+            docsUrl: 'https://cli.dexto.ai/docs/guides/supported-llm-providers#google-vertex-ai',
         },
     },
 

--- a/packages/tui/src/interactive-commands/documentation-commands.ts
+++ b/packages/tui/src/interactive-commands/documentation-commands.ts
@@ -27,7 +27,7 @@ export const documentationCommands: CommandDefinition[] = [
             _agent: TuiAgentBackend,
             _ctx: CommandContext
         ): Promise<boolean | string> => {
-            const docsUrl = 'https://docs.dexto.ai/docs/category/getting-started';
+            const docsUrl = 'https://cli.dexto.ai/docs/category/getting-started';
             try {
                 const { spawn } = await import('child_process');
 

--- a/packages/webui/components/AgentEditor/CustomizePanel.tsx
+++ b/packages/webui/components/AgentEditor/CustomizePanel.tsx
@@ -500,7 +500,7 @@ export default function CustomizePanel({
                         <div className="flex items-center gap-2">
                             <h2 className="text-lg font-semibold">Customize Agent</h2>
                             <a
-                                href="https://docs.dexto.ai/docs/guides/configuring-dexto/overview"
+                                href="https://cli.dexto.ai/docs/guides/configuring-dexto/overview"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 className="text-xs text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1"

--- a/packages/webui/components/ModelPicker/CustomModelForms.tsx
+++ b/packages/webui/components/ModelPicker/CustomModelForms.tsx
@@ -19,7 +19,7 @@ import { useProviderApiKey, type LLMProvider } from '../hooks/useLLM';
 import { useValidateLocalFile } from '../hooks/useModels';
 import { useDextoAuth } from '../hooks/useDextoAuth';
 
-const BEDROCK_DOCS_URL = 'https://docs.dexto.ai/docs/guides/supported-llm-providers#amazon-bedrock';
+const BEDROCK_DOCS_URL = 'https://cli.dexto.ai/docs/guides/supported-llm-providers#amazon-bedrock';
 
 // 'vertex' is TODO - see comment in PROVIDER_OPTIONS.
 export type CustomModelProvider =


### PR DESCRIPTION
## Human notes

<!-- human:dexto-notes -->

_Add context, reviewer guidance, or verification results here. Agents preserve this section._

<!-- agent:dexto-managed:start -->

> [!NOTE]
> The generated sections below this notice are written and maintained by agents and may be regenerated when the PR changes. Add human-authored content to **Human notes** above.

<!-- agent:dexto-pr-head:19ce24917fd5280e600d26415926a90cb0d9fb58 -->

## Intent

Documentation migration: move the open-source Dexto documentation’s canonical public hostname to `cli.dexto.ai`.

## Why

`docs.dexto.ai` is being reserved for the Dexto Cloud documentation site. The open-source repository’s canonical URL, sitemap, LLM links, and README links must follow the new CLI documentation hostname so generated metadata and user-facing links remain consistent after the Vercel domain cutover.

## Summary

- Updated Docusaurus’s production URL and footer `llms.txt` link.
- Updated the sitemap hostname and every open-source `llms.txt` absolute link.
- Updated the repository README’s documentation links.
- Updated the generated CLI package README through the repository’s README sync workflow.
- Audited and updated all tracked user-facing runtime links in CLI, TUI, WebUI, and package README content.
- Added a patch changeset for the affected runtime packages.
- No Vercel project, DNS, or Cloudflare configuration was changed in this PR.

## Change groups

1. **Canonical and public documentation links** — Changed all open-source documentation references from `docs.dexto.ai` to `cli.dexto.ai` across Docusaurus configuration, static metadata, README content, and user-facing runtime links in CLI, TUI, WebUI, and package code.

## Validation

- `pnpm -C docs build` — passed; Docusaurus reported two pre-existing broken-anchor warnings in the examples pages.
- `pnpm run test` — passed: 256 test files, 3,320 tests passed; 1 file and 25 tests skipped.
- `pnpm run lint -- --max-warnings=0` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run hono:check-inference` — passed.
- `pnpm run build` — passed as the first step of the repository quality gate.
- `pnpm run format:check` — passed.
- `git diff --check` — passed.
- `git grep -n -F 'docs.dexto.ai' -- .` — no matches.
- `bash scripts/quality-checks.sh all` — stopped at the existing `sync-openapi-docs:check` failure; the same OpenAPI drift reproduces on clean `main` and is unrelated to this PR.

## Risk and rollout

This PR only updates generated/static links, runtime help links, and canonical metadata. Before merging or immediately after, add `cli.dexto.ai` to the existing Vercel docs project, verify its production deployment, and only then move `docs.dexto.ai` to the Cloudflare docs Worker.

## Manual verification steps

| Scenario | Preconditions | Steps | Expected result |
| -------- | ------------- | ----- | --------------- |
| Vercel CLI docs hostname | The Vercel docs project is accessible | Add `cli.dexto.ai` as a production domain, deploy `main`, and open the hostname | The Docusaurus site loads with CLI docs content |
| Canonical metadata and static files | `cli.dexto.ai` is serving the new deployment | Check page source, `/robots.txt`, `/llms.txt`, and `/sitemap.xml` | Canonical URLs, sitemap, and LLM links use `https://cli.dexto.ai` |
| Cloud/CLI host separation | Cloudflare custom domain cutover is complete | Open `https://docs.dexto.ai` and `https://cli.dexto.ai` | Cloud docs are served from `docs.dexto.ai`; open-source docs are served from `cli.dexto.ai` |

<!-- agent:dexto-managed:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation, installation, API, SDK, storage, configuration, and quick-start links to the new documentation site.
  * Updated sitemap and site navigation references to ensure links direct visitors to the current documentation location.
  * Refreshed documentation references in both the main project and CLI-specific guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
