### PR TITLE
feat(registry): add Parallel Search MCP

### DIFF
--- a/.changeset/bright-otters-search.md
+++ b/.changeset/bright-otters-search.md
@@ -1,0 +1,5 @@
+---
+"@dexto/registry": minor
+---
+
+Add Parallel Search to the MCP server registry.

--- a/packages/registry/src/mcp/server-registry-data.json
+++ b/packages/registry/src/mcp/server-registry-data.json
@@ -260,6 +260,25 @@
     "matchIds": ["hf", "huggingface"]
   },
   {
+    "id": "parallel-search",
+    "name": "Parallel Search",
+    "description": "Search the web and retrieve relevant content with source citations",
+    "category": "research",
+    "icon": "🔍",
+    "config": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp",
+      "headers": {},
+      "timeout": 30000
+    },
+    "tags": ["search", "web", "research", "citations"],
+    "isOfficial": true,
+    "isInstalled": false,
+    "author": "Parallel",
+    "homepage": "https://parallel.ai",
+    "matchIds": ["parallel-search", "parallel_search", "parallel"]
+  },
+  {
     "id": "tavily",
     "name": "Tavily Search",
     "description": "Web search and research using Tavily AI search engine",


### PR DESCRIPTION
### Release Note

- [ ] No release needed (docs/chore/test-only/private package)
- [x] Changeset added via `pnpm changeset` (select packages + bump)
  - Bump type: Minor
  - Packages: `@dexto/registry`

### Summary

- add Parallel Search to the built-in MCP server registry
- use the credential-free HTTP endpoint without changing existing defaults

### Validation

- parsed the registry JSON and verified the new entry, endpoint configuration, and unique IDs
- ran `git diff --check`
- reviewed the exact sealed patch for unrelated changes and credentials

Node-based package checks were not run because Node and pnpm are unavailable in the isolated worker environment.

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Parallel Search to the MCP server registry.
  * Configured HTTP access with search and citation metadata.
  * Added matching identifiers for easier server discovery.

* **Chores**
  * Recorded a minor package release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->