### PR TITLE
feat: inject active model registry into Dexto hosts

### DIFF
--- a/.changeset/quiet-model-registries.md
+++ b/.changeset/quiet-model-registries.md
@@ -1,0 +1,7 @@
+---
+'@dexto/llm': minor
+'@dexto/core': minor
+'@dexto/agent-config': minor
+---
+
+Add injectable model-registry support so hosts can validate and execute against an actively managed registry while preserving the bundled registry as the default.

--- a/.changeset/quiet-model-registries.md
+++ b/.changeset/quiet-model-registries.md
@@ -1,7 +1,7 @@
 ---
-'@dexto/llm': minor
-'@dexto/core': minor
-'@dexto/agent-config': minor
+'@dexto/llm': patch
+'@dexto/core': patch
+'@dexto/agent-config': patch
 ---
 
 Add injectable model-registry support so hosts can validate and execute against an actively managed registry while preserving the bundled registry as the default.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -9791,7 +9791,8 @@
                         "additionalProperties": false,
                         "description": "Reasoning configuration using model/provider-native variants (tuning only; display is controlled separately)."
                       }
-                    }
+                    },
+                    "additionalProperties": false
                   },
                   {
                     "type": "object",

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/agent-config/src/resolver/to-dexto-agent-options.ts
+++ b/packages/agent-config/src/resolver/to-dexto-agent-options.ts
@@ -11,7 +11,7 @@ export interface ToDextoAgentOptionsInput<
     image?: DextoImage<THostContext> | undefined;
     hostContext?: THostContext | undefined;
     overrides?: InitializeServicesOptions | undefined;
-    runtimeOverrides?: Pick<DextoAgentOptions, 'usageScopeId'> | undefined;
+    runtimeOverrides?: Partial<Pick<DextoAgentOptions, 'usageScopeId' | 'llmRegistry'>> | undefined;
 }
 
 export function toDextoAgentOptions<THostContext extends DextoHostContext = DextoHostContext>(

--- a/packages/agent-config/src/schemas/agent-config.test.ts
+++ b/packages/agent-config/src/schemas/agent-config.test.ts
@@ -1,7 +1,7 @@
 import { parse as parseYaml } from 'yaml';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
-import { AgentConfigSchema, type AgentConfig } from './agent-config.js';
+import { AgentConfigSchema, createAgentConfigSchema, type AgentConfig } from './agent-config.js';
 
 describe('AgentConfigSchema', () => {
     afterEach(() => {
@@ -18,6 +18,27 @@ describe('AgentConfigSchema', () => {
     };
 
     describe('Basic Structure Validation', () => {
+        it('validates against a host-injected model registry', () => {
+            const registry = {
+                hasAllRegistryModelsSupport: () => false,
+                supportsBaseURL: () => false,
+                acceptsAnyModel: () => false,
+                supportsCustomModels: () => false,
+                getSupportedModels: () => ['host-model'],
+                isValidProviderModel: (_provider: string, model: string) => model === 'host-model',
+                getMaxInputTokensForModel: () => 128_000,
+                isReasoningCapableModel: () => false,
+            } as unknown as Parameters<typeof createAgentConfigSchema>[0];
+            const schema = createAgentConfigSchema(registry);
+
+            expect(
+                schema.safeParse({
+                    ...validAgentConfig,
+                    llm: { ...validAgentConfig.llm, model: 'host-model' },
+                }).success
+            ).toBe(true);
+        });
+
         it('should accept valid minimal config', () => {
             const result = AgentConfigSchema.parse(validAgentConfig);
 

--- a/packages/agent-config/src/schemas/agent-config.ts
+++ b/packages/agent-config/src/schemas/agent-config.ts
@@ -1,7 +1,6 @@
 import {
     AgentCardSchema,
     ElicitationConfigSchema,
-    LLMConfigSchema,
     LoggerConfigSchema,
     MemoriesConfigSchema,
     ServersConfigSchema as McpServersConfigSchema,
@@ -12,10 +11,13 @@ import {
     PermissionsConfigSchema,
     ResourcesConfigSchema,
 } from '@dexto/core/config';
+import { createLLMConfigSchema } from '@dexto/core';
 import { StorageSchema } from '@dexto/storage/schemas';
 import { z } from 'zod';
 import { HooksConfigSchema } from './hooks.js';
 import { CompactionConfigSchema, DEFAULT_COMPACTION_CONFIG } from './compaction.js';
+
+type AgentConfigModelRegistry = Parameters<typeof createLLMConfigSchema>[0];
 
 // ========================================
 // DI SURFACE CONFIG (validated in resolver)
@@ -51,7 +53,7 @@ export type ToolFactoryEntry = z.output<typeof ToolFactoryEntrySchema>;
 /**
  * Creates the agent config schema.
  */
-export function createAgentConfigSchema() {
+export function createAgentConfigSchema(registry?: AgentConfigModelRegistry) {
     return z
         .object({
             // ========================================
@@ -61,7 +63,7 @@ export function createAgentConfigSchema() {
                 'System prompt: string shorthand or structured config'
             ),
 
-            llm: LLMConfigSchema.describe('Core LLM configuration for the agent'),
+            llm: createLLMConfigSchema(registry).describe('Core LLM configuration for the agent'),
 
             // ========================================
             // OPTIONAL FEATURES (undefined if not provided)

--- a/packages/agent-management/src/AgentFactory.ts
+++ b/packages/agent-management/src/AgentFactory.ts
@@ -26,7 +26,7 @@
 
 import { promises as fs } from 'fs';
 import type { AgentConfig, DextoHostContext } from '@dexto/agent-config';
-import type { DextoAgent, DextoAgentConfigInput } from '@dexto/core';
+import type { DextoAgent, DextoAgentOptions } from '@dexto/core';
 import { getDextoGlobalPath } from './utils/path.js';
 import { deriveDisplayName } from './registry/types.js';
 import { getAgentRegistry, loadBundledRegistryAgents } from './registry/registry.js';
@@ -55,7 +55,7 @@ export interface CreateAgentOptions {
     /** Optional host-owned resolution context for hosted runtimes */
     hostContext?: DextoHostContext | undefined;
     /** Explicit runtime overrides applied outside the validated agent config */
-    runtimeOverrides?: Pick<DextoAgentConfigInput, 'usageScopeId'> | undefined;
+    runtimeOverrides?: Pick<DextoAgentOptions, 'usageScopeId' | 'llmRegistry'> | undefined;
 }
 
 /**

--- a/packages/agent-management/src/agent-creation.test.ts
+++ b/packages/agent-management/src/agent-creation.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AgentConfig } from '@dexto/agent-config';
+import type { ModelRegistry } from '@dexto/llm';
 
 const loadImageMock = vi.fn(async (_specifier: string) => ({ defaults: {} }));
 const resolveServicesFromConfigMock = vi.fn(async () => ({}));
 const enrichAgentConfigMock = vi.fn((config: unknown) => config);
+const createAgentConfigSchemaMock = vi.fn(() => ({ parse: (config: unknown) => config }));
 const toDextoAgentOptionsMock = vi.fn(
     (options: {
         config?: Record<string, unknown> | undefined;
@@ -16,6 +18,7 @@ const toDextoAgentOptionsMock = vi.fn(
 
 vi.mock('@dexto/agent-config', () => ({
     AgentConfigSchema: { parse: (config: unknown) => config },
+    createAgentConfigSchema: createAgentConfigSchemaMock,
     applyImageDefaults: (config: unknown) => config,
     cleanNullValues: (config: unknown) => config,
     loadImage: loadImageMock,
@@ -153,5 +156,19 @@ describe('createDextoAgentFromConfig', () => {
                 hostContext,
             })
         );
+    });
+
+    it('validates config with an injected model registry before agent construction', async () => {
+        const { createDextoAgentFromConfig } = await import('./agent-creation.js');
+        const llmRegistry = {} as ModelRegistry;
+
+        await createDextoAgentFromConfig({
+            config: {
+                llm: { provider: 'openai', model: 'host-model', apiKey: 'test' },
+            } as unknown as AgentConfig,
+            runtimeOverrides: { llmRegistry },
+        });
+
+        expect(createAgentConfigSchemaMock).toHaveBeenCalledWith(llmRegistry);
     });
 });

--- a/packages/agent-management/src/agent-creation.ts
+++ b/packages/agent-management/src/agent-creation.ts
@@ -3,6 +3,7 @@ import {
     AgentConfigSchema,
     applyImageDefaults,
     cleanNullValues,
+    createAgentConfigSchema,
     loadImage,
     resolveServicesFromConfig,
     toDextoAgentOptions,
@@ -10,7 +11,7 @@ import {
 import {
     DextoAgent,
     logger,
-    type DextoAgentConfigInput,
+    type DextoAgentOptions,
     type InitializeServicesOptions,
 } from '@dexto/core';
 import { enrichAgentConfig, type EnrichAgentConfigOptions } from './config/index.js';
@@ -25,7 +26,7 @@ type CreateDextoAgentFromConfigOptions = {
     agentContext?: 'subagent' | undefined;
     hostContext?: DextoHostContext | undefined;
     overrides?: InitializeServicesOptions | undefined;
-    runtimeOverrides?: Pick<DextoAgentConfigInput, 'usageScopeId'> | undefined;
+    runtimeOverrides?: Pick<DextoAgentOptions, 'usageScopeId' | 'llmRegistry'> | undefined;
 };
 
 async function loadImageForConfig(options: {
@@ -112,7 +113,9 @@ export async function createDextoAgentFromConfig(
         enrichedConfig.agentId = agentIdOverride;
     }
 
-    const validatedConfig = AgentConfigSchema.parse(enrichedConfig);
+    const validatedConfig = runtimeOverrides?.llmRegistry
+        ? createAgentConfigSchema(runtimeOverrides.llmRegistry).parse(enrichedConfig)
+        : AgentConfigSchema.parse(enrichedConfig);
     const resolvedHostContext = {
         ...(hostContext ?? {}),
         ...(enrichOptions?.workspaceRoot ? { workspaceRoot: enrichOptions.workspaceRoot } : {}),

--- a/packages/agent-management/src/runtime/AgentRuntime.test.ts
+++ b/packages/agent-management/src/runtime/AgentRuntime.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentConfig } from '@dexto/agent-config';
+import type { DextoAgent, Logger } from '@dexto/core';
+import type { ModelRegistry } from '@dexto/llm';
+import { AgentRuntime } from './AgentRuntime.js';
+
+const { createDextoAgentFromConfigMock } = vi.hoisted(() => ({
+    createDextoAgentFromConfigMock: vi.fn(),
+}));
+
+vi.mock('../agent-creation.js', () => ({
+    createDextoAgentFromConfig: createDextoAgentFromConfigMock,
+}));
+
+function createMockLogger(): Logger {
+    return {
+        debug: vi.fn(),
+        silly: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        trackException: vi.fn(),
+        createChild: vi.fn(),
+        createFileOnlyChild: vi.fn(),
+        destroy: vi.fn(async () => undefined),
+        setLevel: vi.fn(),
+        getLevel: vi.fn(() => 'info' as const),
+        getLogFilePath: vi.fn(() => null),
+    } as unknown as Logger;
+}
+
+describe('AgentRuntime', () => {
+    it('uses the active registry when creating a spawned agent', async () => {
+        const llmRegistry = {} as ModelRegistry;
+        const agent = {
+            start: vi.fn(async () => undefined),
+        } as unknown as DextoAgent;
+        createDextoAgentFromConfigMock.mockResolvedValue(agent);
+
+        const runtime = new AgentRuntime({
+            logger: createMockLogger(),
+            config: { maxAgents: 1, defaultTaskTimeout: 0 },
+            llmRegistry,
+        });
+
+        await runtime.spawnAgent({
+            agentId: 'child-agent',
+            agentConfig: {} as AgentConfig,
+        });
+
+        expect(createDextoAgentFromConfigMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                runtimeOverrides: { llmRegistry },
+            })
+        );
+    });
+});

--- a/packages/agent-management/src/runtime/AgentRuntime.ts
+++ b/packages/agent-management/src/runtime/AgentRuntime.ts
@@ -16,6 +16,7 @@
 
 import { randomUUID } from 'crypto';
 import type { Logger, GenerateResponse } from '@dexto/core';
+import type { ModelRegistry } from '@dexto/llm';
 import { AgentPool } from './AgentPool.js';
 import { RuntimeError } from './errors.js';
 import type {
@@ -36,17 +37,21 @@ export interface AgentRuntimeOptions {
     config?: AgentRuntimeConfig;
     /** Logger instance */
     logger: Logger;
+    /** Host-selected model registry inherited by spawned agents. */
+    llmRegistry?: ModelRegistry;
 }
 
 export class AgentRuntime {
     private pool: AgentPool;
     private config: ValidatedAgentRuntimeConfig;
     private logger: Logger;
+    private llmRegistry: ModelRegistry | undefined;
 
     constructor(options: AgentRuntimeOptions) {
         // Validate and apply defaults
         this.config = AgentRuntimeConfigSchema.parse(options.config ?? {});
         this.logger = options.logger;
+        this.llmRegistry = options.llmRegistry;
         this.pool = new AgentPool(this.config, this.logger);
 
         this.logger.debug('AgentRuntime initialized', {
@@ -85,6 +90,9 @@ export class AgentRuntime {
                 },
                 agentIdOverride: agentId,
                 agentContext: 'subagent',
+                ...(this.llmRegistry
+                    ? { runtimeOverrides: { llmRegistry: this.llmRegistry } }
+                    : {}),
             });
 
             // Create the handle (status: starting)

--- a/packages/agent-management/src/tool-factories/agent-spawner/llm-resolution.test.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/llm-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from 'vitest';
 import { resolveSubAgentLLM } from './llm-resolution.js';
 import type { LLMConfig } from '@dexto/core';
+import { createModelRegistry, getProvider, LLM_REGISTRY } from '@dexto/llm';
 
 describe('resolveSubAgentLLM', () => {
     // Common sub-agent config (like explore-agent)
@@ -54,6 +55,37 @@ describe('resolveSubAgentLLM', () => {
             expect(result.llm.provider).toBe('openrouter');
             expect(result.llm.model).toBe('openai/gpt-5-mini'); // Transformed
             expect(result.llm.apiKey).toBe('$OPENROUTER_API_KEY');
+        });
+
+        test('uses the parent host registry for gateway model transforms', () => {
+            const openRouterModel = getProvider('openrouter').models[0];
+            if (!openRouterModel)
+                throw new Error('Expected the bundled OpenRouter registry to be populated');
+
+            const registry = createModelRegistry({
+                ...LLM_REGISTRY,
+                openrouter: {
+                    ...LLM_REGISTRY.openrouter,
+                    models: [{ ...openRouterModel, name: 'anthropic/custom-haiku' }],
+                },
+            });
+
+            const result = resolveSubAgentLLM({
+                subAgentLLM: {
+                    provider: 'anthropic',
+                    model: 'custom-haiku',
+                    apiKey: '$ANTHROPIC_API_KEY',
+                },
+                parentLLM: {
+                    provider: 'openrouter',
+                    model: 'anthropic/claude-sonnet-4',
+                    apiKey: '$OPENROUTER_API_KEY',
+                },
+                registry,
+            });
+
+            expect(result.llm.model).toBe('anthropic/custom-haiku');
+            expect(result.resolution).toBe('gateway-transform');
         });
 
         test('parent with dexto-nova + sub-agent with google -> dexto-nova + transformed model', () => {

--- a/packages/agent-management/src/tool-factories/agent-spawner/llm-resolution.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/llm-resolution.ts
@@ -15,7 +15,12 @@
  */
 
 import type { LLMConfig } from '@dexto/core';
-import { hasAllRegistryModelsSupport, transformModelNameForProvider } from '@dexto/llm';
+import {
+    DEFAULT_MODEL_REGISTRY,
+    hasAllRegistryModelsSupport,
+    transformModelNameForProvider,
+    type ModelRegistry,
+} from '@dexto/llm';
 
 /**
  * Result of resolving a sub-agent's LLM configuration
@@ -37,6 +42,8 @@ export interface ResolveSubAgentLLMOptions {
     subAgentLLM: LLMConfig;
     /** The parent agent's LLM configuration (already has preferences applied) */
     parentLLM: LLMConfig;
+    /** The registry selected by the host for the parent agent. */
+    registry?: ModelRegistry;
     /** Sub-agent ID for logging purposes */
     subAgentId?: string;
 }
@@ -56,7 +63,7 @@ export interface ResolveSubAgentLLMOptions {
  * // Returns: { provider: 'dexto-nova', model: 'anthropic/claude-haiku-4.5', apiKey: '$DEXTO_API_KEY' }
  */
 export function resolveSubAgentLLM(options: ResolveSubAgentLLMOptions): SubAgentLLMResolution {
-    const { subAgentLLM, parentLLM, subAgentId } = options;
+    const { subAgentLLM, parentLLM, registry = DEFAULT_MODEL_REGISTRY, subAgentId } = options;
     const agentLabel = subAgentId ? `'${subAgentId}'` : 'sub-agent';
 
     const subAgentProvider = subAgentLLM.provider;
@@ -65,12 +72,13 @@ export function resolveSubAgentLLM(options: ResolveSubAgentLLMOptions): SubAgent
 
     // Case 1: Parent's provider is a gateway that can serve all models (dexto-nova, openrouter)
     // Transform sub-agent's model to gateway format and use parent's credentials
-    if (hasAllRegistryModelsSupport(parentProvider)) {
+    if (hasAllRegistryModelsSupport(parentProvider, registry)) {
         try {
             const transformedModel = transformModelNameForProvider(
                 subAgentModel,
                 subAgentProvider,
-                parentProvider
+                parentProvider,
+                registry
             );
 
             return {

--- a/packages/agent-management/src/tool-factories/agent-spawner/runtime.approvals.test.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/runtime.approvals.test.ts
@@ -24,6 +24,7 @@ const createMockLogger = (): Logger => {
 };
 
 const runtimeMocks = vi.hoisted(() => ({
+    constructorOptions: vi.fn(),
     spawnAgent: vi.fn(),
     executeTask: vi.fn(),
     stopAgent: vi.fn(),
@@ -32,6 +33,10 @@ const runtimeMocks = vi.hoisted(() => ({
 
 vi.mock('../../runtime/AgentRuntime.js', () => {
     class AgentRuntime {
+        constructor(options: unknown) {
+            runtimeMocks.constructorOptions(options);
+        }
+
         listAgents = runtimeMocks.listAgents;
         spawnAgent = runtimeMocks.spawnAgent;
         executeTask = runtimeMocks.executeTask;
@@ -52,10 +57,25 @@ describe('AgentSpawnerRuntime sub-agent policies and approvals', () => {
 
     beforeEach(() => {
         runtimeMocks.spawnAgent.mockReset();
+        runtimeMocks.constructorOptions.mockReset();
         runtimeMocks.executeTask.mockReset();
         runtimeMocks.stopAgent.mockReset();
         runtimeMocks.listAgents.mockReset();
         runtimeMocks.listAgents.mockReturnValue([]);
+    });
+
+    it('passes the parent active model registry into the runtime', () => {
+        const parentRegistry = {};
+        const parentAgent = {
+            config: { agentId: 'coding-agent', mcpServers: {} },
+            llmRegistry: parentRegistry,
+        } as unknown as DextoAgent;
+
+        new AgentSpawnerRuntime(parentAgent, config, createMockLogger());
+
+        expect(runtimeMocks.constructorOptions).toHaveBeenCalledWith(
+            expect.objectContaining({ llmRegistry: parentRegistry })
+        );
     });
 
     it('inherits parent toolPolicies into default sub-agent config', async () => {

--- a/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
@@ -55,7 +55,7 @@ export class AgentSpawnerRuntime implements TaskForker {
         model: AgentConfig['llm']['model'],
         preferredVariant: string
     ): string | undefined {
-        const profile = getReasoningProfile(provider, model);
+        const profile = getReasoningProfile(provider, model, this.parentAgent.llmRegistry);
         if (!profile.capable || profile.supportedVariants.length === 0) {
             return undefined;
         }

--- a/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
@@ -338,6 +338,7 @@ export class AgentSpawnerRuntime implements TaskForker {
                 defaultTaskTimeout: config.defaultTimeout,
             },
             logger,
+            llmRegistry: parentAgent.llmRegistry,
         });
 
         this.logger.debug(

--- a/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
+++ b/packages/agent-management/src/tool-factories/agent-spawner/runtime.ts
@@ -1065,6 +1065,7 @@ export class AgentSpawnerRuntime implements TaskForker {
                     const resolution = resolveSubAgentLLM({
                         subAgentLLM: loadedConfig.llm,
                         parentLLM: currentParentLLM,
+                        registry: this.parentAgent.llmRegistry,
                         subAgentId: agentId,
                     });
                     this.logger.debug(`Sub-agent LLM resolution: ${resolution.reason}`);

--- a/packages/core/src/agent/DextoAgent.lifecycle.test.ts
+++ b/packages/core/src/agent/DextoAgent.lifecycle.test.ts
@@ -258,11 +258,15 @@ describe('DextoAgent Lifecycle Management', () => {
             expect(mockGenerateSessionTitle).toHaveBeenCalledWith(
                 mockValidatedConfig.llm,
                 'Need a title for this session',
-                expect.any(Object),
-                {
+                expect.anything(), // logger instance
+                expect.objectContaining({
                     languageModelFactory,
-                    providerContext: { sessionId: 'session-123', authResolver: null },
-                }
+                    providerContext: expect.objectContaining({
+                        sessionId: 'session-123',
+                        authResolver: null,
+                        llmRegistry: expect.anything(),
+                    }),
+                })
             );
         });
 
@@ -314,7 +318,8 @@ describe('DextoAgent Lifecycle Management', () => {
                 expect.anything(), // logger instance
                 expect.anything(), // eventBus instance
                 expect.any(Object),
-                null
+                null,
+                expect.anything() // model registry
             );
         });
 
@@ -380,7 +385,8 @@ describe('DextoAgent Lifecycle Management', () => {
                 expect.anything(), // logger instance
                 expect.anything(), // eventBus instance
                 expect.any(Object),
-                null
+                null,
+                expect.anything() // model registry
             );
         });
 
@@ -414,7 +420,8 @@ describe('DextoAgent Lifecycle Management', () => {
                 expect.objectContaining({
                     telemetryBootstrap,
                 }),
-                null
+                null,
+                expect.anything() // model registry
             );
         });
 

--- a/packages/core/src/agent/DextoAgent.ts
+++ b/packages/core/src/agent/DextoAgent.ts
@@ -49,16 +49,19 @@ import type {
 } from '../mcp/schemas.js';
 import {
     getSupportedProviders,
-    getDefaultModelForProvider,
-    getProviderFromModel,
-    getSupportedFileTypesForModel,
     getModelDisplayName,
+    DEFAULT_MODEL_REGISTRY,
+    type ModelRegistry,
     type ModelInfo,
 } from '@dexto/llm';
-import { getAllModelsForProvider } from '../llm/registry/index.js';
+import {
+    getAllModelsForProvider,
+    getProviderFromModel,
+    getSupportedFileTypesForModel,
+} from '../llm/registry/index.js';
 import type { LLMProvider } from '@dexto/llm';
 import { createAgentServices } from '../utils/service-initializer.js';
-import { LLMConfigSchema, LLMUpdatesSchema } from '../llm/schemas.js';
+import { createLLMConfigSchema, createLLMUpdatesSchema } from '../llm/schemas.js';
 import type { LLMUpdates, ValidatedLLMConfig } from '../llm/schemas.js';
 import { summarizeAssistantUsage } from '../llm/usage-summary.js';
 import { ServersConfigSchema } from '../mcp/schemas.js';
@@ -256,6 +259,7 @@ export class DextoAgent {
 
     // Logger instance for this agent (dependency injection)
     public readonly logger: Logger;
+    public readonly llmRegistry: ModelRegistry;
 
     /**
      * Validate + normalize runtime settings.
@@ -264,10 +268,13 @@ export class DextoAgent {
      * Host layers may validate earlier (e.g. YAML parsing), but core always normalizes
      * runtime settings before use.
      */
-    public static validateConfig(options: DextoAgentConfigInput): AgentRuntimeSettings {
+    public static validateConfig(
+        options: DextoAgentConfigInput,
+        llmRegistry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+    ): AgentRuntimeSettings {
         return {
             agentId: options.agentId,
-            llm: LLMConfigSchema.parse(options.llm),
+            llm: createLLMConfigSchema(llmRegistry).parse(options.llm),
             systemPrompt: SystemPromptConfigSchema.parse(options.systemPrompt),
             mcpServers: ServersConfigSchema.parse(options.mcpServers ?? {}),
             sessions: SessionConfigSchema.parse(options.sessions ?? {}),
@@ -306,6 +313,7 @@ export class DextoAgent {
             tools: toolsInput,
             hooks: hooksInput,
             compaction,
+            llmRegistry,
             overrides: overridesInput,
             ...runtimeSettings
         } = options;
@@ -313,7 +321,8 @@ export class DextoAgent {
         const tools = toolsInput ?? [];
         const hooks = hooksInput ?? [];
 
-        this.config = DextoAgent.validateConfig(runtimeSettings);
+        this.llmRegistry = llmRegistry ?? DEFAULT_MODEL_REGISTRY;
+        this.config = DextoAgent.validateConfig(runtimeSettings, this.llmRegistry);
 
         // Agent logger is always provided by the host (typically created from config).
         this.logger = logger;
@@ -368,7 +377,8 @@ export class DextoAgent {
                 this.logger,
                 this.agentEventBus,
                 this.overrides,
-                this.compactionStrategy
+                this.compactionStrategy,
+                this.llmRegistry
             );
 
             if (this.mcpAuthProviderFactory) {
@@ -1212,7 +1222,8 @@ export class DextoAgent {
                         const textValidation = validateInputForLLM(
                             { text: currentText },
                             { provider: llmConfig.provider, model: llmConfig.model },
-                            this.logger
+                            this.logger,
+                            this.llmRegistry
                         );
                         ensureOk(textValidation, this.logger);
 
@@ -1228,7 +1239,8 @@ export class DextoAgent {
                                     },
                                 },
                                 { provider: llmConfig.provider, model: llmConfig.model },
-                                this.logger
+                                this.logger,
+                                this.llmRegistry
                             );
                             ensureOk(imageValidation, this.logger);
                         }
@@ -1245,7 +1257,8 @@ export class DextoAgent {
                                     },
                                 },
                                 { provider: llmConfig.provider, model: llmConfig.model },
-                                this.logger
+                                this.logger,
+                                this.llmRegistry
                             );
                             ensureOk(fileValidation, this.logger);
                         }
@@ -1254,7 +1267,12 @@ export class DextoAgent {
                     let allowedMediaTypes: string[] | undefined = llmConfig.allowedMediaTypes;
                     if (!allowedMediaTypes) {
                         allowedMediaTypes = fileTypesToMimePatterns(
-                            getSupportedFileTypesForModel(llmConfig.provider, llmConfig.model),
+                            getSupportedFileTypesForModel(
+                                llmConfig.provider,
+                                llmConfig.model,
+                                this.logger,
+                                this.llmRegistry
+                            ),
                             this.logger
                         );
                     }
@@ -1863,6 +1881,7 @@ export class DextoAgent {
         const result = await generateSessionTitle(llmConfig, userText, this.logger, {
             providerContext: {
                 sessionId,
+                llmRegistry: this.llmRegistry,
                 authResolver: this.overrides.authResolver ?? null,
             },
             ...(this.overrides.languageModelFactory !== undefined && {
@@ -2497,7 +2516,7 @@ export class DextoAgent {
 
         // Validate input using schema (single source of truth)
         this.logger.debug(`DextoAgent.switchLLM: llmUpdates: ${safeStringify(llmUpdates)}`);
-        const parseResult = LLMUpdatesSchema.safeParse(llmUpdates);
+        const parseResult = createLLMUpdatesSchema(this.llmRegistry).safeParse(llmUpdates);
         if (!parseResult.success) {
             const validation = fail(zodToIssues(parseResult.error, 'error'));
             ensureOk(validation, this.logger); // This will throw DextoValidationError
@@ -2521,7 +2540,8 @@ export class DextoAgent {
         const result = await resolveAndValidateLLMConfig(
             currentLLMConfig,
             validatedUpdates,
-            this.logger
+            this.logger,
+            this.llmRegistry
         );
         const validatedConfig = ensureOk(result, this.logger);
 
@@ -2645,13 +2665,15 @@ export class DextoAgent {
     public getSupportedModelsForProvider(
         provider: LLMProvider
     ): Array<ModelInfo & { isDefault: boolean; originalProvider?: LLMProvider }> {
-        const models = getAllModelsForProvider(provider);
+        const models = getAllModelsForProvider(provider, this.llmRegistry);
 
         return models.map((model) => {
             // For inherited models, get default from the original provider
             const originalProvider =
                 'originalProvider' in model ? model.originalProvider : provider;
-            const defaultModel = getDefaultModelForProvider(originalProvider ?? provider);
+            const defaultModel = this.llmRegistry.getDefaultModelForProvider(
+                originalProvider ?? provider
+            );
 
             return {
                 ...model,
@@ -2681,7 +2703,7 @@ export class DextoAgent {
      */
     public inferProviderFromModel(modelName: string): LLMProvider | null {
         try {
-            return getProviderFromModel(modelName) as LLMProvider;
+            return getProviderFromModel(modelName, this.llmRegistry);
         } catch {
             return null;
         }

--- a/packages/core/src/agent/agent-options.ts
+++ b/packages/core/src/agent/agent-options.ts
@@ -6,6 +6,7 @@ import type { InitializeServicesOptions, ToolkitLoader } from '../utils/service-
 import type { DextoStores } from '../storage/stores/types.js';
 import type { DextoAgentConfigInput } from './runtime-config.js';
 import type { SkillSource } from '../skills/index.js';
+import type { ModelRegistry } from '@dexto/llm';
 
 /**
  * Constructor options for {@link DextoAgent}.
@@ -66,6 +67,11 @@ export interface DextoAgentOptions {
      * If omitted/null, automatic compaction is disabled.
      */
     compaction?: CompactionStrategy | null | undefined;
+
+    /**
+     * Host-selected LLM registry. When omitted, core uses the bundled registry from `@dexto/llm`.
+     */
+    llmRegistry?: ModelRegistry | undefined;
 }
 
 export interface DextoAgentOptions extends DextoAgentConfigInput {}

--- a/packages/core/src/context/manager.ts
+++ b/packages/core/src/context/manager.ts
@@ -23,6 +23,8 @@ import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
 import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 import { getResourceKind } from './media-helpers.js';
 import { describeContentPartsForAudit } from './content-audit.js';
+import { getSupportedFileTypesForModel } from '../llm/registry/index.js';
+import { DEFAULT_MODEL_REGISTRY, type ModelRegistry } from '@dexto/llm';
 
 export type PreparedHistoryResult = {
     preparedHistory: InternalMessage[];
@@ -112,6 +114,7 @@ export class ContextManager<TMessage = unknown> {
     private resourceManager: import('../resources/index.js').ResourceManager;
 
     private logger: Logger;
+    private readonly llmRegistry: ModelRegistry;
 
     private static deriveResourceKind(mimeType: string): import('./types.js').ResourcePart['kind'] {
         if (
@@ -272,7 +275,8 @@ export class ContextManager<TMessage = unknown> {
         conversationStore: ConversationStore,
         sessionId: string,
         resourceManager: import('../resources/index.js').ResourceManager,
-        logger: Logger
+        logger: Logger,
+        llmRegistry: ModelRegistry = DEFAULT_MODEL_REGISTRY
     ) {
         this.llmConfig = llmConfig;
         this.formatter = formatter;
@@ -282,6 +286,7 @@ export class ContextManager<TMessage = unknown> {
         this.sessionId = sessionId;
         this.resourceManager = resourceManager;
         this.logger = logger.createChild(DextoLogComponent.CONTEXT);
+        this.llmRegistry = llmRegistry;
 
         this.logger.debug(
             `ContextManager: Initialized for session ${sessionId} - history will be managed by ${conversationStore.constructor.name}`
@@ -1063,11 +1068,12 @@ export class ContextManager<TMessage = unknown> {
         if (!allowedMediaTypes) {
             // Fall back to model capabilities from registry
             try {
-                const { getSupportedFileTypesForModel } = await import('@dexto/llm');
                 const { fileTypesToMimePatterns } = await import('./utils.js');
                 const supportedFileTypes = getSupportedFileTypesForModel(
                     llmContext.provider,
-                    llmContext.model
+                    llmContext.model,
+                    this.logger,
+                    this.llmRegistry
                 );
                 allowedMediaTypes = fileTypesToMimePatterns(supportedFileTypes, this.logger);
                 this.logger.debug(

--- a/packages/core/src/context/utils.ts
+++ b/packages/core/src/context/utils.ts
@@ -12,8 +12,12 @@ import {
 import { clonePromptContentPart } from './content-clone.js';
 import { isValidDisplayData, type ToolDisplayData } from '../tools/display-types.js';
 import type { Logger } from '../logger/v2/types.js';
-import { validateModelFileSupport } from '@dexto/llm';
-import type { LLMContext } from '@dexto/llm';
+import {
+    DEFAULT_MODEL_REGISTRY,
+    validateModelFileSupport,
+    type LLMContext,
+    type ModelRegistry,
+} from '@dexto/llm';
 import { safeStringify } from '../utils/safe-stringify.js';
 import { getFileMediaKind, getResourceKind } from './media-helpers.js';
 import type { ArtifactData } from '../storage/artifacts/types.js';
@@ -1004,7 +1008,8 @@ export async function expandBlobReferences(
 export function filterMessagesByLLMCapabilities(
     messages: InternalMessage[],
     config: LLMContext,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): InternalMessage[] {
     try {
         let totalImagesFiltered = 0;
@@ -1029,11 +1034,15 @@ export function filterMessagesByLLMCapabilities(
                     // Filter/transform image parts based on LLM capabilities
                     if (part.type === 'image') {
                         const mimeType = part.mimeType ?? 'image/jpeg';
-                        const validation = validateModelFileSupport(
-                            config.provider,
-                            config.model,
-                            mimeType
-                        );
+                        const validation =
+                            registry === DEFAULT_MODEL_REGISTRY
+                                ? validateModelFileSupport(config.provider, config.model, mimeType)
+                                : validateModelFileSupport(
+                                      config.provider,
+                                      config.model,
+                                      mimeType,
+                                      registry
+                                  );
                         if (validation.isSupported) {
                             return [part];
                         }
@@ -1054,11 +1063,19 @@ export function filterMessagesByLLMCapabilities(
 
                     // Filter/transform file parts based on LLM capabilities
                     if (part.type === 'file' && part.mimeType) {
-                        const validation = validateModelFileSupport(
-                            config.provider,
-                            config.model,
-                            part.mimeType
-                        );
+                        const validation =
+                            registry === DEFAULT_MODEL_REGISTRY
+                                ? validateModelFileSupport(
+                                      config.provider,
+                                      config.model,
+                                      part.mimeType
+                                  )
+                                : validateModelFileSupport(
+                                      config.provider,
+                                      config.model,
+                                      part.mimeType,
+                                      registry
+                                  );
                         if (validation.isSupported) {
                             return [part];
                         }

--- a/packages/core/src/index.browser.test.ts
+++ b/packages/core/src/index.browser.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { createLLMConfigSchema } from './index.browser.js';
+
+describe('browser-safe core exports', () => {
+    it('exports the registry-aware LLM config schema factory', () => {
+        expect(createLLMConfigSchema).toEqual(expect.any(Function));
+    });
+});

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -46,6 +46,7 @@ export { getFileMediaKind, getResourceKind } from './context/media-helpers.js';
 // LLM types (used by client packages)
 export type { LLMProvider } from '@dexto/llm';
 export { LLM_PROVIDERS } from '@dexto/llm';
+export { createLLMConfigSchema } from './llm/schemas.js';
 
 // MCP types and constants (used by webui)
 export type { McpServerType, McpConnectionMode } from './mcp/schemas.js';

--- a/packages/core/src/llm/active-registry.test.ts
+++ b/packages/core/src/llm/active-registry.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+import { createModelRegistry, LLM_REGISTRY, type ModelInfo } from '@dexto/llm';
+import { createMockLogger } from '../logger/v2/test-utils.js';
+import { buildProviderOptions } from './executor/provider-options.js';
+import { getEffectiveMaxInputTokens } from './registry/index.js';
+import { createLLMConfigSchema, LLMConfigSchema } from './schemas.js';
+import { getUsagePricingMetadata } from './usage-metadata.js';
+import { validateInputForLLM } from './validation.js';
+
+function createRegistryWithCloudModel(): ReturnType<typeof createModelRegistry> {
+    const bundledModel = LLM_REGISTRY.openai.models[0];
+    if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+    const model: ModelInfo = {
+        ...bundledModel,
+        name: 'cloud-added-model',
+        maxInputTokens: 777,
+        reasoning: true,
+        supportedFileTypes: ['pdf'],
+        pricing: {
+            inputPerM: 12,
+            outputPerM: 34,
+        },
+    };
+
+    return createModelRegistry({
+        ...LLM_REGISTRY,
+        openai: {
+            ...LLM_REGISTRY.openai,
+            models: [model],
+        },
+    });
+}
+
+describe('active model registry', () => {
+    it('validates a model that exists only in the injected registry', () => {
+        const registry = createRegistryWithCloudModel();
+        const config = {
+            provider: 'openai',
+            model: 'cloud-added-model',
+            apiKey: 'test-openai-key',
+            maxIterations: 10,
+        };
+
+        expect(LLMConfigSchema.safeParse(config).success).toBe(false);
+        expect(createLLMConfigSchema(registry).safeParse(config).success).toBe(true);
+    });
+
+    it('uses injected pricing for usage metadata', () => {
+        const registry = createRegistryWithCloudModel();
+
+        expect(
+            getUsagePricingMetadata({
+                provider: 'openai',
+                model: 'cloud-added-model',
+                tokenUsage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
+                llmRegistry: registry,
+            })
+        ).toMatchObject({
+            estimatedCost: 46,
+            pricingStatus: 'estimated',
+        });
+    });
+
+    it('uses injected reasoning metadata and context limits', () => {
+        const registry = createRegistryWithCloudModel();
+        const logger = createMockLogger();
+
+        expect(
+            buildProviderOptions({
+                provider: 'openai',
+                model: 'cloud-added-model',
+                reasoning: { variant: 'high' },
+                llmRegistry: registry,
+            })
+        ).toEqual({
+            openai: {
+                reasoningEffort: 'high',
+                reasoningSummary: 'auto',
+            },
+        });
+
+        expect(
+            getEffectiveMaxInputTokens(
+                { provider: 'openai', model: 'cloud-added-model' },
+                logger,
+                registry
+            )
+        ).toBe(777);
+    });
+
+    it('uses injected file capabilities during input validation', () => {
+        const registry = createRegistryWithCloudModel();
+        const result = validateInputForLLM(
+            {
+                fileData: {
+                    data: 'SGVsbG8gV29ybGQ=',
+                    mimeType: 'application/pdf',
+                },
+            },
+            { provider: 'openai', model: 'cloud-added-model' },
+            createMockLogger(),
+            registry
+        );
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.data.fileValidation?.isSupported).toBe(true);
+        }
+    });
+});

--- a/packages/core/src/llm/curation.ts
+++ b/packages/core/src/llm/curation.ts
@@ -1,5 +1,5 @@
 import type { LLMProvider } from '@dexto/llm';
-import { LLM_REGISTRY, type ModelInfo } from '@dexto/llm';
+import { DEFAULT_MODEL_REGISTRY, type ModelInfo, type ModelRegistry } from '@dexto/llm';
 import { CURATED_MODEL_IDS_BY_PROVIDER } from './curation-config.js';
 
 type CuratedModelsOptions = {
@@ -33,10 +33,10 @@ export type CuratedModelRef = {
  */
 export function getCuratedModelsForProvider(
     provider: LLMProvider,
-    options?: CuratedModelsOptions
+    options?: CuratedModelsOptions,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): ModelInfo[] {
-    const providerInfo = LLM_REGISTRY[provider];
-    const models = providerInfo.models ?? [];
+    const models = registry.getProvider(provider).models;
 
     if (models.length === 0) return [];
 
@@ -74,7 +74,8 @@ export function getCuratedModelsForProvider(
  * This prevents early providers from consuming the entire featured budget.
  */
 export function getCuratedModelRefsForProviders(
-    options: CuratedModelRefsOptions
+    options: CuratedModelRefsOptions,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): CuratedModelRef[] {
     const max = options.max ?? DEFAULT_MAX;
     if (max <= 0 || options.providers.length === 0) {
@@ -83,7 +84,7 @@ export function getCuratedModelRefsForProviders(
 
     const providerCurated = options.providers.map((provider) => ({
         provider,
-        models: getCuratedModelsForProvider(provider, { max }),
+        models: getCuratedModelsForProvider(provider, { max }, registry),
     }));
     const cursorByProvider = new Array<number>(providerCurated.length).fill(0);
     const picked: CuratedModelRef[] = [];

--- a/packages/core/src/llm/executor/provider-options.ts
+++ b/packages/core/src/llm/executor/provider-options.ts
@@ -2,7 +2,7 @@
  * Provider-specific options builder for Vercel AI SDK's streamText/generateText.
  */
 
-import type { LLMProvider, LLMReasoningConfig } from '@dexto/llm';
+import type { LLMProvider, LLMReasoningConfig, ModelRegistry } from '@dexto/llm';
 import {
     ANTHROPIC_INTERLEAVED_THINKING_BETA,
     getGoogleReasoningBudgetTokens,
@@ -21,6 +21,7 @@ export interface ProviderOptionsConfig {
     provider: LLMProvider;
     model: string;
     reasoning?: LLMReasoningConfig | undefined;
+    llmRegistry?: ModelRegistry;
 }
 
 const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
@@ -65,7 +66,7 @@ function getSelectedReasoningVariant(config: ProviderOptionsConfig): {
     reasoningVariant: string | undefined;
     hasInvalidRequestedReasoningVariant: boolean;
 } {
-    const profile = getReasoningProfile(config.provider, config.model);
+    const profile = getReasoningProfile(config.provider, config.model, config.llmRegistry);
     const requested = config.reasoning?.variant;
     if (requested !== undefined) {
         const supported = profile.variants.some((entry) => entry.id === requested);
@@ -165,9 +166,10 @@ function buildOpenRouterProviderOptions(config: {
     model: string;
     reasoningVariant: string | undefined;
     budgetTokens: number | undefined;
+    llmRegistry?: ModelRegistry;
 }): Record<string, Record<string, unknown>> | undefined {
     const { provider, model, reasoningVariant, budgetTokens } = config;
-    const profile = getReasoningProfile(provider, model);
+    const profile = getReasoningProfile(provider, model, config.llmRegistry);
     if (!profile.capable) {
         return undefined;
     }
@@ -263,12 +265,12 @@ export function buildProviderOptions(
     }
 
     if (provider === 'anthropic') {
-        const capable = isReasoningCapableModel(model, 'anthropic');
+        const capable = isReasoningCapableModel(model, 'anthropic', config.llmRegistry);
         return buildAnthropicProviderOptions({ model, reasoningVariant, budgetTokens, capable });
     }
 
     if (provider === 'bedrock') {
-        const capable = getReasoningProfile('bedrock', model).capable;
+        const capable = getReasoningProfile('bedrock', model, config.llmRegistry).capable;
         if (!capable) {
             return { bedrock: {} };
         }
@@ -317,12 +319,12 @@ export function buildProviderOptions(
     }
 
     if (provider === 'vertex' && modelLower.includes('claude')) {
-        const capable = isReasoningCapableModel(model, 'vertex');
+        const capable = isReasoningCapableModel(model, 'vertex', config.llmRegistry);
         return buildAnthropicProviderOptions({ model, reasoningVariant, budgetTokens, capable });
     }
 
     if (provider === 'google' || (provider === 'vertex' && !modelLower.includes('claude'))) {
-        const profile = getReasoningProfile(provider, model);
+        const profile = getReasoningProfile(provider, model, config.llmRegistry);
         const includeThoughts = profile.capable && reasoningVariant !== 'disabled';
         const isThinkingLevel = profile.paradigm === 'thinking-level';
         const thinkingLevel =
@@ -373,11 +375,17 @@ export function buildProviderOptions(
     }
 
     if (isOpenRouterGatewayProvider(provider)) {
-        return buildOpenRouterProviderOptions({ provider, model, reasoningVariant, budgetTokens });
+        return buildOpenRouterProviderOptions({
+            provider,
+            model,
+            reasoningVariant,
+            budgetTokens,
+            ...(config.llmRegistry !== undefined && { llmRegistry: config.llmRegistry }),
+        });
     }
 
     if (provider === 'openai-compatible') {
-        const profile = getReasoningProfile(provider, model);
+        const profile = getReasoningProfile(provider, model, config.llmRegistry);
         if (!profile.capable) return undefined;
 
         const reasoningEffort = toOpenAICompatibleReasoningEffort(reasoningVariant);

--- a/packages/core/src/llm/executor/stream-processor.ts
+++ b/packages/core/src/llm/executor/stream-processor.ts
@@ -72,6 +72,7 @@ type ToolInputEndEvent = Extract<FullStreamPart, { type: 'tool-input-end' }> & {
 export interface StreamProcessorConfig {
     provider: LLMProvider;
     model: string;
+    llmRegistry?: import('@dexto/llm').ModelRegistry;
     usageScopeId?: string;
     /** Estimated input tokens before LLM call (for analytics/calibration) */
     estimatedInputTokens?: number;
@@ -442,6 +443,9 @@ export class StreamProcessor {
                             provider: this.config.provider,
                             model: this.config.model,
                             tokenUsage: usage,
+                            ...(this.config.llmRegistry !== undefined && {
+                                llmRegistry: this.config.llmRegistry,
+                            }),
                         });
 
                         // Log LLM response metadata. Avoid logging full content at info level.
@@ -501,6 +505,9 @@ export class StreamProcessor {
                             provider: this.config.provider,
                             model: this.config.model,
                             tokenUsage: this.actualTokens,
+                            ...(this.config.llmRegistry !== undefined && {
+                                llmRegistry: this.config.llmRegistry,
+                            }),
                         });
                         await this.persistAssistantResponseMetadata(
                             this.actualTokens,
@@ -542,6 +549,9 @@ export class StreamProcessor {
                     provider: this.config.provider,
                     model: this.config.model,
                     tokenUsage: this.actualTokens,
+                    ...(this.config.llmRegistry !== undefined && {
+                        llmRegistry: this.config.llmRegistry,
+                    }),
                 });
                 await this.persistAssistantResponseMetadata(
                     this.actualTokens,
@@ -574,6 +584,9 @@ export class StreamProcessor {
                 provider: this.config.provider,
                 model: this.config.model,
                 tokenUsage: this.actualTokens,
+                ...(this.config.llmRegistry !== undefined && {
+                    llmRegistry: this.config.llmRegistry,
+                }),
             });
             await this.persistAssistantResponseMetadata(this.actualTokens, failurePricingMetadata, {
                 status: 'stopped',

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -39,6 +39,7 @@ import type {
     LLMReasoningConfig,
     LLMContext,
     LLMProvider,
+    ModelRegistry,
     ReasoningVariant,
 } from '@dexto/llm';
 import type { Logger } from '../../logger/v2/types.js';
@@ -473,6 +474,7 @@ export class TurnExecutor {
             baseURL?: string | undefined;
             usageScopeId?: string | undefined;
             executionControl?: LLMExecutionControl | undefined;
+            llmRegistry?: ModelRegistry;
             // Provider-specific options
             reasoning?: LLMReasoningConfig | undefined;
         },
@@ -510,6 +512,9 @@ export class TurnExecutor {
             model: this.llmContext.model,
             ...(this.config.usageScopeId !== undefined && {
                 usageScopeId: this.config.usageScopeId,
+            }),
+            ...(this.config.llmRegistry !== undefined && {
+                llmRegistry: this.config.llmRegistry,
             }),
             ...(estimatedInputTokens !== undefined && { estimatedInputTokens }),
             ...(reasoning?.reasoningVariant !== undefined && {
@@ -1520,6 +1525,9 @@ export class TurnExecutor {
                     provider: this.llmContext.provider,
                     model: this.llmContext.model,
                     reasoning: this.config.reasoning,
+                    ...(this.config.llmRegistry !== undefined && {
+                        llmRegistry: this.config.llmRegistry,
+                    }),
                 }),
             this.logger
         );

--- a/packages/core/src/llm/formatters/vercel.ts
+++ b/packages/core/src/llm/formatters/vercel.ts
@@ -1,5 +1,5 @@
 import type { ModelMessage, AssistantContent, ToolResultPart } from 'ai';
-import type { LLMContext } from '@dexto/llm';
+import { DEFAULT_MODEL_REGISTRY, type LLMContext, type ModelRegistry } from '@dexto/llm';
 import type {
     InternalMessage,
     AssistantMessage,
@@ -146,9 +146,11 @@ function filePartToText(part: FilePart): { type: 'text'; text: string } | null {
  */
 export class VercelMessageFormatter {
     private logger: Logger;
+    private readonly llmRegistry: ModelRegistry;
 
-    constructor(logger: Logger) {
+    constructor(logger: Logger, llmRegistry: ModelRegistry = DEFAULT_MODEL_REGISTRY) {
         this.logger = logger.createChild(DextoLogComponent.LLM);
+        this.llmRegistry = llmRegistry;
     }
     /**
      * Formats internal messages into Vercel AI SDK format
@@ -168,7 +170,12 @@ export class VercelMessageFormatter {
         // Apply model-aware capability filtering for Vercel
         let filteredHistory: InternalMessage[];
         try {
-            filteredHistory = filterMessagesByLLMCapabilities([...history], context, this.logger);
+            filteredHistory = filterMessagesByLLMCapabilities(
+                [...history],
+                context,
+                this.logger,
+                this.llmRegistry
+            );
 
             const modelInfo = `${context.provider}/${context.model}`;
             this.logger.debug(`Applied Vercel filtering for ${modelInfo}`);

--- a/packages/core/src/llm/registry/auto-update.test.ts
+++ b/packages/core/src/llm/registry/auto-update.test.ts
@@ -305,6 +305,9 @@ describe('llm registry auto-update', () => {
             'gpt-5-mini',
         ]);
         expect(registry.LLM_REGISTRY.openai.models[0]!.maxInputTokens).toBe(1500);
+        expect(registry.DEFAULT_MODEL_REGISTRY.getModel('openai', 'gpt-5-mini')).toMatchObject({
+            maxInputTokens: 800,
+        });
 
         const status = autoUpdate.getLlmRegistryAutoUpdateStatus();
         expect(status.source).toBe('remote');

--- a/packages/core/src/llm/registry/auto-update.ts
+++ b/packages/core/src/llm/registry/auto-update.ts
@@ -4,9 +4,9 @@ import path from 'node:path';
 import { getDextoGlobalPath } from '../../utils/path.js';
 import { logger as defaultLogger } from '../../logger/logger.js';
 import type { Logger } from '../../logger/v2/types.js';
-import type { LLMProvider } from '@dexto/llm';
+import type { LLMProvider, ProviderInfo } from '@dexto/llm';
 import { LLM_PROVIDERS } from '@dexto/llm';
-import { LLM_REGISTRY, type ModelInfo } from '@dexto/llm';
+import { DEFAULT_MODEL_REGISTRY, LLM_REGISTRY, type ModelInfo } from '@dexto/llm';
 import { buildModelsByProviderFromRemote } from './sync.js';
 
 type LogLike = Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
@@ -61,9 +61,11 @@ function isModelInfo(value: unknown): value is ModelInfo {
 }
 
 function applyModelsByProvider(modelsByProvider: Record<LLMProvider, ModelInfo[]>): void {
+    const nextProviders: Record<LLMProvider, ProviderInfo> = { ...LLM_REGISTRY };
+
     for (const provider of UPDATABLE_PROVIDERS) {
         const incoming = modelsByProvider[provider] ?? [];
-        const existing = LLM_REGISTRY[provider].models ?? [];
+        const existing = nextProviders[provider].models;
 
         const incomingByName = new Map<string, ModelInfo>();
         for (const m of incoming) {
@@ -157,7 +159,18 @@ function applyModelsByProvider(modelsByProvider: Record<LLMProvider, ModelInfo[]
             }
         }
 
-        LLM_REGISTRY[provider].models = finalMerged;
+        nextProviders[provider] = {
+            ...nextProviders[provider],
+            models: finalMerged,
+        };
+    }
+
+    // Validate the complete candidate before changing either active representation. The default
+    // registry is a cloned snapshot, so refreshes must update it explicitly as well as the raw
+    // export used by the legacy catalog helpers.
+    DEFAULT_MODEL_REGISTRY.replaceProviders(nextProviders);
+    for (const provider of UPDATABLE_PROVIDERS) {
+        LLM_REGISTRY[provider].models = nextProviders[provider].models;
     }
 }
 
@@ -230,7 +243,14 @@ export function getLlmRegistryAutoUpdateStatus(): LlmRegistryAutoUpdateStatus {
 export function loadLlmRegistryCache(options?: { logger?: LogLike }): boolean {
     const cache = tryLoadCacheFromDisk(options?.logger);
     if (!cache) return false;
-    applyModelsByProvider(cache.modelsByProvider);
+    try {
+        applyModelsByProvider(cache.modelsByProvider);
+    } catch (error) {
+        options?.logger?.warn?.(
+            `Ignored invalid LLM registry cache (${getCachePath()}): ${error instanceof Error ? error.message : String(error)}`
+        );
+        return false;
+    }
     lastFetchedAt = cache.fetchedAt;
     lastSource = 'cache';
     return true;
@@ -291,9 +311,9 @@ export async function refreshLlmRegistryCache(options?: {
             timeoutMs: 30_000,
         });
 
+        applyModelsByProvider(modelsByProvider);
         const cachePath = getCachePath();
         await writeCacheFile(cachePath, modelsByProvider);
-        applyModelsByProvider(modelsByProvider);
         lastFetchedAt = Date.now();
         lastSource = 'remote';
         log?.debug?.(`Refreshed LLM registry cache (${cachePath})`);

--- a/packages/core/src/llm/registry/index.test.ts
+++ b/packages/core/src/llm/registry/index.test.ts
@@ -33,6 +33,7 @@ import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
 import type { Logger } from '../../logger/v2/types.js';
 import {
     getCachedOpenRouterModelsWithInfo,
+    getOpenRouterModelContextLength,
     getOpenRouterModelCacheInfo,
 } from '../providers/openrouter-model-registry.js';
 
@@ -367,6 +368,22 @@ describe('getEffectiveMaxInputTokens', () => {
             } as any;
             expect(getEffectiveMaxInputTokens(config, mockLogger)).toBe(128000);
         });
+
+        it('does not use the default OpenRouter fallback for an injected registry', () => {
+            const registry = createModelRegistry(LLM_REGISTRY);
+            vi.mocked(getOpenRouterModelContextLength).mockClear();
+
+            expect(() =>
+                getMaxInputTokensForModel('openrouter', 'unknown/model', mockLogger, registry)
+            ).toThrow(
+                expect.objectContaining({
+                    code: LLMErrorCode.MODEL_UNKNOWN,
+                    scope: ErrorScope.LLM,
+                    type: ErrorType.USER,
+                })
+            );
+            expect(getOpenRouterModelContextLength).not.toHaveBeenCalled();
+        });
     });
 });
 
@@ -443,6 +460,33 @@ describe('File Support Functions', () => {
                     scope: ErrorScope.LLM,
                     type: ErrorType.USER,
                 })
+            );
+        });
+
+        it('uses file capabilities from an injected registry', () => {
+            const bundledModel = LLM_REGISTRY.openai.models[0];
+            if (!bundledModel)
+                throw new Error('Expected the bundled OpenAI registry to be populated');
+
+            const registry = createModelRegistry({
+                ...LLM_REGISTRY,
+                openai: {
+                    ...LLM_REGISTRY.openai,
+                    models: [
+                        {
+                            ...bundledModel,
+                            name: 'registry-file-model',
+                            supportedFileTypes: ['audio'],
+                        },
+                    ],
+                },
+            });
+
+            expect(modelSupportsFileType('openai', 'registry-file-model', 'audio', registry)).toBe(
+                true
+            );
+            expect(modelSupportsFileType('openai', 'registry-file-model', 'image', registry)).toBe(
+                false
             );
         });
     });

--- a/packages/core/src/llm/registry/index.test.ts
+++ b/packages/core/src/llm/registry/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { LLM_PROVIDERS } from '@dexto/llm';
+import { createModelRegistry, LLM_PROVIDERS } from '@dexto/llm';
 import {
     LLM_REGISTRY,
     getSupportedProviders,
@@ -29,6 +29,7 @@ import {
 } from './index.js';
 import { LLMErrorCode } from '../error-codes.js';
 import { ErrorScope, ErrorType } from '../../errors/types.js';
+import { DextoRuntimeError } from '../../errors/DextoRuntimeError.js';
 import type { Logger } from '../../logger/v2/types.js';
 import {
     getCachedOpenRouterModelsWithInfo,
@@ -119,6 +120,19 @@ describe('LLM Registry Core Functions', () => {
             expect(() => getProviderFromModel('anthropic/claude-opus-4.5')).toThrow();
             expect(() => getProviderFromModel('openai/gpt-5-mini')).toThrow();
             expect(() => getProviderFromModel('x-ai/grok-4')).toThrow();
+        });
+
+        it('normalizes unknown-model errors from an injected registry', () => {
+            const registry = createModelRegistry(LLM_REGISTRY);
+
+            expect(() => getProviderFromModel('unknown-model', registry)).toThrow(
+                expect.objectContaining({ code: LLMErrorCode.MODEL_UNKNOWN })
+            );
+            try {
+                getProviderFromModel('unknown-model', registry);
+            } catch (error) {
+                expect(error).toBeInstanceOf(DextoRuntimeError);
+            }
         });
     });
 

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -175,7 +175,14 @@ export function getProviderFromModel(
     registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): LLMProvider {
     if (registry !== DEFAULT_MODEL_REGISTRY) {
-        return registry.getProviderFromModel(model);
+        try {
+            return registry.getProviderFromModel(model);
+        } catch (error) {
+            if (isUnknownCatalogModelError(error)) {
+                throw LLMError.modelProviderUnknown(model);
+            }
+            throw error;
+        }
     }
 
     try {

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -1,15 +1,12 @@
 import {
-    acceptsAnyModel,
+    DEFAULT_MODEL_REGISTRY,
     DEFAULT_MAX_INPUT_TOKENS,
     getAllModelsForProvider as getSharedAllModelsForProvider,
-    getModel,
     getProviderFromModel as getSharedProviderFromModel,
     getSupportedFileTypesForModel as getSharedSupportedFileTypesForModel,
-    getSupportedModels,
-    hasAllRegistryModelsSupport,
     LLM_REGISTRY,
     LlmCatalogError,
-    supportsCustomModels,
+    type ModelRegistry,
     type ModelInfo,
 } from '@dexto/llm';
 import type { ValidatedLLMConfig } from '../schemas.js';
@@ -133,8 +130,13 @@ function getOpenRouterGatewayCatalogModels(): ModelInfo[] {
 }
 
 export function getAllModelsForProvider(
-    provider: LLMProvider
+    provider: LLMProvider,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): Array<ModelInfo & { originalProvider?: LLMProvider }> {
+    if (registry !== DEFAULT_MODEL_REGISTRY) {
+        return registry.getAllModelsForProvider(provider);
+    }
+
     if (provider === 'openrouter') {
         return getOpenRouterGatewayCatalogModels().map((model) => ({
             ...model,
@@ -142,7 +144,7 @@ export function getAllModelsForProvider(
         }));
     }
 
-    if (!hasAllRegistryModelsSupport(provider)) {
+    if (LLM_REGISTRY[provider].supportsAllRegistryModels !== true) {
         return getSharedAllModelsForProvider(provider) as Array<
             ModelInfo & { originalProvider?: LLMProvider }
         >;
@@ -168,7 +170,14 @@ export function getAllModelsForProvider(
     return allModels;
 }
 
-export function getProviderFromModel(model: string): LLMProvider {
+export function getProviderFromModel(
+    model: string,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+): LLMProvider {
+    if (registry !== DEFAULT_MODEL_REGISTRY) {
+        return registry.getProviderFromModel(model);
+    }
+
     try {
         return getSharedProviderFromModel(model) as LLMProvider;
     } catch (error) {
@@ -181,8 +190,21 @@ export function getProviderFromModel(model: string): LLMProvider {
 
 export function getSupportedFileTypesForModel(
     provider: LLMProvider,
-    model: string
+    model: string,
+    _logger?: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): SupportedFileType[] {
+    if (registry !== DEFAULT_MODEL_REGISTRY) {
+        try {
+            return registry.getSupportedFileTypesForModel(provider, model);
+        } catch (error) {
+            if (isUnknownCatalogModelError(error)) {
+                throw LLMError.unknownModel(provider, model);
+            }
+            throw error;
+        }
+    }
+
     try {
         return getSharedSupportedFileTypesForModel(provider, model) as SupportedFileType[];
     } catch (error) {
@@ -204,9 +226,10 @@ export function modelSupportsFileType(
 export function getMaxInputTokensForModel(
     provider: LLMProvider,
     model: string,
-    logger?: Logger
+    logger?: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): number {
-    const modelInfo = getModel(provider, model);
+    const modelInfo = registry.getModel(provider, model);
     if (modelInfo !== null) {
         logger?.debug(`Found max tokens for ${provider}/${model}: ${modelInfo.maxInputTokens}`);
         return modelInfo.maxInputTokens;
@@ -222,7 +245,7 @@ export function getMaxInputTokensForModel(
         }
     }
 
-    const supportedModels = getSupportedModels(provider).join(', ');
+    const supportedModels = registry.getSupportedModels(provider).join(', ');
     logger?.error(
         `Model '${model}' not found for provider '${provider}' in LLM registry. Supported models: ${supportedModels}`
     );
@@ -231,7 +254,8 @@ export function getMaxInputTokensForModel(
 
 export function getEffectiveMaxInputTokens(
     config: EffectiveMaxInputTokensConfig,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): number {
     const configuredMaxInputTokens = config.maxInputTokens;
 
@@ -247,7 +271,8 @@ export function getEffectiveMaxInputTokens(
             const registryMaxInputTokens = getMaxInputTokensForModel(
                 config.provider,
                 config.model,
-                logger
+                logger,
+                registry
             );
             if (configuredMaxInputTokens > registryMaxInputTokens) {
                 logger.warn(
@@ -285,7 +310,7 @@ export function getEffectiveMaxInputTokens(
         return DEFAULT_MAX_INPUT_TOKENS;
     }
 
-    if (acceptsAnyModel(config.provider)) {
+    if (registry.acceptsAnyModel(config.provider)) {
         logger.debug(
             `Provider ${config.provider} accepts any model, defaulting to ${DEFAULT_MAX_INPUT_TOKENS} tokens`
         );
@@ -296,7 +321,8 @@ export function getEffectiveMaxInputTokens(
         const registryMaxInputTokens = getMaxInputTokensForModel(
             config.provider,
             config.model,
-            logger
+            logger,
+            registry
         );
         logger.debug(
             `Using maxInputTokens from registry for ${config.provider}/${config.model}: ${registryMaxInputTokens}`
@@ -304,7 +330,7 @@ export function getEffectiveMaxInputTokens(
         return registryMaxInputTokens;
     } catch (error: unknown) {
         if (error instanceof DextoRuntimeError && error.code === LLMErrorCode.MODEL_UNKNOWN) {
-            if (supportsCustomModels(config.provider)) {
+            if (registry.supportsCustomModels(config.provider)) {
                 logger.debug(
                     `Custom model ${config.model} not in ${config.provider} registry, defaulting to ${DEFAULT_MAX_INPUT_TOKENS} tokens`
                 );

--- a/packages/core/src/llm/registry/index.ts
+++ b/packages/core/src/llm/registry/index.ts
@@ -225,9 +225,10 @@ export function getSupportedFileTypesForModel(
 export function modelSupportsFileType(
     provider: LLMProvider,
     model: string,
-    fileType: SupportedFileType
+    fileType: SupportedFileType,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): boolean {
-    return getSupportedFileTypesForModel(provider, model).includes(fileType);
+    return getSupportedFileTypesForModel(provider, model, undefined, registry).includes(fileType);
 }
 
 export function getMaxInputTokensForModel(
@@ -242,7 +243,11 @@ export function getMaxInputTokensForModel(
         return modelInfo.maxInputTokens;
     }
 
-    if ((provider === 'openrouter' || provider === 'dexto-nova') && model.includes('/')) {
+    if (
+        registry === DEFAULT_MODEL_REGISTRY &&
+        (provider === 'openrouter' || provider === 'dexto-nova') &&
+        model.includes('/')
+    ) {
         const contextLength = getOpenRouterModelContextLength(model);
         if (typeof contextLength === 'number') {
             logger?.debug(

--- a/packages/core/src/llm/resolver.ts
+++ b/packages/core/src/llm/resolver.ts
@@ -2,17 +2,13 @@ import { Result, hasErrors, splitIssues, ok, fail, zodToIssues } from '../utils/
 import { Issue, ErrorScope, ErrorType } from '../errors/types.js';
 import { LLMErrorCode } from './error-codes.js';
 
-import { type ValidatedLLMConfig, type LLMUpdates, type LLMConfig } from './schemas.js';
-import { LLMConfigSchema } from './schemas.js';
 import {
-    getDefaultModelForProvider,
-    acceptsAnyModel,
-    isValidProviderModel,
-    supportsBaseURL,
-    supportsCustomModels,
-    hasAllRegistryModelsSupport,
-    getProviderFromModel,
-} from '@dexto/llm';
+    type ValidatedLLMConfig,
+    type LLMUpdates,
+    type LLMConfig,
+    createLLMConfigSchema,
+} from './schemas.js';
+import { DEFAULT_MODEL_REGISTRY, type ModelRegistry } from '@dexto/llm';
 import { getEffectiveMaxInputTokens } from './registry/index.js';
 import {
     lookupOpenRouterModel,
@@ -32,16 +28,17 @@ import type { Logger } from '../logger/v2/types.js';
 export async function resolveAndValidateLLMConfig(
     previous: ValidatedLLMConfig,
     updates: LLMUpdates,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): Promise<Result<ValidatedLLMConfig, LLMUpdateContext>> {
-    const { candidate, warnings } = await resolveLLMConfig(previous, updates, logger);
+    const { candidate, warnings } = await resolveLLMConfig(previous, updates, logger, registry);
 
     // If resolver produced any errors, fail immediately (don't try to validate a broken candidate)
     if (hasErrors(warnings)) {
         const { errors } = splitIssues(warnings);
         return fail<ValidatedLLMConfig, LLMUpdateContext>(errors);
     }
-    const result = validateLLMConfig(candidate, warnings, logger);
+    const result = validateLLMConfig(candidate, warnings, logger, registry);
     return result;
 }
 
@@ -54,7 +51,8 @@ export async function resolveAndValidateLLMConfig(
 export async function resolveLLMConfig(
     previous: ValidatedLLMConfig,
     updates: LLMUpdates,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): Promise<{ candidate: LLMConfig; warnings: Issue<LLMUpdateContext>[] }> {
     const warnings: Issue<LLMUpdateContext>[] = [];
 
@@ -64,7 +62,7 @@ export async function resolveLLMConfig(
         (updates.model && !updates.model.includes('/')
             ? (() => {
                   try {
-                      return getProviderFromModel(updates.model);
+                      return registry.getProviderFromModel(updates.model);
                   } catch {
                       return previous.provider;
                   }
@@ -103,11 +101,11 @@ export async function resolveLLMConfig(
     let model = updates.model ?? previous.model;
     if (
         provider !== previous.provider &&
-        !acceptsAnyModel(provider) &&
-        !supportsCustomModels(provider) &&
-        !isValidProviderModel(provider, model)
+        !registry.acceptsAnyModel(provider) &&
+        !registry.supportsCustomModels(provider) &&
+        !registry.isValidProviderModel(provider, model)
     ) {
-        model = getDefaultModelForProvider(provider) ?? previous.model;
+        model = registry.getDefaultModelForProvider(provider) ?? previous.model;
         warnings.push({
             code: LLMErrorCode.MODEL_INCOMPATIBLE,
             message: `Model set to default '${model}' for provider '${provider}'`,
@@ -124,10 +122,10 @@ export async function resolveLLMConfig(
     if (
         provider !== previous.provider &&
         updates.model == null &&
-        hasAllRegistryModelsSupport(provider) &&
+        registry.hasAllRegistryModelsSupport(provider) &&
         !model.includes('/')
     ) {
-        const defaultGatewayModel = getDefaultModelForProvider(provider);
+        const defaultGatewayModel = registry.getDefaultModelForProvider(provider);
         if (defaultGatewayModel) {
             model = defaultGatewayModel;
             warnings.push({
@@ -146,7 +144,7 @@ export async function resolveLLMConfig(
     let baseURL: string | undefined;
     if (updates.baseURL) {
         baseURL = updates.baseURL;
-    } else if (supportsBaseURL(provider)) {
+    } else if (registry.supportsBaseURL(provider)) {
         baseURL = previous.baseURL;
     } else {
         baseURL = undefined;
@@ -191,8 +189,9 @@ export async function resolveLLMConfig(
         }
     }
 
-    // OpenRouter model validation with cache refresh
-    if (provider === 'openrouter') {
+    // The bundled default preserves the legacy OpenRouter cache behavior. A host-owned registry
+    // is already the validated source of truth and must not trigger a hidden network refresh.
+    if (provider === 'openrouter' && registry === DEFAULT_MODEL_REGISTRY) {
         let lookupStatus = lookupOpenRouterModel(model);
 
         if (lookupStatus === 'unknown') {
@@ -262,10 +261,11 @@ export async function resolveLLMConfig(
 export function validateLLMConfig(
     candidate: LLMConfig,
     warnings: Issue<LLMUpdateContext>[],
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): Result<ValidatedLLMConfig, LLMUpdateContext> {
     // Final validation (business rules + shape)
-    const parsed = LLMConfigSchema.safeParse(candidate);
+    const parsed = createLLMConfigSchema(registry).safeParse(candidate);
     if (!parsed.success) {
         return fail<ValidatedLLMConfig, LLMUpdateContext>(zodToIssues(parsed.error, 'error'));
     }
@@ -279,7 +279,8 @@ export function validateLLMConfig(
                 model: parsed.data.model,
                 baseURL: parsed.data.baseURL,
             },
-            logger
+            logger,
+            registry
         );
 
     // Note: Credentials (apiKey/baseURL) are validated at runtime when creating provider clients.

--- a/packages/core/src/llm/schemas.test.ts
+++ b/packages/core/src/llm/schemas.test.ts
@@ -14,6 +14,7 @@ import { LLMErrorCode } from './error-codes.js';
 import {
     LLMConfigSchema,
     LLMUpdatesSchema,
+    LLMUpdatesShapeSchema,
     type LLMConfig,
     type ValidatedLLMConfig,
 } from './schemas.js';
@@ -585,6 +586,16 @@ describe('LLMConfigSchema', () => {
                 } as const;
 
                 expect(() => LLMUpdatesSchema.parse(updates)).toThrow();
+            });
+
+            it('keeps shape validation separate from model compatibility validation', () => {
+                const updates = {
+                    provider: 'openai',
+                    model: 'gpt-5-pro',
+                    reasoning: { variant: 'none' },
+                } as const;
+
+                expect(LLMUpdatesShapeSchema.safeParse(updates).success).toBe(true);
             });
         });
     });

--- a/packages/core/src/llm/schemas.test.ts
+++ b/packages/core/src/llm/schemas.test.ts
@@ -573,6 +573,11 @@ describe('LLMConfigSchema', () => {
                 expect(() => LLMUpdatesSchema.parse(updates)).toThrow();
             });
 
+            it('should reject unknown update fields instead of silently dropping them', () => {
+                const updates = { model: 'gpt-5', unsupportedOption: true } as const;
+                expect(() => LLMUpdatesSchema.parse(updates)).toThrow();
+            });
+
             it('should pass validation when model/provider with other fields', () => {
                 const updates = { model: 'gpt-5', maxIterations: 10 };
                 expect(() => LLMUpdatesSchema.parse(updates)).not.toThrow();

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -281,68 +281,70 @@ export type ValidatedLLMConfig = z.output<typeof LLMConfigSchema>;
 // PATCH-like schema for updates (switch flows)
 
 // TODO: when moving to zod v4 we might be able to set this as strict
+const LLMUpdatesBaseSchema = z
+    .object({
+        ...LLMConfigFields,
+        // Special-case: allow `null` as an explicit "clear reasoning config" sentinel for switch flows.
+        // Full configs (LLMConfigSchema) still require `reasoning` to be an object when present.
+        reasoning: LLMConfigFields.reasoning.nullable(),
+    })
+    .partial();
+
+export const LLMUpdatesShapeSchema = LLMUpdatesBaseSchema.superRefine((data, ctx) => {
+    if (!data.model && !data.provider) {
+        ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'At least model or provider must be specified for LLM switch',
+            path: [],
+        });
+    }
+});
+
 export function createLLMUpdatesSchema(registry: ModelRegistry = DEFAULT_MODEL_REGISTRY) {
-    return z
-        .object({
-            ...LLMConfigFields,
-            // Special-case: allow `null` as an explicit "clear reasoning config" sentinel for switch flows.
-            // Full configs (LLMConfigSchema) still require `reasoning` to be an object when present.
-            reasoning: LLMConfigFields.reasoning.nullable(),
-        })
-        .partial()
-        .superRefine((data, ctx) => {
-            // Require at least one meaningful change field: model or provider
-            if (!data.model && !data.provider) {
+    return LLMUpdatesShapeSchema.superRefine((data, ctx) => {
+        // If we have enough context (provider+model), validate reasoning updates to avoid
+        // sending unsupported reasoning params at runtime.
+        if (
+            data.reasoning &&
+            data.reasoning !== null &&
+            typeof data.provider === 'string' &&
+            typeof data.model === 'string'
+        ) {
+            const profile = getReasoningProfile(data.provider, data.model, registry);
+            const variant = data.reasoning.variant;
+            const budgetTokens = data.reasoning.budgetTokens;
+
+            if (!supportsReasoningVariant(profile, variant)) {
                 ctx.addIssue({
                     code: z.ZodIssueCode.custom,
-                    message: 'At least model or provider must be specified for LLM switch',
-                    path: [],
+                    path: ['reasoning', 'variant'],
+                    message:
+                        `Reasoning variant '${variant}' is not supported for provider '${data.provider}' ` +
+                        `model '${data.model}'. Supported: ${profile.variants.map((entry) => entry.id).join(', ')}`,
+                    params: {
+                        code: LLMErrorCode.MODEL_INCOMPATIBLE,
+                        scope: ErrorScope.LLM,
+                        type: ErrorType.USER,
+                    },
                 });
             }
 
-            // If we have enough context (provider+model), validate reasoning updates to avoid
-            // sending unsupported reasoning params at runtime.
-            if (
-                data.reasoning &&
-                data.reasoning !== null &&
-                typeof data.provider === 'string' &&
-                typeof data.model === 'string'
-            ) {
-                const profile = getReasoningProfile(data.provider, data.model, registry);
-                const variant = data.reasoning.variant;
-                const budgetTokens = data.reasoning.budgetTokens;
-
-                if (!supportsReasoningVariant(profile, variant)) {
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['reasoning', 'variant'],
-                        message:
-                            `Reasoning variant '${variant}' is not supported for provider '${data.provider}' ` +
-                            `model '${data.model}'. Supported: ${profile.variants.map((entry) => entry.id).join(', ')}`,
-                        params: {
-                            code: LLMErrorCode.MODEL_INCOMPATIBLE,
-                            scope: ErrorScope.LLM,
-                            type: ErrorType.USER,
-                        },
-                    });
-                }
-
-                if (typeof budgetTokens === 'number' && !profile.supportsBudgetTokens) {
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['reasoning', 'budgetTokens'],
-                        message:
-                            `Reasoning budgetTokens are not supported for provider '${data.provider}' ` +
-                            `model '${data.model}'. Remove reasoning.budgetTokens to use provider defaults.`,
-                        params: {
-                            code: LLMErrorCode.MODEL_INCOMPATIBLE,
-                            scope: ErrorScope.LLM,
-                            type: ErrorType.USER,
-                        },
-                    });
-                }
+            if (typeof budgetTokens === 'number' && !profile.supportsBudgetTokens) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    path: ['reasoning', 'budgetTokens'],
+                    message:
+                        `Reasoning budgetTokens are not supported for provider '${data.provider}' ` +
+                        `model '${data.model}'. Remove reasoning.budgetTokens to use provider defaults.`,
+                    params: {
+                        code: LLMErrorCode.MODEL_INCOMPATIBLE,
+                        scope: ErrorScope.LLM,
+                        type: ErrorType.USER,
+                    },
+                });
             }
-        });
+        }
+    });
 }
 
 export const LLMUpdatesSchema = createLLMUpdatesSchema();

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -1,19 +1,14 @@
 import { LLMErrorCode } from './error-codes.js';
 import { ErrorScope, ErrorType } from '../errors/types.js';
-import { DextoRuntimeError } from '../errors/index.js';
 import { NonEmptyTrimmed, EnvExpandedString, OptionalURL } from '../utils/result.js';
 import { z } from 'zod';
 import {
-    supportsBaseURL,
-    acceptsAnyModel,
-    supportsCustomModels,
-    hasAllRegistryModelsSupport,
-    getSupportedModels,
+    DEFAULT_MODEL_REGISTRY,
+    type ModelRegistry,
     getReasoningProfile,
-    isValidProviderModel,
     supportsReasoningVariant,
+    LlmCatalogError,
 } from '@dexto/llm';
-import { getMaxInputTokensForModel } from './registry/index.js';
 import { LLM_PROVIDERS } from '@dexto/llm';
 
 /**
@@ -119,58 +114,40 @@ export const LLMConfigBaseSchema = z
  * - API keys and base URLs are validated at runtime (when creating a provider client), not at parse time.
  * - This keeps programmatic construction (code-first DI) ergonomic: you can omit credentials and rely on env.
  */
-export const LLMConfigSchema = LLMConfigBaseSchema.superRefine((data, ctx) => {
-    const baseURLIsSet = data.baseURL != null && data.baseURL.trim() !== '';
-    const maxInputTokensIsSet = data.maxInputTokens != null;
+export function createLLMConfigSchema(
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+): typeof LLMConfigBaseSchema {
+    return LLMConfigBaseSchema.superRefine((data, ctx) => {
+        const baseURLIsSet = data.baseURL != null && data.baseURL.trim() !== '';
+        const maxInputTokensIsSet = data.maxInputTokens != null;
 
-    // Gateway providers require OpenRouter-format model IDs ("provider/model").
-    // This avoids implicit transformation and makes the config unambiguous.
-    if (hasAllRegistryModelsSupport(data.provider) && !data.model.includes('/')) {
-        ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['model'],
-            message:
-                `Provider '${data.provider}' requires OpenRouter-format model IDs (e.g. ` +
-                `'openai/gpt-5-mini' or 'anthropic/claude-sonnet-4.5'). You provided '${data.model}'.`,
-            params: {
-                code: LLMErrorCode.MODEL_INCOMPATIBLE,
-                scope: ErrorScope.LLM,
-                type: ErrorType.USER,
-            },
-        });
-    }
-
-    if (baseURLIsSet) {
-        if (!supportsBaseURL(data.provider)) {
+        // Gateway providers require OpenRouter-format model IDs ("provider/model").
+        // This avoids implicit transformation and makes the config unambiguous.
+        if (registry.hasAllRegistryModelsSupport(data.provider) && !data.model.includes('/')) {
             ctx.addIssue({
                 code: z.ZodIssueCode.custom,
-                path: ['provider'],
+                path: ['model'],
                 message:
-                    `Provider '${data.provider}' does not support baseURL. ` +
-                    `Use an 'openai-compatible' provider if you need a custom base URL.`,
+                    `Provider '${data.provider}' requires OpenRouter-format model IDs (e.g. ` +
+                    `'openai/gpt-5-mini' or 'anthropic/claude-sonnet-4.5'). You provided '${data.model}'.`,
                 params: {
-                    code: LLMErrorCode.BASE_URL_INVALID,
+                    code: LLMErrorCode.MODEL_INCOMPATIBLE,
                     scope: ErrorScope.LLM,
                     type: ErrorType.USER,
                 },
             });
         }
-    }
 
-    // Model and token validation
-    if (!baseURLIsSet || supportsBaseURL(data.provider)) {
-        // Skip model validation for providers that accept any model OR support custom models
-        if (!acceptsAnyModel(data.provider) && !supportsCustomModels(data.provider)) {
-            const supportedModelsList = getSupportedModels(data.provider);
-            if (!isValidProviderModel(data.provider, data.model)) {
+        if (baseURLIsSet) {
+            if (!registry.supportsBaseURL(data.provider)) {
                 ctx.addIssue({
                     code: z.ZodIssueCode.custom,
-                    path: ['model'],
+                    path: ['provider'],
                     message:
-                        `Model '${data.model}' is not supported for provider '${data.provider}'. ` +
-                        `Supported: ${supportedModelsList.join(', ')}`,
+                        `Provider '${data.provider}' does not support baseURL. ` +
+                        `Use an 'openai-compatible' provider if you need a custom base URL.`,
                     params: {
-                        code: LLMErrorCode.MODEL_INCOMPATIBLE,
+                        code: LLMErrorCode.BASE_URL_INVALID,
                         scope: ErrorScope.LLM,
                         type: ErrorType.USER,
                     },
@@ -178,135 +155,86 @@ export const LLMConfigSchema = LLMConfigBaseSchema.superRefine((data, ctx) => {
             }
         }
 
-        // Skip token cap validation for providers that accept any model OR support custom models
-        if (
-            maxInputTokensIsSet &&
-            !acceptsAnyModel(data.provider) &&
-            !supportsCustomModels(data.provider)
-        ) {
-            try {
-                const cap = getMaxInputTokensForModel(data.provider, data.model);
-                if (data.maxInputTokens! > cap) {
+        // Model and token validation
+        if (!baseURLIsSet || registry.supportsBaseURL(data.provider)) {
+            // Skip model validation for providers that accept any model OR support custom models
+            if (
+                !registry.acceptsAnyModel(data.provider) &&
+                !registry.supportsCustomModels(data.provider)
+            ) {
+                const supportedModelsList = registry.getSupportedModels(data.provider);
+                if (!registry.isValidProviderModel(data.provider, data.model)) {
                     ctx.addIssue({
                         code: z.ZodIssueCode.custom,
-                        path: ['maxInputTokens'],
+                        path: ['model'],
                         message:
-                            `Max input tokens for model '${data.model}' is ${cap}. ` +
-                            `You provided ${data.maxInputTokens}`,
+                            `Model '${data.model}' is not supported for provider '${data.provider}'. ` +
+                            `Supported: ${supportedModelsList.join(', ')}`,
                         params: {
-                            code: LLMErrorCode.TOKENS_EXCEEDED,
+                            code: LLMErrorCode.MODEL_INCOMPATIBLE,
                             scope: ErrorScope.LLM,
                             type: ErrorType.USER,
                         },
                     });
                 }
-            } catch (error: unknown) {
-                if (
-                    error instanceof DextoRuntimeError &&
-                    error.code === LLMErrorCode.MODEL_UNKNOWN
-                ) {
-                    // Model not found in registry
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['model'],
-                        message: error.message,
-                        params: {
-                            code: error.code,
-                            scope: error.scope,
-                            type: error.type,
-                        },
-                    });
-                } else {
-                    // Unexpected error
-                    const message =
-                        error instanceof Error ? error.message : 'Unknown error occurred';
-                    ctx.addIssue({
-                        code: z.ZodIssueCode.custom,
-                        path: ['model'],
-                        message,
-                        params: {
-                            code: LLMErrorCode.REQUEST_INVALID_SCHEMA,
-                            scope: ErrorScope.LLM,
-                            type: ErrorType.SYSTEM,
-                        },
-                    });
+            }
+
+            // Skip token cap validation for providers that accept any model OR support custom models
+            if (
+                maxInputTokensIsSet &&
+                !registry.acceptsAnyModel(data.provider) &&
+                !registry.supportsCustomModels(data.provider)
+            ) {
+                try {
+                    const cap = registry.getMaxInputTokensForModel(data.provider, data.model);
+                    if (data.maxInputTokens! > cap) {
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ['maxInputTokens'],
+                            message:
+                                `Max input tokens for model '${data.model}' is ${cap}. ` +
+                                `You provided ${data.maxInputTokens}`,
+                            params: {
+                                code: LLMErrorCode.TOKENS_EXCEEDED,
+                                scope: ErrorScope.LLM,
+                                type: ErrorType.USER,
+                            },
+                        });
+                    }
+                } catch (error: unknown) {
+                    if (error instanceof LlmCatalogError && error.code === 'MODEL_UNKNOWN') {
+                        // Model not found in registry
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ['model'],
+                            message: error.message,
+                            params: {
+                                code: LLMErrorCode.MODEL_UNKNOWN,
+                                scope: ErrorScope.LLM,
+                                type: ErrorType.USER,
+                            },
+                        });
+                    } else {
+                        // Unexpected error
+                        const message =
+                            error instanceof Error ? error.message : 'Unknown error occurred';
+                        ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: ['model'],
+                            message,
+                            params: {
+                                code: LLMErrorCode.REQUEST_INVALID_SCHEMA,
+                                scope: ErrorScope.LLM,
+                                type: ErrorType.SYSTEM,
+                            },
+                        });
+                    }
                 }
             }
         }
-    }
 
-    if (data.reasoning) {
-        const profile = getReasoningProfile(data.provider, data.model);
-        const variant = data.reasoning.variant;
-        const budgetTokens = data.reasoning.budgetTokens;
-
-        if (!supportsReasoningVariant(profile, variant)) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['reasoning', 'variant'],
-                message:
-                    `Reasoning variant '${variant}' is not supported for provider '${data.provider}' ` +
-                    `model '${data.model}'. Supported: ${profile.variants.map((entry) => entry.id).join(', ')}`,
-                params: {
-                    code: LLMErrorCode.MODEL_INCOMPATIBLE,
-                    scope: ErrorScope.LLM,
-                    type: ErrorType.USER,
-                },
-            });
-        }
-
-        if (typeof budgetTokens === 'number' && !profile.supportsBudgetTokens) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                path: ['reasoning', 'budgetTokens'],
-                message:
-                    `Reasoning budgetTokens are not supported for provider '${data.provider}' ` +
-                    `model '${data.model}'. Remove reasoning.budgetTokens to use provider defaults.`,
-                params: {
-                    code: LLMErrorCode.MODEL_INCOMPATIBLE,
-                    scope: ErrorScope.LLM,
-                    type: ErrorType.USER,
-                },
-            });
-        }
-    }
-    // Note: OpenRouter model validation happens in resolver.ts during switchLLM only
-    // to avoid network calls during startup/serverless cold starts
-});
-
-// Input type and output types for the zod schema
-export type LLMConfig = z.input<typeof LLMConfigSchema>;
-export type ValidatedLLMConfig = z.output<typeof LLMConfigSchema>;
-// PATCH-like schema for updates (switch flows)
-
-// TODO: when moving to zod v4 we might be able to set this as strict
-export const LLMUpdatesSchema = z
-    .object({
-        ...LLMConfigFields,
-        // Special-case: allow `null` as an explicit "clear reasoning config" sentinel for switch flows.
-        // Full configs (LLMConfigSchema) still require `reasoning` to be an object when present.
-        reasoning: LLMConfigFields.reasoning.nullable(),
-    })
-    .partial()
-    .superRefine((data, ctx) => {
-        // Require at least one meaningful change field: model or provider
-        if (!data.model && !data.provider) {
-            ctx.addIssue({
-                code: z.ZodIssueCode.custom,
-                message: 'At least model or provider must be specified for LLM switch',
-                path: [],
-            });
-        }
-
-        // If we have enough context (provider+model), validate reasoning updates to avoid
-        // sending unsupported reasoning params at runtime.
-        if (
-            data.reasoning &&
-            data.reasoning !== null &&
-            typeof data.provider === 'string' &&
-            typeof data.model === 'string'
-        ) {
-            const profile = getReasoningProfile(data.provider, data.model);
+        if (data.reasoning) {
+            const profile = getReasoningProfile(data.provider, data.model, registry);
             const variant = data.reasoning.variant;
             const budgetTokens = data.reasoning.budgetTokens;
 
@@ -340,6 +268,83 @@ export const LLMUpdatesSchema = z
                 });
             }
         }
+        // Note: OpenRouter model validation happens in resolver.ts during switchLLM only
+        // to avoid network calls during startup/serverless cold starts
     });
+}
+
+export const LLMConfigSchema = createLLMConfigSchema();
+
+// Input type and output types for the zod schema
+export type LLMConfig = z.input<typeof LLMConfigSchema>;
+export type ValidatedLLMConfig = z.output<typeof LLMConfigSchema>;
+// PATCH-like schema for updates (switch flows)
+
+// TODO: when moving to zod v4 we might be able to set this as strict
+export function createLLMUpdatesSchema(registry: ModelRegistry = DEFAULT_MODEL_REGISTRY) {
+    return z
+        .object({
+            ...LLMConfigFields,
+            // Special-case: allow `null` as an explicit "clear reasoning config" sentinel for switch flows.
+            // Full configs (LLMConfigSchema) still require `reasoning` to be an object when present.
+            reasoning: LLMConfigFields.reasoning.nullable(),
+        })
+        .partial()
+        .superRefine((data, ctx) => {
+            // Require at least one meaningful change field: model or provider
+            if (!data.model && !data.provider) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: 'At least model or provider must be specified for LLM switch',
+                    path: [],
+                });
+            }
+
+            // If we have enough context (provider+model), validate reasoning updates to avoid
+            // sending unsupported reasoning params at runtime.
+            if (
+                data.reasoning &&
+                data.reasoning !== null &&
+                typeof data.provider === 'string' &&
+                typeof data.model === 'string'
+            ) {
+                const profile = getReasoningProfile(data.provider, data.model, registry);
+                const variant = data.reasoning.variant;
+                const budgetTokens = data.reasoning.budgetTokens;
+
+                if (!supportsReasoningVariant(profile, variant)) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['reasoning', 'variant'],
+                        message:
+                            `Reasoning variant '${variant}' is not supported for provider '${data.provider}' ` +
+                            `model '${data.model}'. Supported: ${profile.variants.map((entry) => entry.id).join(', ')}`,
+                        params: {
+                            code: LLMErrorCode.MODEL_INCOMPATIBLE,
+                            scope: ErrorScope.LLM,
+                            type: ErrorType.USER,
+                        },
+                    });
+                }
+
+                if (typeof budgetTokens === 'number' && !profile.supportsBudgetTokens) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        path: ['reasoning', 'budgetTokens'],
+                        message:
+                            `Reasoning budgetTokens are not supported for provider '${data.provider}' ` +
+                            `model '${data.model}'. Remove reasoning.budgetTokens to use provider defaults.`,
+                        params: {
+                            code: LLMErrorCode.MODEL_INCOMPATIBLE,
+                            scope: ErrorScope.LLM,
+                            type: ErrorType.USER,
+                        },
+                    });
+                }
+            }
+        });
+}
+
+export const LLMUpdatesSchema = createLLMUpdatesSchema();
 export type LLMUpdates = z.input<typeof LLMUpdatesSchema>;
 export type { LLMUpdateContext } from '@dexto/llm';

--- a/packages/core/src/llm/schemas.ts
+++ b/packages/core/src/llm/schemas.ts
@@ -280,7 +280,6 @@ export type LLMConfig = z.input<typeof LLMConfigSchema>;
 export type ValidatedLLMConfig = z.output<typeof LLMConfigSchema>;
 // PATCH-like schema for updates (switch flows)
 
-// TODO: when moving to zod v4 we might be able to set this as strict
 const LLMUpdatesBaseSchema = z
     .object({
         ...LLMConfigFields,
@@ -288,7 +287,8 @@ const LLMUpdatesBaseSchema = z
         // Full configs (LLMConfigSchema) still require `reasoning` to be an object when present.
         reasoning: LLMConfigFields.reasoning.nullable(),
     })
-    .partial();
+    .partial()
+    .strict();
 
 export const LLMUpdatesShapeSchema = LLMUpdatesBaseSchema.superRefine((data, ctx) => {
     if (!data.model && !data.provider) {

--- a/packages/core/src/llm/services/factory.ts
+++ b/packages/core/src/llm/services/factory.ts
@@ -503,6 +503,7 @@ export async function createLLMService(
 
     const providerContext: DextoProviderContext = {
         sessionId,
+        ...(options.llmRegistry !== undefined ? { llmRegistry: options.llmRegistry } : {}),
         ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
         authResolver: options.authResolver ?? null,
         logger,
@@ -535,6 +536,7 @@ export async function createLLMService(
         followUpQueue,
         usageScopeId,
         executionControl,
-        compactionStrategy
+        compactionStrategy,
+        options.llmRegistry
     );
 }

--- a/packages/core/src/llm/services/types.ts
+++ b/packages/core/src/llm/services/types.ts
@@ -5,6 +5,7 @@ import type { ValidatedLLMConfig } from '../schemas.js';
 import type { LlmAuthResolver } from '../auth/types.js';
 import type { Logger } from '../../logger/v2/types.js';
 import type { LLMProvider } from '@dexto/llm';
+import type { ModelRegistry } from '@dexto/llm';
 import type { MessageQueueService } from '../../session/message-queue.js';
 import type { AgentRunContext } from '../../runtime/run-context.js';
 import type { TurnDriverState } from '../executor/turn-executor.js';
@@ -27,6 +28,7 @@ export interface CreateLLMServiceOptions {
     authResolver?: LlmAuthResolver | null | undefined;
     steerQueue: MessageQueueService;
     followUpQueue: MessageQueueService;
+    llmRegistry?: ModelRegistry;
 }
 
 export type LLMExecutionControl = {
@@ -56,6 +58,8 @@ export interface DextoProviderContext {
     cwd?: string;
     /** Runtime auth resolver for profile-backed API keys, OAuth, and external accounts. */
     authResolver?: LlmAuthResolver | null;
+    /** Registry selected by the host for this agent/session. */
+    llmRegistry?: ModelRegistry;
     /** Logger for non-secret runtime provider/auth observability. */
     logger?: Logger | undefined;
     /** Optional callback for ChatGPT Login rate-limit status updates from Codex. */

--- a/packages/core/src/llm/services/vercel.ts
+++ b/packages/core/src/llm/services/vercel.ts
@@ -24,6 +24,7 @@ import { LLMErrorCode } from '../error-codes.js';
 import type { ContentInput } from '../../agent/types.js';
 import type { AgentRunContext } from '../../runtime/run-context.js';
 import { recordOperationSpan } from '../../telemetry/operation-span.js';
+import { DEFAULT_MODEL_REGISTRY, type ModelRegistry } from '@dexto/llm';
 
 export function ensureRunContextMatchesServiceSession(
     serviceSessionId: string,
@@ -80,6 +81,7 @@ export class VercelLLMService {
     private modelLimits?: ModelLimits;
     private readonly usageScopeId: string | undefined;
     private readonly executionControl: LLMExecutionControl | undefined;
+    private readonly llmRegistry: ModelRegistry;
 
     /**
      * Helper to extract model ID from LanguageModel union type (string | LanguageModelV2)
@@ -102,7 +104,8 @@ export class VercelLLMService {
         followUpQueue: MessageQueueService,
         usageScopeId?: string,
         executionControl?: LLMExecutionControl,
-        compactionStrategy?: import('../../context/compaction/types.js').CompactionStrategy | null
+        compactionStrategy?: import('../../context/compaction/types.js').CompactionStrategy | null,
+        llmRegistry: ModelRegistry = DEFAULT_MODEL_REGISTRY
     ) {
         this.logger = logger.createChild(DextoLogComponent.LLM);
         this.model = model;
@@ -113,14 +116,15 @@ export class VercelLLMService {
         this.resourceManager = resourceManager;
         this.usageScopeId = usageScopeId;
         this.executionControl = executionControl;
+        this.llmRegistry = llmRegistry;
         this.compactionStrategy = compactionStrategy ?? null;
 
         this.steerQueue = steerQueue;
         this.followUpQueue = followUpQueue;
 
         // Create properly-typed ContextManager for Vercel
-        const formatter = new VercelMessageFormatter(this.logger);
-        const maxInputTokens = getEffectiveMaxInputTokens(config, this.logger);
+        const formatter = new VercelMessageFormatter(this.logger, this.llmRegistry);
+        const maxInputTokens = getEffectiveMaxInputTokens(config, this.logger, this.llmRegistry);
 
         // Set model limits for compaction overflow detection (if enabled)
         if (this.compactionStrategy) {
@@ -135,7 +139,8 @@ export class VercelLLMService {
             conversationStore,
             sessionId,
             resourceManager,
-            this.logger
+            this.logger,
+            this.llmRegistry
         );
 
         this.logger.debug(
@@ -214,10 +219,14 @@ export class VercelLLMService {
                 ...(this.executionControl !== undefined && {
                     executionControl: this.executionControl,
                 }),
+                llmRegistry: this.llmRegistry,
                 // Provider-specific options
                 reasoning: this.config.reasoning,
             },
-            { provider: this.config.provider, model: this.getModelId() },
+            {
+                provider: this.config.provider,
+                model: this.getModelId(),
+            },
             this.logger,
             this.steerQueue,
             this.followUpQueue,
@@ -324,7 +333,8 @@ export class VercelLLMService {
             modelMaxInputTokens = getMaxInputTokensForModel(
                 this.config.provider,
                 this.getModelId(),
-                this.logger
+                this.logger,
+                this.llmRegistry
             );
         } catch (error) {
             // if the model is not found in the LLM registry, log and default to configured max tokens

--- a/packages/core/src/llm/usage-metadata.ts
+++ b/packages/core/src/llm/usage-metadata.ts
@@ -1,4 +1,9 @@
-import { calculateCostBreakdown, getModelPricing, type TokenUsageCostBreakdown } from '@dexto/llm';
+import {
+    calculateCostBreakdown,
+    DEFAULT_MODEL_REGISTRY,
+    type ModelRegistry,
+    type TokenUsageCostBreakdown,
+} from '@dexto/llm';
 import type { LLMProvider, LLMPricingStatus, TokenUsage } from '@dexto/llm';
 
 export interface LLMUsagePricingMetadata {
@@ -44,14 +49,15 @@ export function getUsagePricingMetadata(config: {
     provider?: LLMProvider;
     model?: string;
     tokenUsage?: TokenUsage;
+    llmRegistry?: ModelRegistry;
 }): LLMUsagePricingMetadata {
-    const { provider, model, tokenUsage } = config;
+    const { provider, model, tokenUsage, llmRegistry = DEFAULT_MODEL_REGISTRY } = config;
 
     if (!provider || !model || !tokenUsage || !hasMeaningfulTokenUsage(tokenUsage)) {
         return {};
     }
 
-    const pricing = getModelPricing(provider, model);
+    const pricing = llmRegistry.getModelPricing(provider, model);
     if (!pricing) {
         return { pricingStatus: 'unpriced' };
     }

--- a/packages/core/src/llm/validation.ts
+++ b/packages/core/src/llm/validation.ts
@@ -1,5 +1,10 @@
-import { getAllowedMimeTypes, validateModelFileSupport } from '@dexto/llm';
-import type { LLMProvider } from '@dexto/llm';
+import {
+    DEFAULT_MODEL_REGISTRY,
+    getAllowedMimeTypes,
+    validateModelFileSupport,
+    type LLMProvider,
+    type ModelRegistry,
+} from '@dexto/llm';
 import type { Logger } from '../logger/v2/types.js';
 import type { ImageData, FileData } from '../context/types.js';
 import { Result, ok, fail } from '../utils/result.js';
@@ -10,6 +15,7 @@ import { LLMErrorCode } from './error-codes.js';
 export interface ValidationLLMConfig {
     provider: LLMProvider;
     model?: string;
+    llmRegistry?: ModelRegistry;
 }
 
 export interface ValidationContext {
@@ -59,7 +65,8 @@ const MAX_IMAGE_SIZE = 20971520; // 20MB
 export function validateInputForLLM(
     input: ValidationInput,
     config: ValidationLLMConfig,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry = config.llmRegistry ?? DEFAULT_MODEL_REGISTRY
 ): Result<ValidationData, ValidationContext> {
     const issues: Issue<ValidationContext>[] = [];
     const validationData: ValidationData = {};
@@ -72,7 +79,7 @@ export function validateInputForLLM(
 
         // Validate file data if provided
         if (input.fileData) {
-            const fileValidation = validateFileInput(input.fileData, config, logger);
+            const fileValidation = validateFileInput(input.fileData, config, logger, registry);
             validationData.fileValidation = fileValidation;
 
             if (!fileValidation.isSupported) {
@@ -95,7 +102,7 @@ export function validateInputForLLM(
 
         // Validate image data if provided
         if (input.imageData) {
-            const imageValidation = validateImageInput(input.imageData, config, logger);
+            const imageValidation = validateImageInput(input.imageData, config, logger, registry);
             validationData.imageValidation = imageValidation;
 
             if (!imageValidation.isSupported) {
@@ -147,7 +154,8 @@ export function validateInputForLLM(
 function validateFileInput(
     fileData: FileData,
     config: ValidationLLMConfig,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry
 ): NonNullable<ValidationData['fileValidation']> {
     logger.info(`Validating file input: ${fileData.mimeType}`);
 
@@ -185,7 +193,7 @@ function validateFileInput(
 
     // Model-specific capability validation (only if model is specified)
     if (config.model) {
-        return validateModelFileSupport(config.provider, config.model, fileData.mimeType);
+        return validateModelFileSupport(config.provider, config.model, fileData.mimeType, registry);
     }
 
     // If no model specified, we cannot validate capabilities
@@ -205,7 +213,8 @@ function validateFileInput(
 function validateImageInput(
     imageData: ImageData,
     config: ValidationLLMConfig,
-    logger: Logger
+    logger: Logger,
+    registry: ModelRegistry
 ): NonNullable<ValidationData['imageValidation']> {
     logger.info(`Validating image input: ${imageData.mimeType}`);
 
@@ -244,7 +253,7 @@ function validateImageInput(
     const baseMimeType = resolvedMime.split(';')[0]?.trim() || resolvedMime;
 
     // Delegate both allowed-MIME and model capability to registry helper
-    const res = validateModelFileSupport(config.provider, config.model, baseMimeType);
+    const res = validateModelFileSupport(config.provider, config.model, baseMimeType, registry);
     return {
         isSupported: res.isSupported,
         ...(res.error ? { error: res.error } : {}),

--- a/packages/core/src/session/chat-session.test.ts
+++ b/packages/core/src/session/chat-session.test.ts
@@ -15,6 +15,7 @@ import { ErrorScope, ErrorType } from '../errors/types.js';
 import type { SessionEventMap } from '../events/index.js';
 import { DextoRuntimeError } from '../errors/DextoRuntimeError.js';
 import { HookErrorCode } from '../hooks/error-codes.js';
+import { createModelRegistry, LLM_REGISTRY } from '@dexto/llm';
 
 // Mock all dependencies
 vi.mock('../llm/services/factory.js', () => ({
@@ -1210,6 +1211,48 @@ describe('ChatSession', () => {
                     provider: payloadProvider,
                     model: payloadModel,
                 })
+            );
+        });
+
+        test('calculates usage cost from the injected registry when the event has no estimate', async () => {
+            const bundledModel = LLM_REGISTRY.openai.models[0];
+            if (!bundledModel)
+                throw new Error('Expected the bundled OpenAI registry to be populated');
+
+            mockServices.llmRegistry = createModelRegistry({
+                ...LLM_REGISTRY,
+                openai: {
+                    ...LLM_REGISTRY.openai,
+                    models: [
+                        {
+                            ...bundledModel,
+                            name: 'cloud-added-model',
+                            pricing: { inputPerM: 12, outputPerM: 34 },
+                        },
+                    ],
+                },
+            });
+
+            chatSession.eventBus.emit(
+                'llm:response',
+                createModelResponseEvent({
+                    provider: 'openai',
+                    model: 'cloud-added-model',
+                    tokenUsage: {
+                        inputTokens: 1_000_000,
+                        outputTokens: 1_000_000,
+                        totalTokens: 2_000_000,
+                    },
+                })
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(mockServices.sessionManager.accumulateTokenUsage).toHaveBeenCalledWith(
+                sessionId,
+                expect.any(Object),
+                46,
+                { provider: 'openai', model: 'cloud-added-model' }
             );
         });
 

--- a/packages/core/src/session/chat-session.ts
+++ b/packages/core/src/session/chat-session.ts
@@ -11,6 +11,8 @@ import type {
     LanguageModelFactory,
 } from '../llm/services/types.js';
 import type { LlmAuthResolver } from '../llm/auth/index.js';
+import type { ModelRegistry } from '@dexto/llm';
+import { DEFAULT_MODEL_REGISTRY } from '@dexto/llm';
 import type { SystemPromptManager } from '../systemPrompt/manager.js';
 import type { ToolManager } from '../tools/tool-manager.js';
 import type { ValidatedLLMConfig } from '../llm/schemas.js';
@@ -185,6 +187,7 @@ export class ChatSession {
             followUpQueueStore: SessionMessageQueueStore;
             languageModelFactory?: LanguageModelFactory;
             authResolver?: LlmAuthResolver | null;
+            llmRegistry?: ModelRegistry;
             workspaceManager?: import('../workspace/manager.js').WorkspaceManager;
             compactionStrategy: CompactionStrategy | null;
             executionControl?: LLMExecutionControl | undefined;
@@ -329,6 +332,7 @@ export class ChatSession {
             steerQueue: this.steerQueue,
             followUpQueue: this.followUpQueue,
             authResolver: this.services.authResolver ?? null,
+            llmRegistry: this.services.llmRegistry ?? DEFAULT_MODEL_REGISTRY,
         };
 
         return createLLMService(

--- a/packages/core/src/session/chat-session.ts
+++ b/packages/core/src/session/chat-session.ts
@@ -279,6 +279,9 @@ export class ChatSession {
                 provider: modelInfo.provider,
                 model: modelInfo.model,
                 tokenUsage,
+                ...(this.services.llmRegistry === undefined
+                    ? {}
+                    : { llmRegistry: this.services.llmRegistry }),
             });
 
             // Fire and forget - don't block the event flow

--- a/packages/core/src/session/session-manager.ts
+++ b/packages/core/src/session/session-manager.ts
@@ -23,6 +23,8 @@ import {
 import type { SessionMessageQueueStore } from '../storage/message-queue/types.js';
 import type { ConversationStore } from '../storage/conversation/types.js';
 import type { SessionStore } from '../storage/sessions/types.js';
+import type { ModelRegistry } from '@dexto/llm';
+import { DEFAULT_MODEL_REGISTRY } from '@dexto/llm';
 export type SessionLoggerFactory = (options: {
     baseLogger: Logger;
     agentId: string;
@@ -160,6 +162,7 @@ export class SessionManager {
             followUpQueueStore: SessionMessageQueueStore;
             compactionStrategy: CompactionStrategy | null;
             workspaceManager?: import('../workspace/manager.js').WorkspaceManager;
+            llmRegistry?: ModelRegistry;
         },
         config: SessionManagerConfig = {},
         logger: Logger
@@ -181,6 +184,7 @@ export class SessionManager {
                 languageModelFactory: this.languageModelFactory,
             }),
             authResolver: this.authResolver,
+            llmRegistry: this.services.llmRegistry ?? DEFAULT_MODEL_REGISTRY,
             ...(this.executionControl !== undefined && {
                 executionControl: this.executionControl,
             }),

--- a/packages/core/src/utils/service-initializer.ts
+++ b/packages/core/src/utils/service-initializer.ts
@@ -33,6 +33,7 @@ import type { CompactionStrategy } from '../context/compaction/types.js';
 import { SessionToolPreferencesStore } from '../tools/session-tool-preferences-store.js';
 import type { LLMExecutionControl, LanguageModelFactory } from '../llm/services/types.js';
 import type { WorkspaceHandleProvider } from '../workspace/types.js';
+import type { ModelRegistry } from '@dexto/llm';
 
 /**
  * Type for the core agent services returned by createAgentServices
@@ -126,7 +127,8 @@ export async function createAgentServices(
     logger: Logger,
     agentEventBus: AgentEventBus,
     overrides?: InitializeServicesOptions,
-    compactionStrategy?: CompactionStrategy | null | undefined
+    compactionStrategy?: CompactionStrategy | null | undefined,
+    llmRegistry?: ModelRegistry | undefined
 ): Promise<AgentServices> {
     // 0. Initialize telemetry FIRST (before any decorated classes are instantiated)
     // This must happen before creating any services that use @InstrumentClass decorator
@@ -317,6 +319,7 @@ export async function createAgentServices(
             followUpQueueStore,
             compactionStrategy: compactionStrategy ?? null,
             workspaceManager, // Workspace context propagation
+            ...(llmRegistry !== undefined ? { llmRegistry } : {}),
         },
         {
             maxSessions: config.sessions?.maxSessions,

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -31,6 +31,7 @@
     "sideEffects": false,
     "devDependencies": {
         "tsup": "^8.0.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^3.1.3"
     }
 }

--- a/packages/llm/src/reasoning/profile.ts
+++ b/packages/llm/src/reasoning/profile.ts
@@ -1,5 +1,5 @@
 import type { LLMProvider } from '../types.js';
-import { isReasoningCapableModel } from '../registry/index.js';
+import { DEFAULT_MODEL_REGISTRY, type ModelRegistry } from '../registry/index.js';
 import { isAnthropicAdaptiveThinkingModel, parseClaudeVersion } from './anthropic-thinking.js';
 import { buildAnthropicReasoningProfile } from './profiles/anthropic.js';
 import { buildBedrockReasoningProfile } from './profiles/bedrock.js';
@@ -33,32 +33,37 @@ const GOOGLE_PROFILE_CONFIG = {
 
 function isAnthropicStyleReasoningCapable(
     provider: 'anthropic' | 'vertex',
-    model: string
+    model: string,
+    registry: ModelRegistry
 ): boolean {
     return (
-        isReasoningCapableModel(model, provider) ||
+        registry.isReasoningCapableModel(model, provider) ||
         parseClaudeVersion(model) !== null ||
         isAnthropicAdaptiveThinkingModel(model)
     );
 }
 
-function getNativeReasoningProfile(provider: LLMProvider, model: string): ReasoningProfile {
+function getNativeReasoningProfile(
+    provider: LLMProvider,
+    model: string,
+    registry: ModelRegistry
+): ReasoningProfile {
     switch (provider) {
         case 'openai':
-            if (!isReasoningCapableModel(model, 'openai')) {
+            if (!registry.isReasoningCapableModel(model, 'openai')) {
                 return nonCapableProfile();
             }
             return buildOpenAIReasoningProfile(model);
 
         case 'anthropic':
-            if (!isAnthropicStyleReasoningCapable('anthropic', model)) {
+            if (!isAnthropicStyleReasoningCapable('anthropic', model, registry)) {
                 return nonCapableProfile();
             }
             return buildAnthropicReasoningProfile({ model, ...ANTHROPIC_PROFILE_CONFIG });
 
         case 'bedrock':
             if (
-                !isReasoningCapableModel(model, 'bedrock') &&
+                !registry.isReasoningCapableModel(model, 'bedrock') &&
                 !model.toLowerCase().includes('nova')
             ) {
                 return nonCapableProfile();
@@ -66,19 +71,19 @@ function getNativeReasoningProfile(provider: LLMProvider, model: string): Reason
             return buildBedrockReasoningProfile(model);
 
         case 'google':
-            if (!isReasoningCapableModel(model, 'google')) {
+            if (!registry.isReasoningCapableModel(model, 'google')) {
                 return nonCapableProfile();
             }
             return buildGoogleReasoningProfile({ model, ...GOOGLE_PROFILE_CONFIG });
 
         case 'vertex':
-            if (!isAnthropicStyleReasoningCapable('vertex', model)) {
+            if (!isAnthropicStyleReasoningCapable('vertex', model, registry)) {
                 return nonCapableProfile();
             }
             return buildVertexReasoningProfile(model);
 
         case 'openai-compatible':
-            if (!isReasoningCapableModel(model, 'openai-compatible')) {
+            if (!registry.isReasoningCapableModel(model, 'openai-compatible')) {
                 return nonCapableProfile();
             }
             return buildOpenAICompatibleReasoningProfile();
@@ -117,18 +122,26 @@ function toGatewayReasoningProfile(nativeProfile: ReasoningProfile): ReasoningPr
  * - No generic preset abstraction at this layer
  * - No guessed variants for unknown paradigms
  */
-export function getReasoningProfile(provider: LLMProvider, model: string): ReasoningProfile {
+export function getReasoningProfile(
+    provider: LLMProvider,
+    model: string,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+): ReasoningProfile {
     if (isOpenRouterGatewayProvider(provider)) {
         const target = getOpenRouterReasoningTarget(model);
         if (!target) {
             return nonCapableProfile();
         }
 
-        const nativeProfile = getNativeReasoningProfile(target.upstreamProvider, target.modelId);
+        const nativeProfile = getNativeReasoningProfile(
+            target.upstreamProvider,
+            target.modelId,
+            registry
+        );
         return toGatewayReasoningProfile(nativeProfile);
     }
 
-    return getNativeReasoningProfile(provider, model);
+    return getNativeReasoningProfile(provider, model, registry);
 }
 
 export function supportsReasoningVariant(profile: ReasoningProfile, variant: string): boolean {

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -54,6 +54,24 @@ function modelProviderUnknown(model: string): LlmCatalogError {
     return new LlmCatalogError('MODEL_UNKNOWN', `Could not infer provider for model '${model}'`);
 }
 
+const MODEL_PRICING_FIELDS = [
+    'inputPerM',
+    'outputPerM',
+    'cacheReadPerM',
+    'cacheWritePerM',
+    'reasoningPerM',
+    'inputAudioPerM',
+    'outputAudioPerM',
+] as const;
+
+const LONG_CONTEXT_PRICING_FIELDS = [
+    'inputTokensAbove',
+    'inputPerM',
+    'outputPerM',
+    'cacheReadPerM',
+    'cacheWritePerM',
+] as const;
+
 function getNormalizedModelIdForLookup(model: string): string {
     const stripped = stripBedrockRegionPrefix(model);
     return stripped.toLowerCase();
@@ -489,7 +507,8 @@ export class ModelRegistry {
 
     getModelPricing(provider: LLMProvider, model: string): ModelPricing | undefined {
         if (this.acceptsAnyModel(provider)) return undefined;
-        return findModelInfoInRegistry(this.#providers, provider, model)?.pricing;
+        const modelInfo = findModelInfoInRegistry(this.#providers, provider, model);
+        return modelInfo?.pricing ? cloneModelInfo(modelInfo).pricing : undefined;
     }
 
     isReasoningCapableModel(model: string, provider?: LLMProvider): boolean {
@@ -616,7 +635,7 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
     for (const provider of LLM_PROVIDERS) {
         const providerInfo = providers[provider];
         if (
-            !providerInfo ||
+            !isRecord(providerInfo) ||
             !Array.isArray(providerInfo.models) ||
             !['none', 'optional', 'required'].includes(providerInfo.baseURLSupport) ||
             !Array.isArray(providerInfo.supportedFileTypes)
@@ -627,33 +646,70 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
             );
         }
 
-        for (const model of providerInfo.models) {
+        for (const [modelIndex, model] of providerInfo.models.entries()) {
+            const modelObject = isRecord(model) ? model : null;
+            const modelName =
+                modelObject && typeof modelObject.name === 'string'
+                    ? modelObject.name
+                    : `<index ${modelIndex}>`;
+
             if (
-                model.name.trim().length === 0 ||
-                !Number.isInteger(model.maxInputTokens) ||
-                model.maxInputTokens < 0
+                !modelObject ||
+                typeof modelObject.name !== 'string' ||
+                modelObject.name.trim().length === 0 ||
+                !Number.isInteger(modelObject.maxInputTokens) ||
+                modelObject.maxInputTokens < 0 ||
+                !Array.isArray(modelObject.supportedFileTypes) ||
+                !modelObject.supportedFileTypes.every((fileType) => typeof fileType === 'string')
             ) {
                 throw new LlmCatalogError(
                     'REGISTRY_INVALID',
-                    `Invalid registry model definition for '${provider}/${model.name}'`
+                    `Invalid registry model definition for '${provider}/${modelName}'`
                 );
             }
 
-            const pricing = model.pricing;
-            if (
-                pricing &&
-                (!Number.isFinite(pricing.inputPerM) ||
-                    pricing.inputPerM < 0 ||
-                    !Number.isFinite(pricing.outputPerM) ||
-                    pricing.outputPerM < 0)
-            ) {
+            if (!isValidModelPricing(modelObject.pricing)) {
                 throw new LlmCatalogError(
                     'REGISTRY_INVALID',
-                    `Invalid registry pricing for '${provider}/${model.name}'`
+                    `Invalid registry pricing for '${provider}/${modelName}'`
                 );
             }
         }
     }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isValidPricingNumber(value: unknown): value is number {
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isValidModelPricing(value: unknown): boolean {
+    if (value === undefined) return true;
+    if (!isRecord(value)) return false;
+
+    for (const field of MODEL_PRICING_FIELDS) {
+        if (field in value && !isValidPricingNumber(value[field])) return false;
+    }
+    if (!isValidPricingNumber(value.inputPerM) || !isValidPricingNumber(value.outputPerM)) {
+        return false;
+    }
+
+    const longContextPricing = value.contextOver200kPerM;
+    if (longContextPricing === undefined) return true;
+    if (!isRecord(longContextPricing)) return false;
+
+    for (const field of LONG_CONTEXT_PRICING_FIELDS) {
+        if (field in longContextPricing && !isValidPricingNumber(longContextPricing[field])) {
+            return false;
+        }
+    }
+    return (
+        isValidPricingNumber(longContextPricing.inputPerM) &&
+        isValidPricingNumber(longContextPricing.outputPerM)
+    );
 }
 
 function findModelInfoInRegistry(

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -445,9 +445,20 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
 };
 
 export class ModelRegistry {
-    readonly #providers: Record<LLMProvider, ProviderInfo>;
+    #providers: Record<LLMProvider, ProviderInfo>;
 
     constructor(providers: Record<LLMProvider, ProviderInfo>) {
+        validateRegistryProviders(providers);
+        this.#providers = cloneRegistryProviders(providers);
+    }
+
+    /**
+     * Replaces the active provider snapshot after validating and cloning it.
+     *
+     * Hosts that refresh the bundled registry can update the shared default instance without
+     * exposing mutable provider records to consumers that already hold a ModelRegistry reference.
+     */
+    replaceProviders(providers: Record<LLMProvider, ProviderInfo>): void {
         validateRegistryProviders(providers);
         this.#providers = cloneRegistryProviders(providers);
     }
@@ -1152,9 +1163,11 @@ export function supportsCustomModels(provider: LLMProvider): boolean {
  * @param provider The name of the provider.
  * @returns True if the provider supports all registry models, false otherwise.
  */
-export function hasAllRegistryModelsSupport(provider: LLMProvider): boolean {
-    const providerInfo = LLM_REGISTRY[provider];
-    return providerInfo.supportsAllRegistryModels === true;
+export function hasAllRegistryModelsSupport(
+    provider: LLMProvider,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+): boolean {
+    return registry.hasAllRegistryModelsSupport(provider);
 }
 
 /**
@@ -1171,8 +1184,8 @@ const OPENROUTER_PREFIX_BY_PROVIDER: Partial<Record<LLMProvider, string>> = {
     glm: 'z-ai',
 };
 
-function getOpenRouterModelIdSet(): Set<string> {
-    return new Set(LLM_REGISTRY.openrouter.models.map((m) => m.name.toLowerCase()));
+function getOpenRouterModelIdSet(registry: ModelRegistry): Set<string> {
+    return new Set(registry.getSupportedModels('openrouter').map((model) => model.toLowerCase()));
 }
 
 export function getOpenRouterCandidateModelIds(
@@ -1204,8 +1217,11 @@ export function getOpenRouterCandidateModelIds(
     return [`${prefix}/${model}`];
 }
 
-function pickExistingOpenRouterModelId(candidates: string[]): string | null {
-    const openrouterSet = getOpenRouterModelIdSet();
+function pickExistingOpenRouterModelId(
+    candidates: string[],
+    registry: ModelRegistry
+): string | null {
+    const openrouterSet = getOpenRouterModelIdSet(registry);
     for (const candidate of candidates) {
         if (openrouterSet.has(candidate.toLowerCase())) {
             return candidate;
@@ -1317,15 +1333,16 @@ export function getAllModelsForProvider(
 export function transformModelNameForProvider(
     model: string,
     originalProvider: LLMProvider,
-    targetProvider: LLMProvider
+    targetProvider: LLMProvider,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): string {
     // Only transform when targeting gateway providers (those with supportsAllRegistryModels)
-    if (!hasAllRegistryModelsSupport(targetProvider)) {
+    if (!hasAllRegistryModelsSupport(targetProvider, registry)) {
         return model;
     }
 
     // If original provider is already a gateway, model is already in correct format
-    if (hasAllRegistryModelsSupport(originalProvider)) {
+    if (hasAllRegistryModelsSupport(originalProvider, registry)) {
         return model;
     }
 
@@ -1337,7 +1354,7 @@ export function transformModelNameForProvider(
     const candidates = getOpenRouterCandidateModelIds(model, originalProvider);
     if (candidates.length === 0) return model;
 
-    return pickExistingOpenRouterModelId(candidates) ?? candidates[0]!;
+    return pickExistingOpenRouterModelId(candidates, registry) ?? candidates[0]!;
 }
 
 /**
@@ -1652,7 +1669,7 @@ export function getModelPricing(provider: LLMProvider, model: string): ModelPric
     }
 
     const modelInfo = findModelInfo(provider, model);
-    return modelInfo?.pricing;
+    return modelInfo?.pricing ? cloneModelInfo(modelInfo).pricing : undefined;
 }
 
 /**

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -31,7 +31,7 @@ export interface LlmCatalogLogger {
     error(message: string): void;
 }
 
-export type LlmCatalogErrorCode = 'MODEL_UNKNOWN';
+export type LlmCatalogErrorCode = 'MODEL_UNKNOWN' | 'REGISTRY_INVALID';
 
 export class LlmCatalogError extends Error {
     readonly code: LlmCatalogErrorCode;
@@ -414,6 +414,273 @@ export const LLM_REGISTRY: Record<LLMProvider, ProviderInfo> = {
         supportsAllRegistryModels: true,
     },
 };
+
+export class ModelRegistry {
+    readonly #providers: Record<LLMProvider, ProviderInfo>;
+
+    constructor(providers: Record<LLMProvider, ProviderInfo>) {
+        validateRegistryProviders(providers);
+        this.#providers = cloneRegistryProviders(providers);
+    }
+
+    getProvider(provider: LLMProvider): ProviderInfo {
+        return cloneProviderInfo(this.#providers[provider]);
+    }
+
+    getModel(provider: LLMProvider, model: string): ModelInfo | null {
+        const modelInfo = findModelInfoInRegistry(this.#providers, provider, model);
+        return modelInfo === null ? null : cloneModelInfo(modelInfo);
+    }
+
+    getModelCapabilities(provider: LLMProvider, model: string): ModelCapabilities | null {
+        const modelInfo = this.getModel(provider, model);
+        if (modelInfo === null) return null;
+
+        return {
+            maxInputTokens: modelInfo.maxInputTokens,
+            reasoning: modelInfo.reasoning === true,
+            supportedFileTypes: [...modelInfo.supportedFileTypes],
+            supportsInterleaved: modelInfo.supportsInterleaved === true,
+            supportsTemperature: modelInfo.supportsTemperature === true,
+            supportsToolCall: modelInfo.supportsToolCall === true,
+            ...(modelInfo.modalities
+                ? {
+                      modalities: {
+                          input: [...modelInfo.modalities.input],
+                          output: [...modelInfo.modalities.output],
+                      },
+                  }
+                : {}),
+        };
+    }
+
+    getSupportedModels(provider: LLMProvider): string[] {
+        return this.#providers[provider].models.map((model) => model.name);
+    }
+
+    getDefaultModelForProvider(provider: LLMProvider): string | null {
+        const models = this.#providers[provider].models;
+        const explicit = models.find((model) => model.default)?.name;
+        if (explicit) return explicit;
+        if (models.length === 0) return null;
+
+        return (
+            [...models].sort((left, right) => left.name.localeCompare(right.name))[0]?.name ?? null
+        );
+    }
+
+    getMaxInputTokensForModel(
+        provider: LLMProvider,
+        model: string,
+        logger?: LlmCatalogLogger
+    ): number {
+        const modelInfo = findModelInfoInRegistry(this.#providers, provider, model);
+        if (!modelInfo) {
+            const supportedModels = this.getSupportedModels(provider).join(', ');
+            logger?.error(
+                `Model '${model}' not found for provider '${provider}' in LLM registry. Supported models: ${supportedModels}`
+            );
+            throw unknownModel(provider, model);
+        }
+
+        logger?.debug(`Found max tokens for ${provider}/${model}: ${modelInfo.maxInputTokens}`);
+        return modelInfo.maxInputTokens;
+    }
+
+    getModelPricing(provider: LLMProvider, model: string): ModelPricing | undefined {
+        if (this.acceptsAnyModel(provider)) return undefined;
+        return findModelInfoInRegistry(this.#providers, provider, model)?.pricing;
+    }
+
+    isReasoningCapableModel(model: string, provider?: LLMProvider): boolean {
+        const registryProvider = (() => {
+            if (model.includes('/')) return 'openrouter';
+            if (provider) return provider;
+            try {
+                return this.getProviderFromModel(model);
+            } catch {
+                return undefined;
+            }
+        })();
+
+        if (registryProvider) {
+            const modelInfo = findModelInfoInRegistry(this.#providers, registryProvider, model);
+            if (modelInfo?.reasoning === true) return true;
+            if (modelInfo?.reasoning === false) return false;
+        }
+
+        const modelIdForHeuristics = model.includes('/')
+            ? (model.split('/').pop() ?? model)
+            : model;
+        const modelLower = modelIdForHeuristics.toLowerCase();
+        if (modelLower.includes('codex')) return true;
+        if (
+            modelLower.startsWith('o1') ||
+            modelLower.startsWith('o3') ||
+            modelLower.startsWith('o4')
+        ) {
+            return true;
+        }
+        if (modelLower.includes('gpt-5')) return true;
+        if (modelLower.includes('gemini-2.5') || modelLower.includes('gemini-3')) return true;
+        return false;
+    }
+
+    getProviderFromModel(model: string): LLMProvider {
+        if (model.includes('/')) throw modelProviderUnknown(model);
+
+        const normalizedModel = getNormalizedModelIdForLookup(model);
+        for (const provider of LLM_PROVIDERS) {
+            const info = this.#providers[provider];
+            if (info.models.some((candidate) => candidate.name.toLowerCase() === normalizedModel)) {
+                return provider;
+            }
+        }
+
+        throw modelProviderUnknown(model);
+    }
+
+    acceptsAnyModel(provider: LLMProvider): boolean {
+        return this.#providers[provider].models.length === 0;
+    }
+
+    supportsCustomModels(provider: LLMProvider): boolean {
+        return this.#providers[provider].supportsCustomModels === true;
+    }
+
+    hasAllRegistryModelsSupport(provider: LLMProvider): boolean {
+        return this.#providers[provider].supportsAllRegistryModels === true;
+    }
+
+    supportsBaseURL(provider: LLMProvider): boolean {
+        return this.#providers[provider].baseURLSupport !== 'none';
+    }
+
+    isValidProviderModel(provider: LLMProvider, model: string): boolean {
+        const normalizedModel = getNormalizedModelIdForLookup(model);
+        return this.#providers[provider].models.some(
+            (candidate) => candidate.name.toLowerCase() === normalizedModel
+        );
+    }
+
+    getSupportedFileTypesForModel(provider: LLMProvider, model: string): SupportedFileType[] {
+        const providerInfo = this.#providers[provider];
+        if (this.acceptsAnyModel(provider)) return [...providerInfo.supportedFileTypes];
+
+        const modelInfo = findModelInfoInRegistry(this.#providers, provider, model);
+        if (modelInfo) return [...modelInfo.supportedFileTypes];
+        if (this.supportsCustomModels(provider)) return [...providerInfo.supportedFileTypes];
+        throw unknownModel(provider, model);
+    }
+
+    getAllModelsForProvider(
+        provider: LLMProvider
+    ): Array<ModelInfo & { originalProvider?: LLMProvider }> {
+        const providerInfo = this.#providers[provider];
+        const ownModels = providerInfo.models.map((model) => ({
+            ...cloneModelInfo(model),
+            originalProvider: provider,
+        }));
+        if (!providerInfo.supportsAllRegistryModels || provider === 'openrouter') {
+            return ownModels;
+        }
+
+        const seen = new Set(ownModels.map((model) => model.name.toLowerCase()));
+        const inherited = this.#providers.openrouter.models
+            .filter((model) => !seen.has(model.name.toLowerCase()))
+            .map((model): ModelInfo & { originalProvider: LLMProvider } => ({
+                ...cloneModelInfo(model),
+                originalProvider: 'openrouter',
+            }));
+        return [...ownModels, ...inherited];
+    }
+}
+
+export function createModelRegistry(providers: Record<LLMProvider, ProviderInfo>): ModelRegistry {
+    return new ModelRegistry(providers);
+}
+
+export const DEFAULT_MODEL_REGISTRY = createModelRegistry(LLM_REGISTRY);
+
+function cloneRegistryProviders(
+    providers: Record<LLMProvider, ProviderInfo>
+): Record<LLMProvider, ProviderInfo> {
+    const cloned: Record<LLMProvider, ProviderInfo> = { ...providers };
+    for (const provider of LLM_PROVIDERS) {
+        cloned[provider] = cloneProviderInfo(providers[provider]);
+    }
+    return cloned;
+}
+
+function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>): void {
+    for (const provider of LLM_PROVIDERS) {
+        const providerInfo = providers[provider];
+        if (
+            !providerInfo ||
+            !Array.isArray(providerInfo.models) ||
+            !['none', 'optional', 'required'].includes(providerInfo.baseURLSupport) ||
+            !Array.isArray(providerInfo.supportedFileTypes)
+        ) {
+            throw new LlmCatalogError(
+                'REGISTRY_INVALID',
+                `Invalid registry provider definition for '${provider}'`
+            );
+        }
+
+        for (const model of providerInfo.models) {
+            if (
+                model.name.trim().length === 0 ||
+                !Number.isInteger(model.maxInputTokens) ||
+                model.maxInputTokens < 0
+            ) {
+                throw new LlmCatalogError(
+                    'REGISTRY_INVALID',
+                    `Invalid registry model definition for '${provider}/${model.name}'`
+                );
+            }
+
+            const pricing = model.pricing;
+            if (
+                pricing &&
+                (!Number.isFinite(pricing.inputPerM) ||
+                    pricing.inputPerM < 0 ||
+                    !Number.isFinite(pricing.outputPerM) ||
+                    pricing.outputPerM < 0)
+            ) {
+                throw new LlmCatalogError(
+                    'REGISTRY_INVALID',
+                    `Invalid registry pricing for '${provider}/${model.name}'`
+                );
+            }
+        }
+    }
+}
+
+function findModelInfoInRegistry(
+    providers: Record<LLMProvider, ProviderInfo>,
+    provider: LLMProvider,
+    model: string
+): ModelInfo | null {
+    const normalizedModel = getNormalizedModelIdForLookup(model);
+    const direct = providers[provider].models.find(
+        (candidate) => candidate.name.toLowerCase() === normalizedModel
+    );
+    if (direct) return direct;
+
+    if (
+        provider !== 'openrouter' &&
+        providers[provider].supportsAllRegistryModels &&
+        model.includes('/')
+    ) {
+        return (
+            providers.openrouter.models.find(
+                (candidate) => candidate.name.toLowerCase() === normalizedModel
+            ) ?? null
+        );
+    }
+
+    return null;
+}
 
 function cloneModelInfo(model: ModelInfo): ModelInfo {
     return {
@@ -995,9 +1262,13 @@ export function getSupportedFileTypesForModel(
 export function modelSupportsFileType(
     provider: LLMProvider,
     model: string,
-    fileType: SupportedFileType
+    fileType: SupportedFileType,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): boolean {
-    const supportedTypes = getSupportedFileTypesForModel(provider, model);
+    const supportedTypes =
+        registry === DEFAULT_MODEL_REGISTRY
+            ? getSupportedFileTypesForModel(provider, model)
+            : registry.getSupportedFileTypesForModel(provider, model);
     return supportedTypes.includes(fileType);
 }
 
@@ -1011,7 +1282,8 @@ export function modelSupportsFileType(
 export function validateModelFileSupport(
     provider: LLMProvider,
     model: string,
-    mimeType: string
+    mimeType: string,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
 ): {
     isSupported: boolean;
     fileType?: SupportedFileType;
@@ -1028,7 +1300,7 @@ export function validateModelFileSupport(
     }
 
     try {
-        if (!modelSupportsFileType(provider, model, fileType)) {
+        if (!modelSupportsFileType(provider, model, fileType, registry)) {
             return {
                 isSupported: false,
                 fileType,
@@ -1233,7 +1505,15 @@ export function getModelDisplayName(model: string, provider?: LLMProvider): stri
  * @param provider Optional provider for context (defaults to detecting from model name).
  * @returns True if the registry marks this model as reasoning-capable.
  */
-export function isReasoningCapableModel(model: string, provider?: LLMProvider): boolean {
+export function isReasoningCapableModel(
+    model: string,
+    provider?: LLMProvider,
+    registry: ModelRegistry = DEFAULT_MODEL_REGISTRY
+): boolean {
+    if (registry !== DEFAULT_MODEL_REGISTRY) {
+        return registry.isReasoningCapableModel(model, provider);
+    }
+
     const registryProvider = (() => {
         if (model.includes('/')) return 'openrouter' as const;
         if (provider) return provider;

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -15,6 +15,7 @@
 
 import {
     LLM_PROVIDERS,
+    SUPPORTED_FILE_TYPES,
     type LLMProvider,
     type SupportedFileType,
     type TokenUsage,
@@ -638,7 +639,8 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
             !isRecord(providerInfo) ||
             !Array.isArray(providerInfo.models) ||
             !['none', 'optional', 'required'].includes(providerInfo.baseURLSupport) ||
-            !Array.isArray(providerInfo.supportedFileTypes)
+            !Array.isArray(providerInfo.supportedFileTypes) ||
+            !providerInfo.supportedFileTypes.every(isSupportedFileType)
         ) {
             throw new LlmCatalogError(
                 'REGISTRY_INVALID',
@@ -660,7 +662,7 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
                 !Number.isInteger(modelObject.maxInputTokens) ||
                 modelObject.maxInputTokens < 0 ||
                 !Array.isArray(modelObject.supportedFileTypes) ||
-                !modelObject.supportedFileTypes.every((fileType) => typeof fileType === 'string')
+                !modelObject.supportedFileTypes.every(isSupportedFileType)
             ) {
                 throw new LlmCatalogError(
                     'REGISTRY_INVALID',
@@ -676,6 +678,13 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
             }
         }
     }
+}
+
+function isSupportedFileType(value: unknown): value is SupportedFileType {
+    return (
+        typeof value === 'string' &&
+        SUPPORTED_FILE_TYPES.some((supportedFileType) => supportedFileType === value)
+    );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/llm/src/registry/index.ts
+++ b/packages/llm/src/registry/index.ts
@@ -73,6 +73,16 @@ const LONG_CONTEXT_PRICING_FIELDS = [
     'cacheWritePerM',
 ] as const;
 
+const MODEL_BOOLEAN_FIELDS = [
+    'default',
+    'reasoning',
+    'supportsTemperature',
+    'supportsInterleaved',
+    'supportsToolCall',
+] as const;
+const MODEL_STRING_FIELDS = ['displayName', 'releaseDate', 'status'] as const;
+const MODEL_MODALITIES = ['text', 'audio', 'image', 'video', 'pdf'] as const;
+
 function getNormalizedModelIdForLookup(model: string): string {
     const stripped = stripBedrockRegionPrefix(model);
     return stripped.toLowerCase();
@@ -648,6 +658,22 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
             );
         }
 
+        if (
+            (providerInfo.supportsCustomModels !== undefined &&
+                typeof providerInfo.supportsCustomModels !== 'boolean') ||
+            (providerInfo.supportsAllRegistryModels !== undefined &&
+                typeof providerInfo.supportsAllRegistryModels !== 'boolean') ||
+            (providerInfo.modelsDev !== undefined &&
+                !isValidModelsDevMetadata(providerInfo.modelsDev))
+        ) {
+            throw new LlmCatalogError(
+                'REGISTRY_INVALID',
+                `Invalid registry provider metadata for '${provider}'`
+            );
+        }
+
+        const modelNames = new Set<string>();
+
         for (const [modelIndex, model] of providerInfo.models.entries()) {
             const modelObject = isRecord(model) ? model : null;
             const modelName =
@@ -667,6 +693,22 @@ function validateRegistryProviders(providers: Record<LLMProvider, ProviderInfo>)
                 throw new LlmCatalogError(
                     'REGISTRY_INVALID',
                     `Invalid registry model definition for '${provider}/${modelName}'`
+                );
+            }
+
+            const normalizedModelName = modelObject.name.toLowerCase();
+            if (modelNames.has(normalizedModelName)) {
+                throw new LlmCatalogError(
+                    'REGISTRY_INVALID',
+                    `Duplicate registry model definition for '${provider}/${modelObject.name}'`
+                );
+            }
+            modelNames.add(normalizedModelName);
+
+            if (!isValidModelMetadata(modelObject)) {
+                throw new LlmCatalogError(
+                    'REGISTRY_INVALID',
+                    `Invalid registry metadata for '${provider}/${modelObject.name}'`
                 );
             }
 
@@ -695,9 +737,76 @@ function isValidPricingNumber(value: unknown): value is number {
     return typeof value === 'number' && Number.isFinite(value) && value >= 0;
 }
 
+function isValidModelsDevMetadata(value: unknown): boolean {
+    if (!isRecord(value) || !Array.isArray(value.env) || !value.env.every(isString)) {
+        return false;
+    }
+
+    return ['npm', 'api', 'doc'].every(
+        (field) => value[field] === undefined || isString(value[field])
+    );
+}
+
+function isValidModelMetadata(value: Record<string, unknown>): boolean {
+    if (
+        !MODEL_BOOLEAN_FIELDS.every(
+            (field) => value[field] === undefined || typeof value[field] === 'boolean'
+        ) ||
+        !MODEL_STRING_FIELDS.every((field) => value[field] === undefined || isString(value[field]))
+    ) {
+        return false;
+    }
+
+    if (value.modalities !== undefined && !isValidModelModalities(value.modalities)) {
+        return false;
+    }
+    if (value.providerMetadata !== undefined && !isValidProviderMetadata(value.providerMetadata)) {
+        return false;
+    }
+    if (value.interleaved !== undefined && !isValidInterleavedMetadata(value.interleaved)) {
+        return false;
+    }
+
+    return true;
+}
+
+function isValidModelModalities(value: unknown): boolean {
+    if (!isRecord(value) || !Array.isArray(value.input) || !Array.isArray(value.output)) {
+        return false;
+    }
+
+    return (
+        value.input.every(isSupportedModelModality) && value.output.every(isSupportedModelModality)
+    );
+}
+
+function isValidProviderMetadata(value: unknown): boolean {
+    return (
+        isRecord(value) &&
+        ['npm', 'api'].every((field) => value[field] === undefined || isString(value[field]))
+    );
+}
+
+function isValidInterleavedMetadata(value: unknown): boolean {
+    return (
+        value === true || (isRecord(value) && (value.field === undefined || isString(value.field)))
+    );
+}
+
+function isSupportedModelModality(value: unknown): boolean {
+    return typeof value === 'string' && MODEL_MODALITIES.some((modality) => modality === value);
+}
+
+function isString(value: unknown): value is string {
+    return typeof value === 'string';
+}
+
 function isValidModelPricing(value: unknown): boolean {
     if (value === undefined) return true;
     if (!isRecord(value)) return false;
+
+    if (value.currency !== undefined && value.currency !== 'USD') return false;
+    if (value.unit !== undefined && value.unit !== 'per_million_tokens') return false;
 
     for (const field of MODEL_PRICING_FIELDS) {
         if (field in value && !isValidPricingNumber(value[field])) return false;
@@ -709,6 +818,16 @@ function isValidModelPricing(value: unknown): boolean {
     const longContextPricing = value.contextOver200kPerM;
     if (longContextPricing === undefined) return true;
     if (!isRecord(longContextPricing)) return false;
+
+    const inputTokensAbove = longContextPricing.inputTokensAbove;
+    if (
+        inputTokensAbove !== undefined &&
+        (typeof inputTokensAbove !== 'number' ||
+            !Number.isInteger(inputTokensAbove) ||
+            inputTokensAbove < 0)
+    ) {
+        return false;
+    }
 
     for (const field of LONG_CONTEXT_PRICING_FIELDS) {
         if (field in longContextPricing && !isValidPricingNumber(longContextPricing[field])) {

--- a/packages/llm/src/registry/model-registry.test.ts
+++ b/packages/llm/src/registry/model-registry.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
     createModelRegistry,
+    getModelPricing,
     getProvider,
     LLM_REGISTRY,
+    transformModelNameForProvider,
     type LLMProvider,
     type ModelInfo,
     type ProviderInfo,
@@ -82,6 +84,35 @@ describe('ModelRegistry', () => {
                 outputPerM: 78,
             },
         });
+    });
+
+    it('returns defensive pricing clones from the shared helper', () => {
+        const model = getProvider('openai').models.find((candidate) => candidate.pricing);
+        if (!model?.pricing) throw new Error('Expected a bundled model with pricing metadata');
+
+        const pricing = getModelPricing('openai', model.name);
+        if (!pricing) throw new Error('Expected shared pricing metadata');
+
+        pricing.inputPerM = 999;
+        expect(getModelPricing('openai', model.name)?.inputPerM).toBe(model.pricing.inputPerM);
+    });
+
+    it('uses an injected registry when resolving gateway model names', () => {
+        const openRouterModel = getProvider('openrouter').models[0];
+        if (!openRouterModel)
+            throw new Error('Expected the bundled OpenRouter registry to be populated');
+
+        const registry = createModelRegistry({
+            ...LLM_REGISTRY,
+            openrouter: {
+                ...LLM_REGISTRY.openrouter,
+                models: [{ ...openRouterModel, name: 'anthropic/custom-haiku' }],
+            },
+        });
+
+        expect(
+            transformModelNameForProvider('custom-haiku', 'anthropic', 'openrouter', registry)
+        ).toBe('anthropic/custom-haiku');
     });
 
     it('does not mutate the input provider records', () => {

--- a/packages/llm/src/registry/model-registry.test.ts
+++ b/packages/llm/src/registry/model-registry.test.ts
@@ -48,6 +48,42 @@ describe('ModelRegistry', () => {
         expect(registry.getSupportedModels('openai')).toEqual(['registry-test-model']);
     });
 
+    it('returns defensive pricing clones', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        const registry = createModelRegistry(
+            registryWithModel({
+                ...bundledModel,
+                name: 'pricing-clone-model',
+                pricing: {
+                    inputPerM: 12,
+                    outputPerM: 34,
+                    contextOver200kPerM: {
+                        inputPerM: 56,
+                        outputPerM: 78,
+                    },
+                },
+            })
+        );
+
+        const pricing = registry.getModelPricing('openai', 'pricing-clone-model');
+        if (!pricing || !pricing.contextOver200kPerM) {
+            throw new Error('Expected pricing metadata');
+        }
+        pricing.inputPerM = 999;
+        pricing.contextOver200kPerM.inputPerM = 888;
+
+        expect(registry.getModelPricing('openai', 'pricing-clone-model')).toEqual({
+            inputPerM: 12,
+            outputPerM: 34,
+            contextOver200kPerM: {
+                inputPerM: 56,
+                outputPerM: 78,
+            },
+        });
+    });
+
     it('does not mutate the input provider records', () => {
         const registry = createModelRegistry(LLM_REGISTRY);
 
@@ -74,5 +110,61 @@ describe('ModelRegistry', () => {
                 })
             )
         ).toThrow("Invalid registry pricing for 'openai/invalid-price-model'");
+    });
+
+    it.each([
+        'cacheReadPerM',
+        'cacheWritePerM',
+        'reasoningPerM',
+        'inputAudioPerM',
+        'outputAudioPerM',
+    ])('rejects invalid %s pricing before activation', (field) => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        expect(() =>
+            createModelRegistry(
+                registryWithModel({
+                    ...bundledModel,
+                    name: `invalid-${field}-model`,
+                    pricing: {
+                        inputPerM: 1,
+                        outputPerM: 1,
+                        [field]: -1,
+                    },
+                })
+            )
+        ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
+    });
+
+    it('rejects malformed model fields with a registry error', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        for (const malformedModel of [
+            null,
+            { ...bundledModel, name: 42 },
+            { ...bundledModel, maxInputTokens: Number.NaN },
+            { ...bundledModel, supportedFileTypes: 'image' },
+        ]) {
+            expect(() =>
+                createModelRegistry(registryWithModel(malformedModel as ModelInfo))
+            ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
+        }
+    });
+
+    it('allows zero input-token limits for media models', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        const registry = createModelRegistry(
+            registryWithModel({
+                ...bundledModel,
+                name: 'zero-limit-media-model',
+                maxInputTokens: 0,
+            })
+        );
+
+        expect(registry.getMaxInputTokensForModel('openai', 'zero-limit-media-model')).toBe(0);
     });
 });

--- a/packages/llm/src/registry/model-registry.test.ts
+++ b/packages/llm/src/registry/model-registry.test.ts
@@ -85,13 +85,14 @@ describe('ModelRegistry', () => {
     });
 
     it('does not mutate the input provider records', () => {
+        const bundledCount = LLM_REGISTRY.openai.models.length;
         const registry = createModelRegistry(LLM_REGISTRY);
 
         const provider = registry.getProvider('openai');
         provider.models.pop();
 
-        expect(registry.getSupportedModels('openai').length).toBeGreaterThan(0);
-        expect(LLM_REGISTRY.openai.models.length).toBeGreaterThan(0);
+        expect(registry.getSupportedModels('openai')).toHaveLength(bundledCount);
+        expect(LLM_REGISTRY.openai.models).toHaveLength(bundledCount);
     });
 
     it('rejects invalid model pricing before activation', () => {
@@ -151,6 +152,21 @@ describe('ModelRegistry', () => {
                 createModelRegistry(registryWithModel(malformedModel as ModelInfo))
             ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
         }
+    });
+
+    it('rejects unknown supported file types before activation', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        expect(() =>
+            createModelRegistry(
+                registryWithModel({
+                    ...bundledModel,
+                    name: 'invalid-file-type-model',
+                    supportedFileTypes: ['imag' as ModelInfo['supportedFileTypes'][number]],
+                })
+            )
+        ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
     });
 
     it('allows zero input-token limits for media models', () => {

--- a/packages/llm/src/registry/model-registry.test.ts
+++ b/packages/llm/src/registry/model-registry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createModelRegistry,
+    getProvider,
+    LLM_REGISTRY,
+    type LLMProvider,
+    type ModelInfo,
+    type ProviderInfo,
+} from './index.js';
+
+function registryWithModel(model: ModelInfo): Record<LLMProvider, ProviderInfo> {
+    return {
+        ...LLM_REGISTRY,
+        openai: {
+            ...LLM_REGISTRY.openai,
+            models: [model],
+        },
+    };
+}
+
+describe('ModelRegistry', () => {
+    it('uses injected model metadata for lookup, pricing, limits, and reasoning', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        const registry = createModelRegistry(
+            registryWithModel({
+                ...bundledModel,
+                name: 'registry-test-model',
+                maxInputTokens: 777,
+                reasoning: true,
+                pricing: {
+                    inputPerM: 12,
+                    outputPerM: 34,
+                },
+            })
+        );
+
+        expect(registry.getModel('openai', 'registry-test-model')?.name).toBe(
+            'registry-test-model'
+        );
+        expect(registry.getMaxInputTokensForModel('openai', 'registry-test-model')).toBe(777);
+        expect(registry.getModelPricing('openai', 'registry-test-model')).toEqual({
+            inputPerM: 12,
+            outputPerM: 34,
+        });
+        expect(registry.isReasoningCapableModel('registry-test-model', 'openai')).toBe(true);
+        expect(registry.getSupportedModels('openai')).toEqual(['registry-test-model']);
+    });
+
+    it('does not mutate the input provider records', () => {
+        const registry = createModelRegistry(LLM_REGISTRY);
+
+        const provider = registry.getProvider('openai');
+        provider.models.pop();
+
+        expect(registry.getSupportedModels('openai').length).toBeGreaterThan(0);
+        expect(LLM_REGISTRY.openai.models.length).toBeGreaterThan(0);
+    });
+
+    it('rejects invalid model pricing before activation', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        expect(() =>
+            createModelRegistry(
+                registryWithModel({
+                    ...bundledModel,
+                    name: 'invalid-price-model',
+                    pricing: {
+                        inputPerM: -1,
+                        outputPerM: 1,
+                    },
+                })
+            )
+        ).toThrow("Invalid registry pricing for 'openai/invalid-price-model'");
+    });
+});

--- a/packages/llm/src/registry/model-registry.test.ts
+++ b/packages/llm/src/registry/model-registry.test.ts
@@ -169,6 +169,51 @@ describe('ModelRegistry', () => {
         ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
     });
 
+    it('rejects duplicate model IDs regardless of case', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        expect(() =>
+            createModelRegistry({
+                ...LLM_REGISTRY,
+                openai: {
+                    ...LLM_REGISTRY.openai,
+                    models: [
+                        bundledModel,
+                        { ...bundledModel, name: bundledModel.name.toUpperCase() },
+                    ],
+                },
+            })
+        ).toThrow("Duplicate registry model definition for 'openai/");
+    });
+
+    it('rejects malformed optional model metadata before activation', () => {
+        const bundledModel = getProvider('openai').models[0];
+        if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');
+
+        const malformedModels = [
+            { modalities: { input: ['spreadsheet'], output: ['text'] } },
+            { providerMetadata: { npm: 42 } },
+            { interleaved: { field: 42 } },
+            { reasoning: 'yes' },
+            { displayName: 42 },
+            { pricing: { inputPerM: 1, outputPerM: 1, currency: 'EUR' } },
+            { pricing: { inputPerM: 1, outputPerM: 1, unit: 'per_token' } },
+        ];
+
+        for (const changes of malformedModels) {
+            expect(() =>
+                createModelRegistry(
+                    registryWithModel({
+                        ...bundledModel,
+                        name: `invalid-metadata-${Object.keys(changes)[0]}`,
+                        ...changes,
+                    } as ModelInfo)
+                )
+            ).toThrow(expect.objectContaining({ code: 'REGISTRY_INVALID' }));
+        }
+    });
+
     it('allows zero input-token limits for media models', () => {
         const bundledModel = getProvider('openai').models[0];
         if (!bundledModel) throw new Error('Expected the bundled OpenAI registry to be populated');

--- a/packages/server/src/events/usage-event-subscriber.ts
+++ b/packages/server/src/events/usage-event-subscriber.ts
@@ -6,7 +6,7 @@ import {
     type AgentEventMap,
     type Database,
 } from '@dexto/core';
-import { calculateCostBreakdown, getModelPricing } from '@dexto/llm';
+import { calculateCostBreakdown, DEFAULT_MODEL_REGISTRY, type ModelRegistry } from '@dexto/llm';
 import type { EventSubscriber } from './types.js';
 import type {
     UsageEvent,
@@ -37,6 +37,7 @@ interface UsageEventSubscriberConfig extends UsageEventDeliveryOptions {
     database: Database;
     targetUrl: string;
     authToken: string;
+    llmRegistry?: ModelRegistry;
     runtimeId?: string;
     runId?: string;
 }
@@ -57,6 +58,7 @@ export class UsageEventSubscriber implements EventSubscriber {
     private readonly database: Database;
     private readonly targetUrl: string;
     private readonly authToken: string;
+    private readonly llmRegistry: ModelRegistry;
     private readonly runtimeId: string | undefined;
     private readonly runId: string | undefined;
     private readonly deliveryOptions: Required<UsageEventDeliveryOptions>;
@@ -71,6 +73,7 @@ export class UsageEventSubscriber implements EventSubscriber {
         this.database = config.database;
         this.targetUrl = config.targetUrl;
         this.authToken = config.authToken;
+        this.llmRegistry = config.llmRegistry ?? DEFAULT_MODEL_REGISTRY;
         this.runtimeId = config.runtimeId;
         this.runId = config.runId;
         const flushIntervalMs = requirePositiveIntegerOption(
@@ -156,7 +159,10 @@ export class UsageEventSubscriber implements EventSubscriber {
             payload.costBreakdown ??
             (payload.provider && payload.model
                 ? (() => {
-                      const pricing = getModelPricing(payload.provider, payload.model);
+                      const pricing = this.llmRegistry.getModelPricing(
+                          payload.provider,
+                          payload.model
+                      );
                       if (!pricing) {
                           return undefined;
                       }

--- a/packages/server/src/hono/__tests__/api.integration.test.ts
+++ b/packages/server/src/hono/__tests__/api.integration.test.ts
@@ -113,6 +113,22 @@ describe('Hono API Integration Tests', () => {
             expect(res.status).toBe(200);
         });
 
+        it('POST /api/llm/switch accepts a session-specific model update', async () => {
+            if (!testServer) throw new Error('Test server not initialized');
+            const sessionId = 'test-session-llm-switch';
+            const createRes = await httpRequest(testServer.baseUrl, 'POST', '/api/sessions', {
+                sessionId,
+            });
+            expect(createRes.status).toBe(201);
+
+            const res = await httpRequest(testServer.baseUrl, 'POST', '/api/llm/switch', {
+                model: 'gpt-5',
+                sessionId,
+            });
+            expect(res.status).toBe(200);
+            expect((res.body as { sessionId: string }).sessionId).toBe(sessionId);
+        });
+
         it('GET /api/llm/model-picker-state returns picker sections', async () => {
             if (!testServer) throw new Error('Test server not initialized');
             const res = await httpRequest(testServer.baseUrl, 'GET', '/api/llm/model-picker-state');

--- a/packages/server/src/hono/routes/llm.ts
+++ b/packages/server/src/hono/routes/llm.ts
@@ -12,12 +12,11 @@ import {
     LLMUpdatesSchema,
 } from '@dexto/core';
 import {
-    LLM_REGISTRY,
     LLM_PROVIDERS,
     SUPPORTED_FILE_TYPES,
     getReasoningProfile,
-    supportsBaseURL,
     type LLMProvider,
+    type ModelRegistry,
     type ProviderInfo,
     type SupportedFileType,
 } from '@dexto/llm';
@@ -672,14 +671,14 @@ export function createLlmRouter(getAgent: GetAgentFn) {
         return deduped;
     };
 
-    const buildModelPickerSections = async () => {
+    const buildModelPickerSections = async (registry: ModelRegistry) => {
         const byKey = new Map<string, z.output<typeof ModelPickerEntrySchema>>();
         const customSection: Array<z.output<typeof ModelPickerEntrySchema>> = [];
         const hydrateStateEntry = (
             entry: z.output<typeof ModelPickerModelRefSchema>
         ): z.output<typeof ModelPickerEntrySchema> => {
-            const providerInfo = LLM_REGISTRY[entry.provider];
-            const modelInfo = providerInfo.models.find((model) => model.name === entry.model);
+            const providerInfo = registry.getProvider(entry.provider);
+            const modelInfo = registry.getModel(entry.provider, entry.model);
             const supportedFileTypes =
                 Array.isArray(modelInfo?.supportedFileTypes) &&
                 modelInfo.supportedFileTypes.length > 0
@@ -707,8 +706,8 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                 continue;
             }
 
-            const providerInfo = LLM_REGISTRY[provider];
-            for (const model of getAllModelsForProvider(provider)) {
+            const providerInfo = registry.getProvider(provider);
+            for (const model of getAllModelsForProvider(provider, registry)) {
                 const supportedFileTypes =
                     Array.isArray(model.supportedFileTypes) && model.supportedFileTypes.length > 0
                         ? model.supportedFileTypes
@@ -736,7 +735,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                 continue;
             }
 
-            const providerInfo = LLM_REGISTRY[provider];
+            const providerInfo = registry.getProvider(provider);
             const entry: z.output<typeof ModelPickerEntrySchema> = {
                 provider,
                 model: customModel.name,
@@ -750,7 +749,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
             customSection.push(entry);
         }
 
-        const localProviderSupportedFileTypes = LLM_REGISTRY.local.supportedFileTypes;
+        const localProviderSupportedFileTypes = registry.getProvider('local').supportedFileTypes;
         const installedLocalModels = await getAllInstalledModels();
         for (const installedModel of installedLocalModels) {
             const modelInfo = getLocalModelById(installedModel.id);
@@ -765,10 +764,13 @@ export function createLlmRouter(getAgent: GetAgentFn) {
         }
 
         const featuredProviders = LLM_PROVIDERS.filter((provider) => isProviderEnabled(provider));
-        const featured = getCuratedModelRefsForProviders({
-            providers: featuredProviders,
-            max: MODEL_PICKER_FEATURED_LIMIT,
-        })
+        const featured = getCuratedModelRefsForProviders(
+            {
+                providers: featuredProviders,
+                max: MODEL_PICKER_FEATURED_LIMIT,
+            },
+            registry
+        )
             .map((ref) => byKey.get(toModelPickerKey(ref)))
             .filter((entry): entry is z.output<typeof ModelPickerEntrySchema> => Boolean(entry));
 
@@ -820,6 +822,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
     return app
         .openapi(currentRoute, async (ctx) => {
             const agent = await getAgent(ctx);
+            const registry = agent.llmRegistry;
             const { sessionId } = ctx.req.valid('query');
 
             const currentConfig = sessionId
@@ -829,9 +832,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
             let displayName: string | undefined;
             try {
                 // First check registry for built-in models
-                const model = LLM_REGISTRY[currentConfig.provider]?.models.find(
-                    (m) => m.name.toLowerCase() === String(currentConfig.model).toLowerCase()
-                );
+                const model = registry.getModel(currentConfig.provider, currentConfig.model);
                 displayName = model?.displayName || undefined;
 
                 // If not found in registry, check custom models
@@ -867,7 +868,9 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                 200
             );
         })
-        .openapi(catalogRoute, (ctx) => {
+        .openapi(catalogRoute, async (ctx) => {
+            const agent = await getAgent(ctx);
+            const registry = agent.llmRegistry;
             type ProviderCatalog = Pick<ProviderInfo, 'models' | 'supportedFileTypes'> & {
                 name: string;
                 hasApiKey: boolean;
@@ -889,7 +892,7 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                     continue;
                 }
 
-                const info = LLM_REGISTRY[provider];
+                const info = registry.getProvider(provider);
                 const displayName =
                     provider === 'dexto-nova'
                         ? 'Dexto Nova'
@@ -900,18 +903,18 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                     if (!includeModels) return [];
                     if (scope === 'all') {
                         // Full list (may include inherited models for gateway providers)
-                        return getAllModelsForProvider(provider);
+                        return getAllModelsForProvider(provider, registry);
                     }
 
                     // Curated list for UI: keep it small but not single-model-per-provider.
-                    return getCuratedModelsForProvider(provider);
+                    return getCuratedModelsForProvider(provider, undefined, registry);
                 })();
 
                 providers[provider] = {
                     name: displayName,
                     hasApiKey: keyStatus.hasApiKey,
                     primaryEnvVar: keyStatus.envVar,
-                    supportsBaseURL: supportsBaseURL(provider),
+                    supportsBaseURL: registry.supportsBaseURL(provider),
                     models,
                     supportedFileTypes: info.supportedFileTypes,
                 };
@@ -1041,7 +1044,8 @@ export function createLlmRouter(getAgent: GetAgentFn) {
             return ctx.json({ ok: true as const, deleted: name } as const, 200);
         })
         .openapi(modelPickerStateRoute, async (ctx) => {
-            const sections = await buildModelPickerSections();
+            const agent = await getAgent(ctx);
+            const sections = await buildModelPickerSections(agent.llmRegistry);
             return ctx.json(sections, 200);
         })
         .openapi(recordRecentModelRoute, async (ctx) => {
@@ -1073,7 +1077,9 @@ export function createLlmRouter(getAgent: GetAgentFn) {
                 200
             );
         })
-        .openapi(capabilitiesRoute, (ctx) => {
+        .openapi(capabilitiesRoute, async (ctx) => {
+            const agent = await getAgent(ctx);
+            const registry = agent.llmRegistry;
             const { provider, model } = ctx.req.valid('query');
 
             // getSupportedFileTypesForModel handles:
@@ -1083,14 +1089,19 @@ export function createLlmRouter(getAgent: GetAgentFn) {
             // Falls back to provider-level supportedFileTypes if model not found
             let supportedFileTypes: SupportedFileType[];
             try {
-                supportedFileTypes = getSupportedFileTypesForModel(provider, model);
+                supportedFileTypes = getSupportedFileTypesForModel(
+                    provider,
+                    model,
+                    undefined,
+                    registry
+                );
             } catch {
                 // If model lookup fails, fall back to provider-level capabilities
-                const providerInfo = LLM_REGISTRY[provider];
+                const providerInfo = registry.getProvider(provider);
                 supportedFileTypes = providerInfo?.supportedFileTypes ?? [];
             }
 
-            const reasoning = getReasoningProfile(provider, model);
+            const reasoning = getReasoningProfile(provider, model, registry);
 
             return ctx.json(
                 {

--- a/packages/server/src/hono/routes/llm.ts
+++ b/packages/server/src/hono/routes/llm.ts
@@ -9,7 +9,7 @@ import {
     getCuratedModelRefsForProviders,
     getSupportedFileTypesForModel,
     getLocalModelById,
-    LLMUpdatesSchema,
+    LLMUpdatesShapeSchema,
 } from '@dexto/core';
 import {
     LLM_PROVIDERS,
@@ -119,9 +119,9 @@ const CatalogQuerySchema = z
     .strict()
     .describe('Query parameters for filtering and formatting the LLM catalog');
 
-// Combine LLM updates schema with sessionId for API requests
-// LLMUpdatesSchema is no longer strict, so it accepts extra fields like sessionId
-const SwitchLLMBodySchema = LLMUpdatesSchema.and(
+// Combine shape validation with sessionId for API requests. Model and reasoning compatibility
+// are validated by DextoAgent against its active registry.
+const SwitchLLMBodySchema = LLMUpdatesShapeSchema.and(
     z.object({
         sessionId: z
             .string()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,6 +560,9 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.2
+      vitest:
+        specifier: ^3.1.3
+        version: 3.2.4(@edge-runtime/vm@3.2.0)(@types/debug@4.1.12)(@types/node@22.19.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/orchestration:
     dependencies:


### PR DESCRIPTION
## Human notes

<!-- human:dexto-notes -->

_Add context, reviewer guidance, or verification results here. Agents preserve this section._

<!-- agent:dexto-managed:start -->

> [!NOTE]
> This section is written and maintained by agents. It may be regenerated when the PR changes; put human-authored context in the Human notes section above.

<!-- agent:dexto-pr-head:f8285d1c2143126ab41cfc124a881fb32e130d3c -->

## Intent

Feature with regression hardening: host-injected model registries with compatibility-preserving runtime propagation.

## Why

Cloud needs to refresh model metadata and add supported models without waiting for an upstream registry release. The injected registry must preserve the bundled default behavior while preventing malformed metadata and registry-dependent runtime paths from falling back to the bundled snapshot.

## Summary

- Add the additive host-registry seam across @dexto/llm, @dexto/core, agent management, and server boundaries.
- Keep the bundled registry as the backwards-compatible default when no host registry is supplied.
- Carry one selected registry through agent construction, spawned agents, reasoning, provider options, request formatting, pricing, usage metadata, and file capability checks.
- Harden activation validation for duplicate IDs, optional metadata shapes, pricing units, long-context thresholds, and provider metadata.
- Preserve the default OpenRouter cache fallback while preventing injected registries from querying that unrelated global cache.
- Add browser-entry, session-specific LLM switching, and registry edge-case regression coverage.
- Include the requested Core patch changeset and synchronized OpenAPI metadata.

## Change groups

1. Shared registry contracts and validation establish the host-owned boundary, including reasoning/schema behavior and defensive metadata checks.
2. Agent and context propagation carry one selected registry through complete runs and spawned agents.
3. Runtime adapters, usage accounting, file support, formatting, and server routes consume that same registry.
4. Release metadata records the patch release and keeps generated OpenAPI metadata in sync.

## Compatibility and rollout

Injection is opt-in. Existing Core, CLI, and other hosts continue using the bundled registry and existing static behavior. Hosts that supply a registry receive the same validation, reasoning, context-limit, file-support, and pricing semantics without enabling the default OpenRouter cache fallback.

## Validation

- Current Core root gates passed: pnpm lint, pnpm format:check, pnpm typecheck, and pnpm test (260 files passed, 1 skipped; 3,353 tests passed, 25 skipped).
- Current server dependency build passed with pnpm --filter @dexto/server... build.
- Current OpenAPI generation check passed with pnpm run sync-openapi-docs:check.
- The new server integration regression covers session-specific model switching through the existing strict request boundary; it passed in the full suite.
- Dedicated registry, reasoning, pricing, file-support, auto-refresh, browser-entry, agent-construction, and spawned-agent regressions are included in the full passing suite.
- .changeset/quiet-model-registries.md remains present for the requested Core patch release across @dexto/llm, @dexto/core, and @dexto/agent-config.

## Hosted check note

All substantive Core PR checks passed, including build/test, typecheck, lint, OpenAPI sync, and all platform smoke jobs. The Vercel check remains blocked by the external team's authorization gate.

<!-- agent:dexto-managed:end -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configurable, validated model registries.
  * Model capabilities, pricing, limits, reasoning options, and supported models now reflect the selected registry.
  * Custom registries can be applied to agent configuration, sessions, and spawned agents.
  * The bundled model catalog remains the default when no custom registry is provided.

* **Bug Fixes**
  * Improved validation and error reporting for invalid registries and unknown models.
  * Prevented custom registries from triggering unnecessary external catalog refreshes.

* **Tests**
  * Added coverage for custom registry metadata, pricing, limits, reasoning, file support, and immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



