### PR TITLE
Add canonical tool presentation metadata

### DIFF
--- a/.changeset/structured-tool-results.md
+++ b/.changeset/structured-tool-results.md
@@ -1,0 +1,6 @@
+---
+'@dexto/core': patch
+---
+
+Add model-authored tool activity metadata plus explicit result presentation policies and reusable
+structured display data while keeping legacy display metadata out of model-visible tool results.

--- a/docs/static/openapi/openapi.json
+++ b/docs/static/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Dexto API",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "OpenAPI spec for the Dexto REST API server"
   },
   "servers": [

--- a/packages/core/src/context/types.ts
+++ b/packages/core/src/context/types.ts
@@ -1,6 +1,6 @@
 import type { LLMProvider, LLMPricingStatus, TokenUsage } from '@dexto/llm';
 import type { ToolDisplayData } from '../tools/display-types.js';
-import type { ToolPresentationSnapshotV1 } from '../tools/types.js';
+import type { ToolPresentationResultType, ToolPresentationSnapshotV1 } from '../tools/types.js';
 import type { ToolCallMetadata } from '../tools/tool-call-metadata.js';
 
 // =============================================================================
@@ -161,6 +161,8 @@ export interface SanitizedToolResult {
         success: boolean;
         /** Structured display data for tool-specific rendering (diffs, shell output, etc.) */
         display?: ToolDisplayData;
+        /** Serializable host result-presentation policy for this tool result. */
+        resultPresentation?: ToolPresentationResultType;
     };
 }
 

--- a/packages/core/src/context/utils.test.ts
+++ b/packages/core/src/context/utils.test.ts
@@ -174,6 +174,38 @@ describe('sanitizeToolResult success tracking', () => {
         expect(result.meta.toolCallId).toBe('call-123');
     });
 
+    it('keeps explicit display metadata out of model-visible content', async () => {
+        const display = {
+            type: 'status' as const,
+            title: null,
+            status: 'success' as const,
+            message: 'Workspace is ready',
+        };
+        const legacyDisplay = {
+            type: 'text' as const,
+            title: null,
+            text: 'Legacy display',
+        };
+
+        const result = await sanitizeToolResult(
+            { value: 'kept', _display: legacyDisplay },
+            {
+                display,
+                resultPresentation: 'display',
+                toolName: 'status_tool',
+                toolCallId: 'call-display',
+                success: true,
+            },
+            mockLogger
+        );
+
+        expect(result.meta.display).toEqual(display);
+        expect(result.meta.resultPresentation).toBe('display');
+        expect(JSON.stringify(result.content)).not.toContain('_display');
+        expect(JSON.stringify(result.content)).not.toContain('Legacy display');
+        expect(JSON.stringify(result.content)).toContain('kept');
+    });
+
     it('should include success=false in meta when tool fails', async () => {
         const result = await sanitizeToolResult(
             { error: 'Something went wrong' },

--- a/packages/core/src/context/utils.ts
+++ b/packages/core/src/context/utils.ts
@@ -1988,6 +1988,8 @@ export async function sanitizeToolResult(
     result: unknown,
     options: {
         artifactStore?: import('../storage/artifacts/types.js').ArtifactStore;
+        display?: ToolDisplayData;
+        resultPresentation?: import('../tools/types.js').ToolPresentationResultType;
         toolName: string;
         toolCallId: string;
         success: boolean;
@@ -1999,9 +2001,17 @@ export async function sanitizeToolResult(
     let display: ToolDisplayData | undefined;
     let resultForNormalization = result;
 
+    if (options.display !== undefined) {
+        if (isValidDisplayData(options.display)) {
+            display = options.display;
+        } else {
+            logger.debug(`sanitizeToolResult: ignoring invalid explicit display data`);
+        }
+    }
+
     if (result && typeof result === 'object' && '_display' in result) {
         const { _display: rawDisplay, ...rest } = result as Record<string, unknown>;
-        if (isValidDisplayData(rawDisplay)) {
+        if (display === undefined && isValidDisplayData(rawDisplay)) {
             display = rawDisplay;
             logger.debug(
                 `sanitizeToolResult: extracted display data (type=${display.type}) for ${options.toolName}`
@@ -2044,6 +2054,9 @@ export async function sanitizeToolResult(
             toolCallId: options.toolCallId,
             success: options.success,
             ...(display ? { display } : {}),
+            ...(options.resultPresentation
+                ? { resultPresentation: options.resultPresentation }
+                : {}),
         },
     };
 }

--- a/packages/core/src/events/index.ts
+++ b/packages/core/src/events/index.ts
@@ -533,8 +533,6 @@ interface SessionEventMapBase {
         args: Record<string, any>;
         /** Optional non-execution metadata from the reserved __meta wrapper */
         meta?: ToolCallMetadata;
-        /** Optional user-facing description from tool call metadata (e.g., __meta.callDescription) */
-        callDescription?: string;
         callId: string;
     };
 
@@ -542,8 +540,6 @@ interface SessionEventMapBase {
     'llm:tool-call-partial': {
         toolName: string;
         args: Record<string, any>;
-        /** Optional user-facing description from tool call metadata (e.g., __meta.callDescription) */
-        callDescription?: string;
         callId: string;
         isComplete?: boolean;
     };

--- a/packages/core/src/llm/executor/turn-executor.ts
+++ b/packages/core/src/llm/executor/turn-executor.ts
@@ -2075,6 +2075,12 @@ export class TurnExecutor {
             executionResult.result,
             {
                 artifactStore: this.resourceManager.getArtifactStore(),
+                ...(executionResult.display !== undefined
+                    ? { display: executionResult.display }
+                    : {}),
+                ...(executionResult.resultPresentation !== undefined
+                    ? { resultPresentation: executionResult.resultPresentation }
+                    : {}),
                 toolName: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 success,
@@ -2116,10 +2122,7 @@ export class TurnExecutor {
 
     private emitToolCall(
         toolCall: ModelToolCall,
-        call: Pick<
-            ExecutableToolCall,
-            'callDescription' | 'input' | 'meta' | 'presentationSnapshot' | 'toolName'
-        >
+        call: Pick<ExecutableToolCall, 'input' | 'meta' | 'presentationSnapshot' | 'toolName'>
     ): void {
         this.eventBus.emit('llm:tool-call', {
             toolName: toolCall.toolName,
@@ -2128,7 +2131,6 @@ export class TurnExecutor {
             }),
             args: call.input,
             ...(call.meta !== undefined ? { meta: call.meta } : {}),
-            ...(call.callDescription !== undefined && { callDescription: call.callDescription }),
             callId: toolCall.toolCallId,
             ...(this.runContext?.hostRuntime !== undefined && {
                 hostRuntime: this.runContext.hostRuntime,

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -74,3 +74,8 @@ export type {
     ToolExecutionStartResult,
     ToolExecutionStore,
 } from './tool-executions/types.js';
+export {
+    completedToolExecutionToResult,
+    createToolExecutionId,
+    splitToolExecutionResult,
+} from './tool-executions/types.js';

--- a/packages/core/src/storage/tool-executions/types.ts
+++ b/packages/core/src/storage/tool-executions/types.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { z } from 'zod';
-import type { ToolExecutionResult } from '../../tools/types.js';
+import type { ToolExecutionResult, ToolPresentationResultType } from '../../tools/types.js';
+import { isValidDisplayData, type ToolDisplayData } from '../../tools/display-types.js';
 import { ToolPresentationSnapshotV1Schema } from '../../tools/presentation-schema.js';
 import type { ToolCallMetadata } from '../../tools/tool-call-metadata.js';
 
@@ -16,6 +17,15 @@ export const ToolExecutionIdentitySchema = z
 const ToolExecutionResultMetadataSchema = z
     .object({
         presentationSnapshot: ToolPresentationSnapshotV1Schema.optional(),
+        display: z.custom<ToolDisplayData>(isValidDisplayData).optional(),
+        resultPresentation: z
+            .enum([
+                'none',
+                'content',
+                'passthrough',
+                'display',
+            ] satisfies ToolPresentationResultType[])
+            .optional(),
         meta: z.custom<ToolCallMetadata>().optional(),
         requireApproval: z.boolean().optional(),
         approvalStatus: z.enum(['approved', 'rejected']).optional(),
@@ -115,6 +125,12 @@ export function splitToolExecutionResult(result: ToolExecutionResult): {
     if (result.presentationSnapshot !== undefined) {
         resultMetadata.presentationSnapshot = result.presentationSnapshot;
     }
+    if (result.display !== undefined) {
+        resultMetadata.display = result.display;
+    }
+    if (result.resultPresentation !== undefined) {
+        resultMetadata.resultPresentation = result.resultPresentation;
+    }
     if (result.meta !== undefined) {
         resultMetadata.meta = result.meta;
     }
@@ -136,6 +152,12 @@ export function completedToolExecutionToResult(
 ): ToolExecutionResult {
     return {
         result: record.modelOutput,
+        ...(record.resultMetadata?.display !== undefined
+            ? { display: record.resultMetadata.display }
+            : {}),
+        ...(record.resultMetadata?.resultPresentation !== undefined
+            ? { resultPresentation: record.resultMetadata.resultPresentation }
+            : {}),
         ...(record.resultMetadata?.presentationSnapshot !== undefined
             ? { presentationSnapshot: record.resultMetadata.presentationSnapshot }
             : {}),

--- a/packages/core/src/tools/display-types.test.ts
+++ b/packages/core/src/tools/display-types.test.ts
@@ -14,10 +14,58 @@ describe('isValidDisplayData', () => {
         ).toBe(true);
     });
 
+    it('accepts the reusable result display variants with explicit fields', () => {
+        expect(
+            isValidDisplayData({
+                type: 'text',
+                title: null,
+                text: 'The operation returned plain text',
+            })
+        ).toBe(true);
+        expect(
+            isValidDisplayData({
+                type: 'status',
+                title: 'Sync',
+                status: 'success',
+                message: 'The workspace is up to date',
+            })
+        ).toBe(true);
+        expect(
+            isValidDisplayData({
+                type: 'record',
+                title: null,
+                fields: [{ label: 'status', value: 'ready' }],
+            })
+        ).toBe(true);
+        expect(
+            isValidDisplayData({
+                type: 'collection',
+                title: 'Files',
+                items: ['README.md', 'package.json'],
+            })
+        ).toBe(true);
+        expect(
+            isValidDisplayData({
+                type: 'process',
+                title: null,
+                processId: 'proc_123',
+                command: 'pnpm test',
+                state: 'succeeded',
+                exitCode: 0,
+                startedAt: '2026-08-17T00:00:00.000Z',
+                finishedAt: '2026-08-17T00:00:01.000Z',
+            })
+        ).toBe(true);
+    });
+
     it('rejects a display discriminator without the fields its renderer requires', () => {
         expect(isValidDisplayData({ type: 'diff' })).toBe(false);
         expect(isValidDisplayData({ type: 'shell', command: 'pnpm test' })).toBe(false);
         expect(isValidDisplayData({ type: 'file', path: 'config.json' })).toBe(false);
+        expect(isValidDisplayData({ type: 'text', title: null })).toBe(false);
+        expect(isValidDisplayData({ type: 'record', title: null, fields: [] })).toBe(true);
+        expect(isValidDisplayData({ type: 'collection', title: null, items: [1] })).toBe(false);
+        expect(isValidDisplayData({ type: 'process', title: null })).toBe(false);
     });
 
     it.each([

--- a/packages/core/src/tools/display-types.ts
+++ b/packages/core/src/tools/display-types.ts
@@ -5,8 +5,9 @@
  * These types enable both CLI and WebUI to render tool results with
  * appropriate formatting (diffs, shell output, search results, etc.)
  *
- * Tools return `_display` field in their result, which is preserved
- * by the sanitizer in `SanitizedToolResult.meta.display`.
+ * Legacy tools may return a `_display` field in their result. Tool presentation resolvers can
+ * provide the same metadata without adding it to the model-visible result. Both paths end up in
+ * `SanitizedToolResult.meta.display`.
  */
 
 // =============================================================================
@@ -22,7 +23,58 @@ export type ToolDisplayData =
     | ShellDisplayData
     | SearchDisplayData
     | FileDisplayData
-    | GenericDisplayData;
+    | GenericDisplayData
+    | TextDisplayData
+    | StatusDisplayData
+    | RecordDisplayData
+    | CollectionDisplayData
+    | ProcessDisplayData;
+
+/** Display data for a plain text result. */
+export interface TextDisplayData {
+    type: 'text';
+    title: string | null;
+    text: string;
+}
+
+/** Display data for a single operation status. */
+export interface StatusDisplayData {
+    type: 'status';
+    title: string | null;
+    status: 'success' | 'error' | 'info' | 'warning';
+    message: string;
+}
+
+export interface ToolDisplayField {
+    label: string;
+    value: string;
+}
+
+/** Display data for one structured record. */
+export interface RecordDisplayData {
+    type: 'record';
+    title: string | null;
+    fields: ToolDisplayField[];
+}
+
+/** Display data for a list of values. */
+export interface CollectionDisplayData {
+    type: 'collection';
+    title: string | null;
+    items: string[];
+}
+
+/** Display data for a supervised process and its lifecycle state. */
+export interface ProcessDisplayData {
+    type: 'process';
+    title: string | null;
+    processId: string;
+    command: string | null;
+    state: 'running' | 'succeeded' | 'failed' | 'stopped' | 'interrupted';
+    exitCode: number | null;
+    startedAt: string | null;
+    finishedAt: string | null;
+}
 
 /**
  * Display data for file edit operations (edit_file, write_file overwrites).
@@ -171,6 +223,31 @@ export function isGenericDisplay(d: ToolDisplayData): d is GenericDisplayData {
     return d.type === 'generic';
 }
 
+/** Type guard for TextDisplayData. */
+export function isTextDisplay(d: ToolDisplayData): d is TextDisplayData {
+    return d.type === 'text';
+}
+
+/** Type guard for StatusDisplayData. */
+export function isStatusDisplay(d: ToolDisplayData): d is StatusDisplayData {
+    return d.type === 'status';
+}
+
+/** Type guard for RecordDisplayData. */
+export function isRecordDisplay(d: ToolDisplayData): d is RecordDisplayData {
+    return d.type === 'record';
+}
+
+/** Type guard for CollectionDisplayData. */
+export function isCollectionDisplay(d: ToolDisplayData): d is CollectionDisplayData {
+    return d.type === 'collection';
+}
+
+/** Type guard for ProcessDisplayData. */
+export function isProcessDisplay(d: ToolDisplayData): d is ProcessDisplayData {
+    return d.type === 'process';
+}
+
 // =============================================================================
 // Validation
 // =============================================================================
@@ -181,6 +258,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isOptionalString(value: unknown): boolean {
     return value === undefined || typeof value === 'string';
+}
+
+function isNullableString(value: unknown): value is string | null {
+    return value === null || typeof value === 'string';
 }
 
 function isNonNegativeInteger(value: unknown): value is number {
@@ -203,6 +284,12 @@ function isSearchMatch(value: unknown): value is SearchMatch {
         typeof value['content'] === 'string' &&
         (context === undefined ||
             (Array.isArray(context) && context.every((line) => typeof line === 'string')))
+    );
+}
+
+function isToolDisplayField(value: unknown): value is ToolDisplayField {
+    return (
+        isRecord(value) && typeof value['label'] === 'string' && typeof value['value'] === 'string'
     );
 }
 
@@ -262,6 +349,44 @@ export function isValidDisplayData(d: unknown): d is ToolDisplayData {
             );
         case 'generic':
             return isOptionalString(d['title']);
+        case 'text':
+            return isNullableString(d['title']) && typeof d['text'] === 'string';
+        case 'status':
+            return (
+                isNullableString(d['title']) &&
+                (d['status'] === 'success' ||
+                    d['status'] === 'error' ||
+                    d['status'] === 'info' ||
+                    d['status'] === 'warning') &&
+                typeof d['message'] === 'string'
+            );
+        case 'record':
+            return (
+                isNullableString(d['title']) &&
+                Array.isArray(d['fields']) &&
+                d['fields'].every(isToolDisplayField)
+            );
+        case 'collection':
+            return (
+                isNullableString(d['title']) &&
+                Array.isArray(d['items']) &&
+                d['items'].every((item) => typeof item === 'string')
+            );
+        case 'process':
+            return (
+                isNullableString(d['title']) &&
+                typeof d['processId'] === 'string' &&
+                isNullableString(d['command']) &&
+                (d['state'] === 'running' ||
+                    d['state'] === 'succeeded' ||
+                    d['state'] === 'failed' ||
+                    d['state'] === 'stopped' ||
+                    d['state'] === 'interrupted') &&
+                (d['exitCode'] === null ||
+                    (typeof d['exitCode'] === 'number' && Number.isInteger(d['exitCode']))) &&
+                isNullableString(d['startedAt']) &&
+                isNullableString(d['finishedAt'])
+            );
         default:
             return false;
     }

--- a/packages/core/src/tools/presentation.ts
+++ b/packages/core/src/tools/presentation.ts
@@ -2,6 +2,11 @@ import type { ToolPresentationSnapshotV1 } from './types.js';
 
 export type { ToolDisplayData } from './display-types.js';
 export { isValidDisplayData } from './display-types.js';
+export type {
+    ToolPresentationResultPolicy,
+    ToolPresentationResultResolver,
+    ToolPresentationResultType,
+} from './types.js';
 export type { ToolPresentationSnapshotV1 } from './presentation-schema.js';
 export {
     isToolPresentationSnapshotV1,

--- a/packages/core/src/tools/presentation/tool-presentation.test.ts
+++ b/packages/core/src/tools/presentation/tool-presentation.test.ts
@@ -179,4 +179,126 @@ describe('ToolPresentation', () => {
             result: { summaryText: 'written' },
         });
     });
+
+    it('resolves explicit display policies without adding display data to the tool result', async () => {
+        const display = {
+            type: 'record' as const,
+            title: null,
+            fields: [{ label: 'status', value: 'ready' }],
+        };
+        const resolve = vi.fn(() => display);
+        const tool = defineTool({
+            id: 'status',
+            description: 'Read status',
+            inputSchema: z.object({ value: z.string() }).strict(),
+            execute: vi.fn(),
+            presentation: {
+                result: { type: 'display', resolve },
+            },
+        });
+        const presentation = new ToolPresentation(
+            () => tool,
+            (_toolName, args) => args,
+            (context) => ({ ...context, logger: createMockLogger() }),
+            createMockLogger()
+        );
+
+        await expect(
+            presentation.resolveResultDisplay({
+                toolName: 'status',
+                result: { ok: true },
+                args: { value: 'workspace' },
+                toolCallId: 'call-1',
+            })
+        ).resolves.toEqual(display);
+        expect(resolve).toHaveBeenCalledWith(
+            { ok: true },
+            { value: 'workspace' },
+            expect.objectContaining({ logger: expect.anything() })
+        );
+    });
+
+    it.each([{ type: 'none' as const }, { type: 'content' as const }])(
+        'does not synthesize display data for a %s result policy',
+        async (result) => {
+            const tool = defineTool({
+                id: 'status',
+                description: 'Read status',
+                inputSchema: z.object({}).strict(),
+                execute: vi.fn(),
+                presentation: { result },
+            });
+            const presentation = new ToolPresentation(
+                () => tool,
+                (_toolName, args) => args,
+                (context) => ({ ...context, logger: createMockLogger() }),
+                createMockLogger()
+            );
+
+            await expect(
+                presentation.resolveResultDisplay({
+                    toolName: 'status',
+                    result: { ok: true },
+                    args: {},
+                    toolCallId: 'call-1',
+                })
+            ).resolves.toBeUndefined();
+        }
+    );
+
+    it.each([
+        { type: 'none' as const },
+        { type: 'content' as const },
+        { type: 'passthrough' as const },
+        {
+            type: 'display' as const,
+            resolve: () => ({ type: 'text' as const, title: null, text: 'Done' }),
+        },
+    ])('exposes the declared result policy type for a %s tool', (result) => {
+        const tool = defineTool({
+            id: 'status',
+            description: 'Read status',
+            inputSchema: z.object({}).strict(),
+            execute: vi.fn(),
+            presentation: { result },
+        });
+        const presentation = new ToolPresentation(
+            () => tool,
+            (_toolName, args) => args,
+            (context) => ({ ...context, logger: createMockLogger() }),
+            createMockLogger()
+        );
+
+        expect(presentation.getResultPolicyType('status')).toBe(result.type);
+    });
+
+    it('extracts legacy display data only for a passthrough result policy', async () => {
+        const display = {
+            type: 'text' as const,
+            title: null,
+            text: 'Done',
+        };
+        const tool = defineTool({
+            id: 'status',
+            description: 'Read status',
+            inputSchema: z.object({}).strict(),
+            execute: vi.fn(),
+            presentation: { result: { type: 'passthrough' } },
+        });
+        const presentation = new ToolPresentation(
+            () => tool,
+            (_toolName, args) => args,
+            (context) => ({ ...context, logger: createMockLogger() }),
+            createMockLogger()
+        );
+
+        await expect(
+            presentation.resolveResultDisplay({
+                toolName: 'status',
+                result: { ok: true, _display: display },
+                args: {},
+                toolCallId: 'call-1',
+            })
+        ).resolves.toEqual(display);
+    });
 });

--- a/packages/core/src/tools/presentation/tool-presentation.ts
+++ b/packages/core/src/tools/presentation/tool-presentation.ts
@@ -2,7 +2,12 @@ import { DextoRuntimeError } from '../../errors/index.js';
 import type { Logger } from '../../logger/v2/types.js';
 import type { AgentRunContext } from '../../runtime/run-context.js';
 import { ToolErrorCode } from '../error-codes.js';
-import type { Tool, ToolExecutionContext, ToolPresentationSnapshotV1 } from '../types.js';
+import type {
+    Tool,
+    ToolExecutionContext,
+    ToolPresentationResultType,
+    ToolPresentationSnapshotV1,
+} from '../types.js';
 import { isValidDisplayData, type ToolDisplayData } from '../display-types.js';
 
 const MCP_TOOL_PREFIX = 'mcp--';
@@ -251,6 +256,71 @@ export class ToolPresentation {
             ...(resultActivity ? { activity: resultActivity } : {}),
             ...(resultPresentation ? { result: resultPresentation } : {}),
         };
+    }
+
+    async resolveResultDisplay(input: {
+        toolName: string;
+        result: unknown;
+        args: Record<string, unknown>;
+        toolCallId: string;
+        sessionId?: string | undefined;
+        runContext?: AgentRunContext | undefined;
+    }): Promise<ToolDisplayData | undefined> {
+        if (input.toolName.startsWith(MCP_TOOL_PREFIX)) {
+            return undefined;
+        }
+
+        const policy = this.getLocalTool(input.toolName)?.presentation?.result;
+        if (policy === undefined || policy.type === 'none' || policy.type === 'content') {
+            return undefined;
+        }
+
+        if (policy.type === 'passthrough') {
+            return this.extractDisplayData(input.result);
+        }
+
+        let context: ToolExecutionContext;
+        try {
+            context = this.buildToolExecutionContext(input);
+        } catch (error) {
+            this.logger.debug(
+                `Tool result display context generation failed for '${input.toolName}': ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
+            return undefined;
+        }
+
+        try {
+            const display = await Promise.resolve(
+                policy.resolve(input.result, input.args, context)
+            );
+            if (display === null) {
+                return undefined;
+            }
+            if (!isValidDisplayData(display)) {
+                this.logger.debug(
+                    `Tool result display resolver returned invalid display data for '${input.toolName}'`
+                );
+                return undefined;
+            }
+            return display;
+        } catch (error) {
+            this.logger.debug(
+                `Tool result display resolution failed for '${input.toolName}': ${
+                    error instanceof Error ? error.message : String(error)
+                }`
+            );
+            return undefined;
+        }
+    }
+
+    getResultPolicyType(toolName: string): ToolPresentationResultType | undefined {
+        if (toolName.startsWith(MCP_TOOL_PREFIX)) {
+            return undefined;
+        }
+
+        return this.getLocalTool(toolName)?.presentation?.result?.type;
     }
 
     private extractDisplayData(result: unknown): ToolDisplayData | undefined {

--- a/packages/core/src/tools/tool-call-metadata.test.ts
+++ b/packages/core/src/tools/tool-call-metadata.test.ts
@@ -44,4 +44,38 @@ describe('wrapToolParametersSchema', () => {
 
         expect(schema.properties?.format).toEqual({ enum: ['email', 'sms'] });
     });
+
+    it('injects grouped model-authored call activity metadata', () => {
+        const schema = wrapToolParametersSchema({
+            type: 'object',
+            properties: {
+                path: { type: 'string' },
+            },
+        });
+
+        expect(schema.properties?.__meta).toEqual(
+            expect.objectContaining({
+                type: 'object',
+                additionalProperties: true,
+                properties: expect.objectContaining({
+                    callActivity: {
+                        type: 'object',
+                        properties: {
+                            running: expect.objectContaining({
+                                type: 'string',
+                                maxLength: expect.any(Number),
+                            }),
+                            completed: expect.objectContaining({
+                                type: 'string',
+                                maxLength: expect.any(Number),
+                            }),
+                        },
+                        required: ['running', 'completed'],
+                        additionalProperties: false,
+                        description: expect.any(String),
+                    },
+                }),
+            })
+        );
+    });
 });

--- a/packages/core/src/tools/tool-call-metadata.ts
+++ b/packages/core/src/tools/tool-call-metadata.ts
@@ -6,7 +6,10 @@ export type ToolCallMetadata = Record<string, unknown> & {
     runInBackground?: boolean;
     timeoutMs?: number;
     notifyOnComplete?: boolean;
-    callDescription?: string;
+    callActivity?: {
+        running: string;
+        completed: string;
+    };
 };
 
 export type ToolCallMetaWrapper = {
@@ -28,9 +31,26 @@ const META_SCHEMA: JSONSchema7 = {
             type: 'boolean',
             description: 'Notify when the background task completes.',
         },
-        callDescription: {
-            type: 'string',
-            description: 'Optional description shown to the user when requesting approval.',
+        callActivity: {
+            type: 'object',
+            description:
+                'Concise action-only descriptions for the tool call. Use present-progressive tense while running and past tense when complete. Write in sentence case without terminal punctuation; do not speculate about the outcome.',
+            properties: {
+                running: {
+                    type: 'string',
+                    maxLength: 120,
+                    description:
+                        'Present-progressive description of the action currently being performed, in concise sentence case without terminal punctuation.',
+                },
+                completed: {
+                    type: 'string',
+                    maxLength: 120,
+                    description:
+                        'Past-tense description of the action that was performed, in concise sentence case without terminal punctuation.',
+                },
+            },
+            required: ['running', 'completed'],
+            additionalProperties: false,
         },
     },
     additionalProperties: true,

--- a/packages/core/src/tools/tool-manager.test.ts
+++ b/packages/core/src/tools/tool-manager.test.ts
@@ -1818,6 +1818,80 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             expect(result).toEqual(expect.objectContaining({ result: 'Hello, World' }));
         });
 
+        it('carries resolved display data through durable execution replay', async () => {
+            mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
+            const execution = {
+                runId: 'run-1',
+                turnId: 'turn-1',
+                modelStepId: 'step-1',
+                toolCallId: 'call-display',
+            };
+            const toolExecutionStore = new InMemoryDextoStores().getStore('toolExecutions');
+            const toolManager = new ToolManager(
+                mockMcpManager,
+                mockApprovalManager,
+                mockAllowedToolsProvider,
+                'auto-approve',
+                mockAgentEventBus,
+                { alwaysAllow: [] },
+                [
+                    defineTool({
+                        id: 'status',
+                        description: 'Read status',
+                        inputSchema: z.object({ scope: z.string() }).strict(),
+                        execute: vi.fn().mockResolvedValue({ ready: true }),
+                        presentation: {
+                            result: {
+                                type: 'display',
+                                resolve: (_result, input) => ({
+                                    type: 'text',
+                                    title: null,
+                                    text: `Ready in ${input.scope}`,
+                                }),
+                            },
+                        },
+                    }),
+                ],
+                mockLogger,
+                createInMemorySessionToolPreferencesStore(mockLogger),
+                toolExecutionStore
+            );
+            toolManager.setToolExecutionContextFactory((baseContext) => baseContext);
+
+            const first = await toolManager.executeTool(
+                'status',
+                { scope: 'workspace' },
+                execution.toolCallId,
+                { sessionId: 'session-1', executionIdentity: execution }
+            );
+            const replayed = await toolManager.executeTool(
+                'status',
+                { scope: 'workspace' },
+                execution.toolCallId,
+                { sessionId: 'session-1', executionIdentity: execution }
+            );
+
+            expect(first.display).toEqual({
+                type: 'text',
+                title: null,
+                text: 'Ready in workspace',
+            });
+            expect(first.resultPresentation).toBe('display');
+            expect(replayed.display).toEqual(first.display);
+            expect(replayed.resultPresentation).toBe('display');
+            await expect(
+                toolExecutionStore.get({ executionId: createToolExecutionId(execution) })
+            ).resolves.toEqual(
+                expect.objectContaining({
+                    status: 'completed',
+                    resultMetadata: expect.objectContaining({
+                        display: first.display,
+                        resultPresentation: 'display',
+                    }),
+                })
+            );
+        });
+
         it('replays a completed durable execution without invoking the tool body again', async () => {
             mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
             const execute = vi.fn().mockResolvedValue('created file');
@@ -2241,7 +2315,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
     });
 
     describe('Approval Flow Logic', () => {
-        it('should emit callDescription on llm:tool-call events when __meta.callDescription is provided', async () => {
+        it('should emit model-authored call activity metadata on llm:tool-call events', async () => {
             mockMcpManager.getAllTools = vi.fn().mockResolvedValue({});
 
             const tool = defineTool({
@@ -2269,7 +2343,15 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
 
             await toolManager.executeTool(
                 'typed',
-                { count: 5, __meta: { callDescription: 'Read test file' } },
+                {
+                    count: 5,
+                    __meta: {
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
+                    },
+                },
                 'call-1',
                 { sessionId: 'session-1' }
             );
@@ -2279,7 +2361,12 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 expect.objectContaining({
                     toolName: 'typed',
                     args: { count: 5 },
-                    callDescription: 'Read test file',
+                    meta: {
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
+                    },
                     callId: 'call-1',
                     sessionId: 'session-1',
                 })
@@ -2317,7 +2404,10 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 {
                     count: 5,
                     __meta: {
-                        callDescription: 'Read test file',
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
                         reactiveUi: {
                             type: 'open',
                             surface: 'browser',
@@ -2334,13 +2424,15 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                     toolName: 'typed',
                     args: { count: 5 },
                     meta: {
-                        callDescription: 'Read test file',
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
                         reactiveUi: {
                             type: 'open',
                             surface: 'browser',
                         },
                     },
-                    callDescription: 'Read test file',
                     callId: 'call-1',
                     sessionId: 'session-1',
                 })
@@ -2348,7 +2440,10 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             expect(result).toEqual(
                 expect.objectContaining({
                     meta: {
-                        callDescription: 'Read test file',
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
                         reactiveUi: {
                             type: 'open',
                             surface: 'browser',
@@ -2358,7 +2453,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             );
         });
 
-        it('should emit callDescription on llm:tool-call events when args.description is provided', async () => {
+        it('should not promote args.description into llm:tool-call metadata', async () => {
             mockMcpManager.executeTool = vi.fn().mockResolvedValue('result');
 
             const toolManager = createToolManager(
@@ -2384,7 +2479,6 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 expect.objectContaining({
                     toolName: 'mcp--file_read',
                     args: { path: '/test', description: 'Read test file' },
-                    callDescription: 'Read test file',
                     callId: 'call-1',
                     sessionId: 'session-1',
                 })
@@ -2581,7 +2675,10 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                 {
                     path: '/test',
                     __meta: {
-                        callDescription: 'Read test file',
+                        callActivity: {
+                            running: 'Reading the test file',
+                            completed: 'Read the test file',
+                        },
                     },
                 },
                 'call-123',
@@ -2596,7 +2693,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                         toolName: 'mcp--file_read',
                         toolCallId: 'call-123',
                         args: { path: '/test' },
-                        description: 'Read test file',
+                        description: 'Reading the test file',
                         presentationSnapshot: expect.objectContaining({ version: 1 }),
                     }),
                 }),
@@ -2632,7 +2729,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
                     toolName: 'mcp--file_read',
                     toolCallId: 'call-123',
                     args: { path: '/test' },
-                    description: 'Read test file',
+                    description: 'Reading the test file',
                     sessionId: 'session123',
                     presentationSnapshot: expect.objectContaining({ version: 1 }),
                 })
@@ -2798,7 +2895,7 @@ describe('ToolManager - Unit Tests (Pure Logic)', () => {
             expect(mockAllowedToolsProvider.allowTool).not.toHaveBeenCalled();
         });
 
-        it('should fall back to args.description for approval description when __meta.callDescription is missing', async () => {
+        it('should fall back to args.description for approval description when call activity is missing', async () => {
             mockMcpManager.executeTool = vi.fn().mockResolvedValue('result');
 
             const toolManager = createToolManager(

--- a/packages/core/src/tools/tool-manager.ts
+++ b/packages/core/src/tools/tool-manager.ts
@@ -77,7 +77,6 @@ export type ExecutableToolCall = {
         approvalStatus: 'approved';
         requireApproval: true;
     };
-    callDescription?: string;
     input: Record<string, unknown>;
     meta?: ToolCallMetadata;
     presentationSnapshot: ToolPresentationSnapshotV1;
@@ -1079,9 +1078,9 @@ export class ToolManager {
         const { toolArgs: rawToolArgs, meta } = extractToolCallMeta(input.input);
         const eventMeta: ToolCallMetadata | undefined =
             Object.keys(meta).length > 0 ? meta : undefined;
-        const callDescription =
-            typeof meta.callDescription === 'string'
-                ? meta.callDescription
+        const approvalDescription =
+            typeof meta.callActivity?.running === 'string'
+                ? meta.callActivity.running
                 : typeof rawToolArgs.description === 'string'
                   ? rawToolArgs.description
                   : undefined;
@@ -1110,7 +1109,6 @@ export class ToolManager {
             source,
             toolCallId: input.toolCallId,
             toolName: input.toolName,
-            ...(callDescription !== undefined ? { callDescription } : {}),
             ...(eventMeta !== undefined ? { meta: eventMeta } : {}),
         };
 
@@ -1134,7 +1132,7 @@ export class ToolManager {
             approvalGate,
             args: validatedArgs,
             call,
-            ...(callDescription !== undefined ? { callDescription } : {}),
+            ...(approvalDescription !== undefined ? { approvalDescription } : {}),
             ...(input.runContext !== undefined ? { runContext: input.runContext } : {}),
             ...(sessionId !== undefined ? { sessionId } : {}),
             toolCallId: input.toolCallId,
@@ -1146,7 +1144,7 @@ export class ToolManager {
         approvalGate: Extract<ToolApprovalGate, { kind: 'approval-required' }>;
         args: Record<string, unknown>;
         call: ExecutableToolCall;
-        callDescription?: string | undefined;
+        approvalDescription?: string | undefined;
         runContext?: AgentRunContext | undefined;
         sessionId?: string | undefined;
         toolCallId: string;
@@ -1172,8 +1170,8 @@ export class ToolManager {
                 presentationSnapshot: input.call.presentationSnapshot,
                 toolCallId: input.toolCallId,
                 args: input.args,
-                ...(input.callDescription !== undefined
-                    ? { description: input.callDescription }
+                ...(input.approvalDescription !== undefined
+                    ? { description: input.approvalDescription }
                     : {}),
                 ...(displayPreview !== undefined ? { displayPreview } : {}),
             },
@@ -1497,9 +1495,6 @@ export class ToolManager {
             }),
             args: call.input,
             ...(call.meta !== undefined ? { meta: call.meta } : {}),
-            ...(call.callDescription !== undefined
-                ? { callDescription: call.callDescription }
-                : {}),
             callId: call.toolCallId,
             sessionId,
             ...(hostRuntime !== undefined && { hostRuntime }),
@@ -1920,9 +1915,20 @@ export class ToolManager {
                 ...(sessionId !== undefined ? { sessionId } : {}),
                 ...(runContext !== undefined ? { runContext } : {}),
             });
+            const display = await this.toolPresentation.resolveResultDisplay({
+                toolName: call.toolName,
+                result,
+                args: toolArgs,
+                toolCallId: call.toolCallId,
+                ...(sessionId !== undefined ? { sessionId } : {}),
+                ...(runContext !== undefined ? { runContext } : {}),
+            });
+            const resultPresentation = this.toolPresentation.getResultPolicyType(call.toolName);
 
             const executionResult = {
                 result,
+                ...(display !== undefined ? { display } : {}),
+                ...(resultPresentation !== undefined ? { resultPresentation } : {}),
                 ...(presentationSnapshot !== undefined && { presentationSnapshot }),
                 ...(call.meta !== undefined ? { meta: call.meta } : {}),
                 ...(call.approval !== undefined ? call.approval : {}),

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -107,6 +107,10 @@ export interface ToolExecutionContext extends ToolExecutionContextBase {
 export interface ToolExecutionResult {
     /** The actual result data from tool execution */
     result: unknown;
+    /** Structured display metadata resolved by tool presentation, never sent to the model */
+    display?: ToolDisplayData;
+    /** Serializable result-presentation policy used by the host UI for the completed result */
+    resultPresentation?: ToolPresentationResultType;
     /** Optional UI-agnostic presentation snapshot for this call/result */
     presentationSnapshot?: ToolPresentationSnapshotV1;
     /** Optional non-execution metadata carried through the tool lifecycle */
@@ -199,9 +203,29 @@ export type ToolNeedsApproval<TSchema extends ZodTypeAny = ZodTypeAny> =
           context: ToolExecutionContext
       ) => Promise<ToolApprovalDecision> | ToolApprovalDecision);
 
+/** Resolves structured UI display metadata from a completed tool result. */
+export type ToolPresentationResultResolver<TSchema extends ZodTypeAny = ZodTypeAny> = (
+    result: unknown,
+    input: z.output<TSchema>,
+    context: ToolExecutionContext
+) => Promise<ToolDisplayData | null> | ToolDisplayData | null;
+
+/** Declares how a tool result should be surfaced to a host UI. */
+export type ToolPresentationResultPolicy<TSchema extends ZodTypeAny = ZodTypeAny> =
+    | { type: 'none' }
+    | { type: 'content' }
+    | { type: 'passthrough' }
+    | { type: 'display'; resolve: ToolPresentationResultResolver<TSchema> };
+
+/** Serializable result-presentation discriminator carried alongside a completed tool result. */
+export type ToolPresentationResultType = ToolPresentationResultPolicy['type'];
+
 export interface ToolPresentation<TSchema extends ZodTypeAny = ZodTypeAny> {
     /** Deterministic lifecycle copy and aggregation grammar for this first-party tool. */
     activity?: ToolActivityPresentation;
+
+    /** Explicit contract for the tool's post-execution result presentation. */
+    result?: ToolPresentationResultPolicy<TSchema>;
 
     /**
      * Optional rich preview used in approval prompts.

--- a/packages/tui/src/services/processStream.ts
+++ b/packages/tui/src/services/processStream.ts
@@ -850,13 +850,15 @@ export async function processStream(
                         }),
                     });
 
-                    // Add call description if present (dim styling, on new line)
-                    // NOTE: This should come from tool call metadata (e.g., __meta.callDescription),
-                    // not from tool args, to keep approval + history consistent.
+                    // Add the model-authored running description if present (dim styling, on new
+                    // line). Keep it in metadata so tool args remain execution-only.
                     let finalToolContent = toolContent;
-                    const callDescription = event.callDescription;
-                    if (typeof callDescription === 'string' && callDescription.trim().length > 0) {
-                        finalToolContent += `\n${chalk.dim(callDescription)}`;
+                    const runningDescription = event.meta?.callActivity?.running;
+                    if (
+                        typeof runningDescription === 'string' &&
+                        runningDescription.trim().length > 0
+                    ) {
+                        finalToolContent += `\n${chalk.dim(runningDescription)}`;
                     }
 
                     // Tool calls start in 'pending' state (don't know if approval needed yet)


### PR DESCRIPTION
## Human notes

<!-- human:dexto-notes -->

_Add context, reviewer guidance, or verification results here. Agents preserve this section._

<!-- agent:dexto-managed:start -->

> [!NOTE]
> The generated sections below this notice are written and maintained by agents and may be
> regenerated when the PR changes. Add human-authored content to **Human notes** above.

<!-- agent:dexto-pr-head:fe0d6c96154b4f13d95be8bdf152c780af5a0fa4 -->

## Intent

Feature.

## Why

Tool hosts currently rely on ad hoc result parsing and generic lifecycle copy. That makes it hard
for clients to render consistent, compact activity rows or to distinguish content, structured
display data, passthrough results, and intentionally hidden results. This is the core contract
needed by the Cloud Dashboard work tracked in [DEXTO-532](https://linear.app/truffleai/issue/DEXTO-532/).

## Summary

- Adds canonical model-authored running/completed activity metadata under the reserved tool-call
  metadata envelope.
- Adds explicit result-presentation policies and reusable structured display types for shell,
  file, diff, search, record, collection, process, status, and text results.
- Resolves presentation metadata in the tool manager and carries it through execution storage,
  context projection, events, and TUI streaming without exposing host-only display metadata to the
  model.
- Records the patch release and refreshes the generated OpenAPI version snapshot.

## Change groups

### Presentation contracts

Defines the schemas, public types, validation, metadata parsing, and result-policy resolution used
by tool producers and host renderers.

### Runtime propagation

Carries the canonical metadata through tool execution, stored context, LLM turn execution, and
session events while removing the duplicated top-level call-description field.

### TUI compatibility

Updates process streaming to preserve and consume the new lifecycle metadata without changing the
TUI's role as a separate client.

### Release artifacts

Adds the core patch changeset and updates the generated OpenAPI snapshot to the current package
version.

## Validation

- `bash scripts/quality-checks.sh` — passed on the submitted commit: build, OpenAPI freshness,
  tests, lint, typecheck, and Hono client inference.
- GitHub Actions — Build Documentation, ESLint, TypeScript, Hono Inference, build-and-test,
  changeset guard, and all five platform smoke jobs passed.
- Vercel preview — blocked because the fork author is not authorized to deploy to the target Vercel
  team; this is an external preview-permission limitation rather than a code failure.

## Risk and rollout

This adds a host-facing contract consumed by a follow-up Cloud PR. Existing tools that do not
declare a result policy continue to execute normally; clients adopt the new metadata when they are
upgraded. Merge and publish this core patch before updating Cloud to the released version.

<!-- agent:dexto-managed:end -->
