### PR TITLE
fix(llm): expose max reasoning effort for Anthropic models via OpenRouter gateways

### DIFF
--- a/.changeset/openrouter-max-effort.md
+++ b/.changeset/openrouter-max-effort.md
@@ -1,0 +1,5 @@
+---
+'@dexto/llm': patch
+---
+
+Expose `max` reasoning effort for Anthropic models (e.g. Claude Fable 5) when routed through OpenRouter / dexto-nova gateways. Previously the gateway profile stripped `max`; OpenRouter now supports it, so capable models keep their native variants and default.

--- a/packages/core/src/llm/executor/provider-options.test.ts
+++ b/packages/core/src/llm/executor/provider-options.test.ts
@@ -399,14 +399,19 @@ describe('buildProviderOptions', () => {
             });
         });
 
-        it('does not map Anthropic-only adaptive max on gateway providers', () => {
+        it('maps Anthropic adaptive max on gateway providers now that OpenRouter supports it', () => {
             expect(
                 buildProviderOptions({
                     provider: 'openrouter',
                     model: 'anthropic/claude-opus-4.6',
                     reasoning: { variant: 'max' },
                 })
-            ).toBeUndefined();
+            ).toEqual({
+                openrouter: {
+                    include_reasoning: true,
+                    reasoning: { enabled: true, effort: 'max' },
+                },
+            });
         });
 
         it('uses max_tokens when budgetTokens is provided', () => {

--- a/packages/llm/src/reasoning/profile.test.ts
+++ b/packages/llm/src/reasoning/profile.test.ts
@@ -183,7 +183,7 @@ describe('getReasoningProfile', () => {
         expect(getReasoningProfile('openrouter', 'anthropic/claude-fable-5')).toMatchObject({
             capable: true,
             paradigm: 'adaptive-effort',
-            supportedVariants: ['low', 'medium', 'high', 'xhigh'],
+            supportedVariants: ['low', 'medium', 'high', 'xhigh', 'max'],
             defaultVariant: 'high',
             supportsBudgetTokens: true,
         });
@@ -225,10 +225,7 @@ describe('getReasoningProfile', () => {
             const gateways = ['openrouter', 'dexto-nova'] as const;
             for (const gateway of gateways) {
                 const gatewayProfile = getReasoningProfile(gateway, entry.gatewayModel);
-                const expectedVariants =
-                    native.paradigm === 'adaptive-effort'
-                        ? native.supportedVariants.filter((variant) => variant !== 'max')
-                        : native.supportedVariants;
+                const expectedVariants = native.supportedVariants;
                 expect(gatewayProfile.capable).toBe(native.capable);
                 expect(gatewayProfile.paradigm).toBe(native.paradigm);
                 expect(gatewayProfile.supportedVariants).toEqual(expectedVariants);

--- a/packages/llm/src/reasoning/profile.ts
+++ b/packages/llm/src/reasoning/profile.ts
@@ -98,13 +98,8 @@ function toGatewayReasoningProfile(nativeProfile: ReasoningProfile): ReasoningPr
         return nonCapableProfile();
     }
 
-    const variants =
-        nativeProfile.paradigm === 'adaptive-effort'
-            ? nativeProfile.variants.filter((variant) => variant.id !== 'max')
-            : nativeProfile.variants.map((variant) => ({ ...variant }));
-    const defaultVariant =
-        // Variants are ordered lowest to highest effort, so this picks the strongest gateway-safe fallback.
-        nativeProfile.defaultVariant === 'max' ? variants.at(-1)?.id : nativeProfile.defaultVariant;
+    const variants = nativeProfile.variants.map((variant) => ({ ...variant }));
+    const defaultVariant = nativeProfile.defaultVariant;
 
     return {
         ...nativeProfile,


### PR DESCRIPTION
### Release Note

- [x] Changeset added via \`pnpm changeset\`
  - Bump type: Patch
  - Packages: \`@dexto/llm\`

## Summary

Closes #836.

OpenRouter now supports the \`max\` reasoning effort level for Anthropic Claude 4.6+ models, so this re-enables \`max\` on the OpenRouter / dexto-nova gateway profiles. It was previously stripped in #834 because OpenRouter returned HTTP 400 for \`reasoning.effort: "max"\` at the time.

## Changes

- \`packages/llm/src/reasoning/profile.ts\`: \`toGatewayReasoningProfile\` no longer strips \`max\` for adaptive-effort gateway models (gateway mirrors native variants).
- \`packages/llm/src/reasoning/profile.test.ts\` and \`packages/core/src/llm/executor/provider-options.test.ts\`: updated expectations for the restored \`max\` variant.
- Changeset added (\`@dexto/llm\` patch).

## Verification

\`@dexto/llm\` builds; reasoning profile tests 19/19; provider-options tests 35/35; ESLint clean on changed files.

Refs: https://github.com/truffle-ai/dexto/issues/836 · https://openrouter.ai/docs/cookbook/evaluate-and-optimize/model-migrations/claude-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Anthropic models routed through OpenRouter or dexto-nova gateways now support the `max` reasoning effort option.
  - Compatible models retain their native reasoning variants and default settings.

- **Bug Fixes**
  - Fixed provider configuration so the `max` reasoning effort is correctly enabled and passed to OpenRouter.
  - Updated gateway behavior to match the reasoning options supported by the underlying model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->